### PR TITLE
fix: 展开教室连续占用节次

### DIFF
--- a/lib/pages/campus/classroom/classroom_detail_page.dart
+++ b/lib/pages/campus/classroom/classroom_detail_page.dart
@@ -44,10 +44,7 @@ class ClassroomDetailPage extends StatelessWidget {
   }
 
   Widget _buildInfoCard(BuildContext context, AppLocalizations l10n) {
-    final statusMap = <int, ClassroomPeriodStatus>{};
-    for (final slot in timeSlots) {
-      statusMap[slot.sessionstart] = slot.status;
-    }
+    final statusMap = classroomPeriodStatusMap(timeSlots);
 
     var freeCount = 0;
     var inClassCount = 0;
@@ -220,10 +217,7 @@ class ClassroomDetailPage extends StatelessWidget {
   }
 
   Widget _buildPeriodGrid(BuildContext context, AppLocalizations l10n) {
-    final statusMap = <int, ClassroomPeriodStatus>{};
-    for (final slot in timeSlots) {
-      statusMap[slot.sessionstart] = slot.status;
-    }
+    final statusMap = classroomPeriodStatusMap(timeSlots);
 
     return Column(
       children: List.generate(12, (i) {

--- a/lib/pages/campus/models/classroom_model.dart
+++ b/lib/pages/campus/models/classroom_model.dart
@@ -142,6 +142,19 @@ class ClassroomTimeSlot {
 
 enum ClassroomPeriodStatus { free, inClass, exam, experiment, borrowed }
 
+Map<int, ClassroomPeriodStatus> classroomPeriodStatusMap(
+  Iterable<ClassroomTimeSlot> timeSlots,
+) {
+  final map = <int, ClassroomPeriodStatus>{};
+  for (final slot in timeSlots) {
+    final duration = slot.continuingsession > 0 ? slot.continuingsession : 1;
+    for (var offset = 0; offset < duration; offset++) {
+      map[slot.sessionstart + offset] = slot.status;
+    }
+  }
+  return map;
+}
+
 class ClassroomQueryResult {
   final List<ClassroomInfo> classrooms;
   final List<ClassroomTimeSlot> classroomTime;
@@ -178,10 +191,6 @@ class ClassroomQueryResult {
       classroomTime.where((s) => s.classroomNumber == classroomNumber).toList();
 
   Map<int, ClassroomPeriodStatus> periodStatusMap(String classroomNumber) {
-    final map = <int, ClassroomPeriodStatus>{};
-    for (final slot in slotsFor(classroomNumber)) {
-      map[slot.sessionstart] = slot.status;
-    }
-    return map;
+    return classroomPeriodStatusMap(slotsFor(classroomNumber));
   }
 }

--- a/test/classroom_model_test.dart
+++ b/test/classroom_model_test.dart
@@ -1,0 +1,69 @@
+import 'package:bugaoshan/pages/campus/models/classroom_model.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('ClassroomQueryResult.periodStatusMap', () {
+    test('expands continuing periods without mixing classrooms', () {
+      final result = ClassroomQueryResult(
+        classrooms: const [],
+        classroomTime: [
+          _timeSlot(
+            classroomNumber: 'A101',
+            sessionStart: 1,
+            continuingSession: 2,
+            occupancyModuleId: '06',
+          ),
+          _timeSlot(
+            classroomNumber: 'B202',
+            sessionStart: 1,
+            continuingSession: 1,
+            occupancyModuleId: '07',
+          ),
+        ],
+        date: '2026-07-14',
+        jxzc: 20,
+      );
+
+      expect(result.periodStatusMap('A101'), {
+        1: ClassroomPeriodStatus.inClass,
+        2: ClassroomPeriodStatus.inClass,
+      });
+      expect(result.periodStatusMap('B202'), {1: ClassroomPeriodStatus.exam});
+    });
+
+    test('treats non-positive continuing periods as one period', () {
+      for (final invalidDuration in [0, -1]) {
+        final statusMap = classroomPeriodStatusMap([
+          _timeSlot(
+            classroomNumber: 'A101',
+            sessionStart: 5,
+            continuingSession: invalidDuration,
+            occupancyModuleId: 'room',
+          ),
+        ]);
+
+        expect(statusMap, {
+          5: ClassroomPeriodStatus.borrowed,
+        }, reason: 'continuingsession=$invalidDuration');
+      }
+    });
+  });
+}
+
+ClassroomTimeSlot _timeSlot({
+  required String classroomNumber,
+  required int sessionStart,
+  required int continuingSession,
+  required String occupancyModuleId,
+}) {
+  return ClassroomTimeSlot(
+    campusNumber: '01',
+    teachingBuildingNumber: '01',
+    classroomNumber: classroomNumber,
+    xq: 1,
+    sessionstart: sessionStart,
+    continuingsession: continuingSession,
+    timestatenumber: '',
+    occupancymoduleId: occupancyModuleId,
+  );
+}


### PR DESCRIPTION
## 问题

教室占用接口使用 `sessionstart` 和 `continuingsession` 表示连续节次。现有实现只标记起始节次，导致后续节次在空闲筛选、详情统计和节次列表中被误报为空闲。

## 修改

- 在模型层统一展开连续占用范围。
- 查询结果、详情统计和详情节次列表复用同一状态映射。
- 对非正的持续节数按 1 节处理，避免异常数据丢失起始节次状态。

## 用户影响

空教室筛选不会再把仍处于上课、考试、实验或借用中的后续节次显示为可用。

## 验证

- `flutter test --no-pub`：109 项全部通过。
- 定向 `flutter analyze --no-pub`：无问题。
- 新增模型回归测试，覆盖连续两节、教室隔离和异常持续值。

本 PR 不涉及权限声明、认证凭据、隐私/EULA 或签名配置。
