### PR TITLE
fix: 教室查询增加当前空闲文案区分

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -52,6 +52,7 @@
     "allBuildings": "All Buildings",
     "seats": "seats",
     "free": "Free",
+    "currentlyFree": "Currently Free",
     "inClass": "In Class",
     "borrowed": "Borrowed",
     "classroomPeriodExam": "Exam",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -355,6 +355,12 @@ abstract class AppLocalizations {
   /// **'Free'**
   String get free;
 
+  /// No description provided for @currentlyFree.
+  ///
+  /// In en, this message translates to:
+  /// **'Currently Free'**
+  String get currentlyFree;
+
   /// No description provided for @inClass.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -143,6 +143,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get free => 'Free';
 
   @override
+  String get currentlyFree => 'Currently Free';
+
+  @override
   String get inClass => 'In Class';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -136,6 +136,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get free => '空闲';
 
   @override
+  String get currentlyFree => '当前空闲';
+
+  @override
   String get inClass => '上课中';
 
   @override

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -52,6 +52,7 @@
     "allBuildings": "全部教学楼",
     "seats": "座",
     "free": "空闲",
+    "currentlyFree": "当前空闲",
     "inClass": "上课中",
     "borrowed": "已借用",
     "classroomPeriodExam": "考试中",

--- a/lib/pages/campus/classroom/classroom_page.dart
+++ b/lib/pages/campus/classroom/classroom_page.dart
@@ -496,7 +496,7 @@ class _ClassroomPageState extends State<ClassroomPage> {
                 if (_isToday)
                   FilterChip(
                     avatar: const Icon(Icons.access_time, size: 16),
-                    label: Text(l10n.free),
+                    label: Text(l10n.currentlyFree),
                     selected:
                         _filterPeriodStart == currentPeriod &&
                         _filterPeriodEnd == currentPeriod,


### PR DESCRIPTION
将教室查询里的”空闲“按钮改成”当前空闲“以便用户理解