### PR TITLE
fix: 统一重叠课表轨道坐标

### DIFF
--- a/lib/widgets/course/grid_logic.dart
+++ b/lib/widgets/course/grid_logic.dart
@@ -84,10 +84,28 @@ List<TrackInfo> assignCourseTracks(List<Course> courses) {
 
   final trackEnds = <int>[];
   final assignments = List<int>.filled(courses.length, -1);
+  final totalTracks = List<int>.filled(courses.length, 1);
+  final componentIndices = <int>[];
+  var componentEnd = -1;
+
+  void finishComponent() {
+    for (final index in componentIndices) {
+      totalTracks[index] = trackEnds.length;
+    }
+    componentIndices.clear();
+    trackEnds.clear();
+    componentEnd = -1;
+  }
 
   for (final entry in indexed) {
     final originalIndex = entry.key;
     final course = entry.value;
+
+    // 与上一连通组没有时间交集时重新开始分轨，避免另一时段的
+    // 高并发课程无谓压窄当前课程。
+    if (componentIndices.isNotEmpty && course.startSection > componentEnd) {
+      finishComponent();
+    }
 
     int assignedTrack = -1;
     for (int t = 0; t < trackEnds.length; t++) {
@@ -102,20 +120,16 @@ List<TrackInfo> assignCourseTracks(List<Course> courses) {
     }
     trackEnds[assignedTrack] = course.endSection;
     assignments[originalIndex] = assignedTrack;
-  }
-
-  // 重新映射：对于每门课程，仅基于其时间段内实际重叠的课程计算 track/totalTracks
-  return List.generate(courses.length, (i) {
-    final course = courses[i];
-    final overlapping = <int>[];
-    for (int j = 0; j < courses.length; j++) {
-      if (coursesOverlapInSections(courses[j], course)) {
-        overlapping.add(j);
-      }
+    componentIndices.add(originalIndex);
+    if (course.endSection > componentEnd) {
+      componentEnd = course.endSection;
     }
-    overlapping.sort((a, b) => assignments[a].compareTo(assignments[b]));
-    final localTrack = overlapping.indexOf(i);
-    return TrackInfo(track: localTrack, totalTracks: overlapping.length);
+  }
+  finishComponent();
+
+  // 同一重叠连通组共享轨道坐标系，避免直接重叠的课程因分母不同而水平遮挡。
+  return List.generate(courses.length, (i) {
+    return TrackInfo(track: assignments[i], totalTracks: totalTracks[i]);
   });
 }
 

--- a/test/grid_logic_test.dart
+++ b/test/grid_logic_test.dart
@@ -1,0 +1,67 @@
+import 'package:bugaoshan/models/course.dart';
+import 'package:bugaoshan/widgets/course/grid_logic.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('Course track assignment', () {
+    test('uses one coordinate system for an overlap-connected component', () {
+      final courses = [
+        _buildCourse('A', 1, 2),
+        _buildCourse('B', 2, 5),
+        _buildCourse('C', 3, 4),
+        _buildCourse('D', 4, 5),
+      ];
+
+      final tracks = assignCourseTracks(courses);
+
+      expect(tracks.map((track) => track.totalTracks), everyElement(3));
+      for (var i = 0; i < courses.length; i++) {
+        for (var j = i + 1; j < courses.length; j++) {
+          if (!coursesOverlapInSections(courses[i], courses[j])) continue;
+
+          expect(
+            _horizontalIntervalsAreDisjoint(tracks[i], tracks[j]),
+            isTrue,
+            reason: '${courses[i].name} and ${courses[j].name} overlap in time',
+          );
+        }
+      }
+    });
+
+    test('sizes disconnected overlap components independently', () {
+      final tracks = assignCourseTracks([
+        _buildCourse('A', 1, 2),
+        _buildCourse('B', 2, 3),
+        _buildCourse('C', 5, 6),
+        _buildCourse('D', 5, 7),
+        _buildCourse('E', 6, 6),
+      ]);
+
+      expect(tracks.take(2).map((track) => track.totalTracks), everyElement(2));
+      expect(tracks.skip(2).map((track) => track.totalTracks), everyElement(3));
+    });
+  });
+}
+
+Course _buildCourse(String name, int startSection, int endSection) {
+  return Course(
+    name: name,
+    teacher: '老师',
+    location: '教室',
+    startWeek: 1,
+    endWeek: 16,
+    dayOfWeek: 1,
+    startSection: startSection,
+    endSection: endSection,
+    colorValue: 0xFF2196F3,
+    weekType: WeekType.every,
+  );
+}
+
+bool _horizontalIntervalsAreDisjoint(TrackInfo a, TrackInfo b) {
+  final aLeft = a.track / a.totalTracks;
+  final aRight = (a.track + 1) / a.totalTracks;
+  final bLeft = b.track / b.totalTracks;
+  final bRight = (b.track + 1) / b.totalTracks;
+  return aRight <= bLeft || bRight <= aLeft;
+}


### PR DESCRIPTION
## 问题

全周课表先分配全局轨道，随后又根据每门课程自己的直接重叠邻居重算轨道和宽度。同一重叠连通组因此可能使用不同横向坐标系，使时间重叠的课程卡片在屏幕上互相遮挡。

## 修改

- 按时间重叠连通组划分课程。
- 每个连通组独立进行贪心分轨，组内统一使用实际轨道总数。
- 互不相交的时段单独计算宽度，避免被其他时段的高并发课程无谓压窄。

## 用户影响

全周视图中的并排课程不会再覆盖彼此的文字和点击区域，同时低并发时段仍能充分利用列宽。

## 验证

- `flutter test --no-pub`：109 项全部通过。
- 定向 `flutter analyze --no-pub`：无问题。
- 回归测试覆盖已确认的遮挡用例，并逐对验证所有时间重叠课程的横向区间不相交。

本 PR 不涉及权限声明、认证凭据、隐私/EULA 或签名配置。
