### PR TITLE
fix: 保持非当前课表编辑状态隔离

### DIFF
--- a/lib/providers/course_provider.dart
+++ b/lib/providers/course_provider.dart
@@ -123,10 +123,13 @@ class CourseProvider {
 
   Future<void> updateScheduleConfig(ScheduleConfig config) async {
     await _db.saveScheduleConfig(config);
-    scheduleConfig.value = config;
     allSchedules.value = _db.getAllSchedules();
-    currentWeek.value = config.getCurrentWeek();
-    onCoursesChanged?.call();
+    if (config.id == _db.getCurrentScheduleId()) {
+      scheduleConfig.value = config;
+      currentWeek.value = config.getCurrentWeek();
+      // 非当前课表不影响当前课程展示，也无需刷新桌面组件。
+      onCoursesChanged?.call();
+    }
   }
 
   /// 替换指定课表的所有课程（先删后插）。用于「更新课表」场景。

--- a/test/course_provider_test.dart
+++ b/test/course_provider_test.dart
@@ -1,0 +1,118 @@
+import 'package:bugaoshan/models/course.dart';
+import 'package:bugaoshan/providers/course_provider.dart';
+import 'package:bugaoshan/services/database_service.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test(
+    'editing a non-current schedule only refreshes the schedule list',
+    () async {
+      final current = _schedule(id: 'A', name: '当前课表', weeksAgo: 1);
+      final other = _schedule(id: 'B', name: '其他课表', weeksAgo: 2);
+      final database = _FakeDatabaseService(
+        currentScheduleId: current.id,
+        schedules: [current, other],
+      );
+      final provider = CourseProvider(database);
+      var coursesChangedCount = 0;
+      provider.onCoursesChanged = () => coursesChangedCount++;
+      final initialWeek = provider.currentWeek.value;
+      final updatedOther = other.copyWith(
+        semesterName: '已重命名的其他课表',
+        semesterStartDate: _weeksAgo(5),
+      );
+
+      await provider.updateScheduleConfig(updatedOther);
+
+      expect(provider.scheduleConfig.value, same(current));
+      expect(provider.currentWeek.value, initialWeek);
+      expect(
+        provider.allSchedules.value.singleWhere((item) => item.id == other.id),
+        same(updatedOther),
+      );
+      expect(coursesChangedCount, 0);
+    },
+  );
+
+  test(
+    'editing the current schedule refreshes current config and week',
+    () async {
+      final current = _schedule(id: 'A', name: '当前课表', weeksAgo: 1);
+      final other = _schedule(id: 'B', name: '其他课表', weeksAgo: 2);
+      final database = _FakeDatabaseService(
+        currentScheduleId: current.id,
+        schedules: [current, other],
+      );
+      final provider = CourseProvider(database);
+      var coursesChangedCount = 0;
+      provider.onCoursesChanged = () => coursesChangedCount++;
+      final updatedCurrent = current.copyWith(
+        semesterName: '已更新的当前课表',
+        semesterStartDate: _weeksAgo(4),
+      );
+
+      await provider.updateScheduleConfig(updatedCurrent);
+
+      expect(provider.scheduleConfig.value, same(updatedCurrent));
+      expect(provider.currentWeek.value, updatedCurrent.getCurrentWeek());
+      expect(
+        provider.allSchedules.value.singleWhere(
+          (item) => item.id == current.id,
+        ),
+        same(updatedCurrent),
+      );
+      expect(coursesChangedCount, 1);
+    },
+  );
+}
+
+ScheduleConfig _schedule({
+  required String id,
+  required String name,
+  required int weeksAgo,
+}) {
+  return ScheduleConfig(
+    id: id,
+    semesterName: name,
+    semesterStartDate: _weeksAgo(weeksAgo),
+    totalWeeks: 20,
+  );
+}
+
+DateTime _weeksAgo(int weeks) {
+  final now = DateTime.now();
+  final today = DateTime(now.year, now.month, now.day);
+  return today.subtract(Duration(days: weeks * 7));
+}
+
+class _FakeDatabaseService extends DatabaseService {
+  _FakeDatabaseService({
+    required String currentScheduleId,
+    required List<ScheduleConfig> schedules,
+  }) : _currentScheduleId = currentScheduleId,
+       _schedules = List.of(schedules);
+
+  final String _currentScheduleId;
+  List<ScheduleConfig> _schedules;
+
+  @override
+  List<Course> getCourses({String? scheduleId}) => const [];
+
+  @override
+  List<ScheduleConfig> getAllSchedules() => List.unmodifiable(_schedules);
+
+  @override
+  ScheduleConfig getScheduleConfig() =>
+      _schedules.singleWhere((schedule) => schedule.id == _currentScheduleId);
+
+  @override
+  String getCurrentScheduleId() => _currentScheduleId;
+
+  @override
+  Future<void> saveScheduleConfig(ScheduleConfig config) async {
+    _schedules = [
+      for (final schedule in _schedules)
+        if (schedule.id == config.id) config else schedule,
+    ];
+  }
+}


### PR DESCRIPTION
## 问题

课表管理页允许重命名非当前课表，但 `CourseProvider.updateScheduleConfig` 会无条件覆盖当前配置和周次。这样会出现数据库与课程缓存仍属于课表 A，而页面配置已经变成课表 B 的不一致状态。

## 修改

- 保存任意课表配置后始终刷新课表列表。
- 仅当被编辑课表就是数据库当前课表时，更新当前配置与周次。
- 非当前课表编辑不触发当前课程/桌面组件刷新通知。

## 用户影响

重命名其他课表后，主课表不会再错误套用其他学期的周次、节次和日期配置。

## 验证

- `flutter test --no-pub`：109 项全部通过。
- 定向 `flutter analyze --no-pub`：无问题。
- 回归测试分别覆盖编辑当前课表和非当前课表的状态与通知行为。

本 PR 不涉及权限声明、认证凭据、隐私/EULA 或签名配置。
