### PR TITLE
fix: 校验远程校历后再更新缓存

### DIFF
--- a/lib/services/api/academic_calendar_service.dart
+++ b/lib/services/api/academic_calendar_service.dart
@@ -14,21 +14,27 @@ class AcademicCalendarService {
       'https://raw.githubusercontent.com/The-Brotherhood-of-SCU/Bugaoshan/main/assets/academic_calendar.json';
   static const String _cacheKey = 'cached_academic_calendar_json';
 
-  AcademicCalendarService(this._prefs, {http.Client? client}) : _client = client;
+  AcademicCalendarService(this._prefs, {http.Client? client})
+    : _client = client;
 
   Future<AcademicCalendarData> fetchCalendarData() async {
     try {
       final client = _client ?? http.Client();
-      final response = await client.get(Uri.parse(_remoteUrl)).timeout(const Duration(seconds: 5));
+      final response = await client
+          .get(Uri.parse(_remoteUrl))
+          .timeout(const Duration(seconds: 5));
       if (response.statusCode == 200 && response.body.isNotEmpty) {
         final data = jsonDecode(response.body);
         if (data is Map<String, dynamic> && data.containsKey('semesters')) {
+          final calendar = AcademicCalendarData.fromJson(data);
           await _prefs.setString(_cacheKey, response.body);
-          return AcademicCalendarData.fromJson(data);
+          return calendar;
         }
       }
     } catch (e) {
-      debugPrint('AcademicCalendarService: failed to fetch remote calendar: $e');
+      debugPrint(
+        'AcademicCalendarService: failed to fetch remote calendar: $e',
+      );
     }
 
     final cached = _prefs.getString(_cacheKey);
@@ -36,12 +42,16 @@ class AcademicCalendarService {
       try {
         return AcademicCalendarData.fromJsonString(cached);
       } catch (e) {
-        debugPrint('AcademicCalendarService: failed to parse cached calendar: $e');
+        debugPrint(
+          'AcademicCalendarService: failed to parse cached calendar: $e',
+        );
       }
     }
 
     try {
-      final assetContent = await rootBundle.loadString('assets/academic_calendar.json');
+      final assetContent = await rootBundle.loadString(
+        'assets/academic_calendar.json',
+      );
       return AcademicCalendarData.fromJsonString(assetContent);
     } catch (e) {
       debugPrint('AcademicCalendarService: failed to load bundled asset: $e');
@@ -52,11 +62,17 @@ class AcademicCalendarService {
   CalendarExportPayload genExportPayload(AcademicCalendarSemester semester) {
     final events = <CalendarEventPayload>[];
     for (final event in semester.events) {
-      final start = DateTime(event.date.year, event.date.month, event.date.day, 8, 0);
+      final start = DateTime(
+        event.date.year,
+        event.date.month,
+        event.date.day,
+        8,
+        0,
+      );
       final lastDay = event.endDate ?? event.date;
       final end = DateTime(lastDay.year, lastDay.month, lastDay.day, 18, 0);
       final location = CalendarLocationMapper.resolve('四川大学');
-      
+
       events.add(
         CalendarEventPayload(
           start: start,
@@ -64,13 +80,17 @@ class AcademicCalendarService {
           title: event.label,
           location: location.title,
           description: '四川大学官方校历日程\n类型: ${event.tag}',
-          uid: 'acad-${semester.name.replaceAll(" ", "_")}-${event.label.replaceAll(" ", "_")}-${event.date.millisecondsSinceEpoch}@bugaoshan',
+          uid:
+              'acad-${semester.name.replaceAll(" ", "_")}-${event.label.replaceAll(" ", "_")}-${event.date.millisecondsSinceEpoch}@bugaoshan',
           structuredLocation: location.structuredLocation,
         ),
       );
     }
 
-    final sanitizedSemesterName = semester.name.replaceAll(RegExp(r'[^\w\u4e00-\u9fff.-]'), '_');
+    final sanitizedSemesterName = semester.name.replaceAll(
+      RegExp(r'[^\w\u4e00-\u9fff.-]'),
+      '_',
+    );
     return CalendarExportPayload(
       fileName: 'SCU_Calendar_$sanitizedSemesterName.ics',
       icsContent: _genCalendarIcs(events),
@@ -106,12 +126,18 @@ class AcademicCalendarService {
 
     for (final event in events) {
       buffer.writeln('BEGIN:VEVENT');
-      buffer.writeln('DTSTART;TZID=${event.timeZone}:${_formatIcsDate(event.start)}');
-      buffer.writeln('DTEND;TZID=${event.timeZone}:${_formatIcsDate(event.end)}');
+      buffer.writeln(
+        'DTSTART;TZID=${event.timeZone}:${_formatIcsDate(event.start)}',
+      );
+      buffer.writeln(
+        'DTEND;TZID=${event.timeZone}:${_formatIcsDate(event.end)}',
+      );
       buffer.writeln('SUMMARY:${_escapeIcsText(event.title)}');
       buffer.writeln('LOCATION:${_escapeIcsText(event.location)}');
       if (event.structuredLocation != null) {
-        buffer.writeln('GEO:${event.structuredLocation!.latitude};${event.structuredLocation!.longitude}');
+        buffer.writeln(
+          'GEO:${event.structuredLocation!.latitude};${event.structuredLocation!.longitude}',
+        );
       }
       buffer.writeln('DESCRIPTION:${_escapeIcsText(event.description)}');
       buffer.writeln('UID:${event.uid}');

--- a/test/academic_calendar_cache_test.dart
+++ b/test/academic_calendar_cache_test.dart
@@ -1,0 +1,36 @@
+import 'package:bugaoshan/services/api/academic_calendar_service.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  const cacheKey = 'cached_academic_calendar_json';
+  const validCalendar = '''
+  {
+    "semesters": [
+      {
+        "name": "2026-2027学年秋季学期",
+        "startDate": "2026-09-07",
+        "totalWeeks": 20,
+        "events": []
+      }
+    ]
+  }
+  ''';
+
+  test('无效远程校历不会覆盖最后一份有效缓存', () async {
+    SharedPreferences.setMockInitialValues({cacheKey: validCalendar});
+    final prefs = await SharedPreferences.getInstance();
+    final client = MockClient(
+      (_) async => http.Response('{"semesters":"invalid"}', 200),
+    );
+    final service = AcademicCalendarService(prefs, client: client);
+
+    final calendar = await service.fetchCalendarData();
+
+    expect(calendar.semesters, hasLength(1));
+    expect(calendar.semesters.single.name, '2026-2027学年秋季学期');
+    expect(prefs.getString(cacheKey), validCalendar);
+  });
+}


### PR DESCRIPTION
## 问题

远程校历响应只要包含 `semesters` 键就会先覆盖本地缓存，之后才进行强类型解析。若响应结构无效，解析会失败，而最后一份有效缓存已经被破坏。

## 修改

- 先把远程 JSON 完整解析为校历模型。
- 只有解析成功后才更新持久化缓存。
- 解析失败时保留并继续使用原有有效缓存。

## 用户影响

远程校历文件短暂损坏或结构异常时，应用仍能使用上一次有效校历，不会退化为无数据或只能依赖内置版本。

## 验证

- `flutter test --no-pub`：108 项全部通过。
- 定向 `flutter analyze --no-pub`：无问题。
- 回归测试模拟 `semesters` 类型错误，确认返回旧缓存且持久化内容不变。

本 PR 不涉及权限声明、认证凭据、隐私/EULA 或签名配置。
