### PR TITLE
fix(ios): 避免 Profile 覆盖安装残留进程导致白屏

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,6 +68,18 @@ flutter pub run build_runner build --delete-conflicting-outputs
 flutter run
 ```
 
+### iOS Profile 真机安装
+
+需要以 Profile 模式在已连接的 iPhone 上验证时，使用仓库脚本：
+
+```bash
+tool/install_ios_profile.sh <device>
+```
+
+`<device>` 可以是 `xcrun devicectl list devices` 显示的设备标识、UDID 或设备名。若已经完成 Profile 构建，可用 `--no-build` 复用现有产物。
+
+脚本会先结束旧 App 及 Widget Extension 进程，再覆盖安装并启动新包。请不要直接对正在运行的 App 反复执行 `devicectl device install app`：iOS 可能保留指向旧安装路径的 Runner 进程，表现为安装成功但启动后白屏。若启动在 15 秒内没有完成，脚本会停止等待并提示解锁或重启设备。
+
 ---
 
 ## 📁 项目结构

--- a/tool/install_ios_profile.sh
+++ b/tool/install_ios_profile.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly bundle_id="io.github.thebrotherhoodofscu.bugaoshan"
+readonly app_path="build/ios/iphoneos/Runner.app"
+
+usage() {
+  cat <<'EOF'
+Usage: tool/install_ios_profile.sh <device> [--no-build]
+
+Build and install the iOS Profile app on a connected physical device.
+<device> may be a CoreDevice identifier, UDID, or device name.
+
+Options:
+  --no-build  Reuse build/ios/iphoneos/Runner.app.
+EOF
+}
+
+if [[ $# -lt 1 || $# -gt 2 ]]; then
+  usage >&2
+  exit 64
+fi
+
+readonly device="$1"
+readonly build_option="${2:-}"
+if [[ -n "$build_option" && "$build_option" != "--no-build" ]]; then
+  usage >&2
+  exit 64
+fi
+
+for command in flutter xcrun python3; do
+  if ! command -v "$command" >/dev/null 2>&1; then
+    echo "Missing required command: $command" >&2
+    exit 69
+  fi
+done
+
+if [[ "$build_option" != "--no-build" ]]; then
+  flutter build ios --profile
+fi
+
+if [[ ! -d "$app_path" ]]; then
+  echo "Profile app not found at $app_path" >&2
+  echo "Run without --no-build to create it first." >&2
+  exit 66
+fi
+
+temp_dir="$(mktemp -d "${TMPDIR:-/tmp}/bugaoshan-ios-profile.XXXXXX")"
+trap 'rm -rf "$temp_dir"' EXIT
+
+apps_json="$temp_dir/apps.json"
+processes_json="$temp_dir/processes.json"
+
+# devicectl may keep the old executable alive while replacing its app bundle.
+# Resolve the currently installed bundle path and stop every process inside it
+# before installing, including WidgetKit extensions.
+xcrun devicectl device info apps \
+  --device "$device" \
+  --json-output "$apps_json" >/dev/null
+
+installed_path="$({
+  python3 - "$apps_json" "$bundle_id" <<'PY'
+import json
+import sys
+from urllib.parse import unquote, urlparse
+
+with open(sys.argv[1], encoding="utf-8") as source:
+    apps = json.load(source)["result"]["apps"]
+
+for app in apps:
+    if app.get("bundleIdentifier") == sys.argv[2]:
+        print(unquote(urlparse(app["url"]).path).rstrip("/"))
+        break
+PY
+} || true)"
+
+if [[ -n "$installed_path" ]]; then
+  xcrun devicectl device info processes \
+    --device "$device" \
+    --json-output "$processes_json" >/dev/null
+
+  running_pids="$({
+    python3 - "$processes_json" "$installed_path" <<'PY'
+import json
+import sys
+from urllib.parse import unquote, urlparse
+
+with open(sys.argv[1], encoding="utf-8") as source:
+    processes = json.load(source)["result"]["runningProcesses"]
+
+prefix = sys.argv[2].rstrip("/") + "/"
+for process in processes:
+    executable = unquote(urlparse(process.get("executable", "")).path)
+    if executable.startswith(prefix):
+        print(process["processIdentifier"])
+PY
+  } || true)"
+
+  for pid in $running_pids; do
+    echo "Stopping existing process $pid before installation..."
+    if ! xcrun devicectl device process terminate \
+      --device "$device" \
+      --pid "$pid" >/dev/null; then
+      echo "Warning: process $pid exited before it could be stopped." >&2
+    fi
+  done
+fi
+
+xcrun devicectl device install app --device "$device" "$app_path"
+
+if ! xcrun devicectl device --timeout 15 process launch \
+  --device "$device" \
+  "$bundle_id"; then
+  cat >&2 <<'EOF'
+
+The app was installed, but iOS did not finish launching it within 15 seconds.
+Unlock the device and try opening the app. If it remains blank, reboot the
+device once to clear stale LaunchServices/Scene state, then rerun with
+--no-build.
+EOF
+  exit 1
+fi
+


### PR DESCRIPTION
## 问题

使用 `devicectl device install app` 连续覆盖安装 iOS Profile 包时，iOS 可能不会结束正在运行的旧 Runner。此次真机排查中观察到：

- 新包已经安装到新的 App 容器路径；
- 仍在运行的 Runner 却指向上一次安装的旧路径；
- 此时应用表现为白屏，且新包没有真正创建进程；
- 同一构建改用全新 Bundle ID 可以正常启动，旧数据库、偏好设置和背景图复制过去后仍正常，排除了业务初始化与用户数据；
- 结束残留进程并重启设备后，新包可正常启动。

## 修复

新增 `tool/install_ios_profile.sh`：

1. 构建 iOS Profile 包（支持 `--no-build` 复用产物）；
2. 根据 Bundle ID 查询当前已登记的 App 路径；
3. 仅结束该路径下的主 App 和 Widget Extension 进程；
4. 再执行覆盖安装并启动；
5. 启动超过 15 秒时停止等待，并提示解锁或重启设备清理 LaunchServices/Scene 残留状态。

同时在 `CONTRIBUTING.md` 补充使用方式和白屏原因说明。

## 验证

- `bash -n tool/install_ios_profile.sh`
- `git diff --check`
- iPhone 真机 Profile 回归：脚本识别并结束主 App 与 Widget Extension，随后安装、启动成功；运行进程路径与新安装路径一致。