### PR TITLE
校历导入增强-2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 将验证码识别从LiteRT切换为内置实现减小包体积、提高跨平台兼容性
 - 适配成绩页面支持存在多个培养方案的情况
 
+### Removed
+- 移除功能：当软件状态恢复时，例如从后台打开，最小化之后打开：课表跳转到当前周
 
 ### Fixed
 - 修复课程表左侧时间标签可能换行的问题

--- a/lib/pages/course/course_page.dart
+++ b/lib/pages/course/course_page.dart
@@ -26,6 +26,7 @@ part 'course_page_top_bar.dart';
 part 'course_page_actions.dart';
 part 'course_page_no_schedule_view.dart';
 part 'course_page_vacation_view.dart';
+part 'course_preview_data.dart';
 
 class CoursePage extends StatefulWidget {
   const CoursePage({super.key, this.demoMode = false});
@@ -101,13 +102,6 @@ class _CoursePageState extends State<CoursePage> with WidgetsBindingObserver {
     courseProvider.scheduleConfig.removeListener(_onScheduleConfigChanged);
     _pageController.dispose();
     super.dispose();
-  }
-
-  @override
-  void didChangeAppLifecycleState(AppLifecycleState state) {
-    if (state == AppLifecycleState.resumed) {
-      _syncToCurrentWeek();
-    }
   }
 
   void _onCurrentWeekChanged() {
@@ -447,75 +441,3 @@ class _CoursePageState extends State<CoursePage> with WidgetsBindingObserver {
     }
   }
 }
-
-/// 课程表样式预览中使用的示例课程。
-/// 覆盖周一至周五，分布在上午和下午时段，便于在 [SetCourseStylePage] 中预览样式变化。
-final List<Course> _kDemoCourses = [
-  Course(
-    name: '高等数学',
-    teacher: '张教授',
-    location: '综C407',
-    startWeek: 1,
-    endWeek: 20,
-    dayOfWeek: 1,
-    startSection: 1,
-    endSection: 2,
-    colorValue: 0xFF1976D2,
-  ),
-  Course(
-    name: '大学英语（三）',
-    teacher: '李老师',
-    location: '综B207',
-    startWeek: 1,
-    endWeek: 20,
-    dayOfWeek: 2,
-    startSection: 3,
-    endSection: 4,
-    colorValue: 0xFF388E3C,
-  ),
-  Course(
-    name: '程序设计基础',
-    teacher: '王老师',
-    location: '二基楼B501',
-    startWeek: 1,
-    endWeek: 20,
-    dayOfWeek: 3,
-    startSection: 6,
-    endSection: 8,
-    colorValue: 0xFFE64A19,
-  ),
-  Course(
-    name: '线性代数',
-    teacher: '赵教授',
-    location: '综C103',
-    startWeek: 1,
-    endWeek: 20,
-    dayOfWeek: 4,
-    startSection: 1,
-    endSection: 2,
-    colorValue: 0xFF7B1FA2,
-  ),
-  Course(
-    name: '大学物理（下）',
-    teacher: '陈老师',
-    location: '综B307',
-    startWeek: 1,
-    endWeek: 20,
-    dayOfWeek: 5,
-    startSection: 3,
-    endSection: 4,
-    colorValue: 0xFF00838F,
-  ),
-  // 第15周才开始的课程，用于展示「显示非本周课程」开关效果
-  Course(
-    name: '体育',
-    teacher: '刘老师',
-    location: '江安体育馆',
-    startWeek: 15,
-    endWeek: 20,
-    dayOfWeek: 1,
-    startSection: 5,
-    endSection: 6,
-    colorValue: 0xFFF9A825,
-  ),
-];

--- a/lib/pages/course/course_page.dart
+++ b/lib/pages/course/course_page.dart
@@ -59,6 +59,7 @@ class _CoursePageState extends State<CoursePage> with WidgetsBindingObserver {
       initialPage: _isViewingVacation ? totalWeeks : _visibleWeek - 1,
     );
     courseProvider.currentWeek.addListener(_onCurrentWeekChanged);
+    courseProvider.scheduleConfig.addListener(_onScheduleConfigChanged);
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
       _syncToCurrentWeek();
@@ -69,6 +70,7 @@ class _CoursePageState extends State<CoursePage> with WidgetsBindingObserver {
   void dispose() {
     WidgetsBinding.instance.removeObserver(this);
     courseProvider.currentWeek.removeListener(_onCurrentWeekChanged);
+    courseProvider.scheduleConfig.removeListener(_onScheduleConfigChanged);
     _pageController.dispose();
     super.dispose();
   }
@@ -81,6 +83,11 @@ class _CoursePageState extends State<CoursePage> with WidgetsBindingObserver {
   }
 
   void _onCurrentWeekChanged() {
+    final config = courseProvider.scheduleConfig.value;
+    if (config.getCurrentWeek() > config.totalWeeks) {
+      // 处于假期，由 _syncToCurrentWeek 管理页面位置，不响应 currentWeek 变化
+      return;
+    }
     final targetPage = courseProvider.currentWeek.value - 1;
     if (_pageController.hasClients &&
         _pageController.page?.round() != targetPage) {
@@ -96,6 +103,10 @@ class _CoursePageState extends State<CoursePage> with WidgetsBindingObserver {
     }
   }
 
+  void _onScheduleConfigChanged() {
+    _syncToCurrentWeek();
+  }
+
   void _syncToCurrentWeek() {
     final config = courseProvider.scheduleConfig.value;
     final actualWeek = config.getCurrentWeek();
@@ -103,16 +114,30 @@ class _CoursePageState extends State<CoursePage> with WidgetsBindingObserver {
     if (actualWeek > totalWeeks) {
       _navigateToVacation();
     } else {
+      if (_isViewingVacation) {
+        setState(() => _isViewingVacation = false);
+      }
       courseProvider.updateCurrentWeek(actualWeek);
     }
     _checkAndPromptNextSemester();
   }
 
   void _navigateToVacation() {
+    final totalWeeks = courseProvider.scheduleConfig.value.totalWeeks;
     if (!_isViewingVacation && _pageController.hasClients) {
       _isViewingVacation = true;
       _pageController.animateToPage(
-        courseProvider.scheduleConfig.value.totalWeeks,
+        totalWeeks,
+        duration: appConfig.cardSizeAnimationDuration.value,
+        curve: AppCurves.quick,
+      );
+      setState(() {});
+    } else if (_isViewingVacation &&
+        _pageController.hasClients &&
+        _pageController.page?.round() != totalWeeks) {
+      // 切换课表后仍在假期，但总周数不同，需要更新 PageController 位置
+      _pageController.animateToPage(
+        totalWeeks,
         duration: appConfig.cardSizeAnimationDuration.value,
         curve: AppCurves.quick,
       );

--- a/lib/pages/course/course_page.dart
+++ b/lib/pages/course/course_page.dart
@@ -44,6 +44,33 @@ class _CoursePageState extends State<CoursePage> with WidgetsBindingObserver {
   bool _isViewingVacation = false;
   bool _promptedNextSemester = false;
 
+  /// 判断当前课表是否应该显示放假页。
+  /// 规则：当前学期已结束，且下学期还未开始（今天在两个学期之间）时显示。
+  bool _computeShowVacationPage() {
+    final config = courseProvider.scheduleConfig.value;
+    final now = DateTime.now();
+    final today = DateTime(now.year, now.month, now.day);
+
+    // 学期未结束 → 不显示
+    if (!today.isAfter(config.semesterEndDate)) return false;
+
+    // 找下学期（当前学期结束后最早开始的课表）
+    ScheduleConfig? next;
+    for (final s in courseProvider.allSchedules.value) {
+      if (s.id != config.id &&
+          s.semesterStartDate.isAfter(config.semesterEndDate)) {
+        if (next == null ||
+            s.semesterStartDate.isBefore(next.semesterStartDate)) {
+          next = s;
+        }
+      }
+    }
+    if (next == null) return false;
+
+    // 今天在下学期开始前
+    return today.isBefore(next.semesterStartDate);
+  }
+
   @override
   void initState() {
     super.initState();
@@ -51,7 +78,8 @@ class _CoursePageState extends State<CoursePage> with WidgetsBindingObserver {
     final config = courseProvider.scheduleConfig.value;
     final actualWeek = config.getCurrentWeek();
     final totalWeeks = config.totalWeeks;
-    _isViewingVacation = actualWeek > totalWeeks;
+    final showVacation = _computeShowVacationPage();
+    _isViewingVacation = showVacation && actualWeek > totalWeeks;
     _visibleWeek = _isViewingVacation
         ? totalWeeks
         : courseProvider.currentWeek.value;
@@ -83,9 +111,8 @@ class _CoursePageState extends State<CoursePage> with WidgetsBindingObserver {
   }
 
   void _onCurrentWeekChanged() {
-    final config = courseProvider.scheduleConfig.value;
-    if (config.getCurrentWeek() > config.totalWeeks) {
-      // 处于假期，由 _syncToCurrentWeek 管理页面位置，不响应 currentWeek 变化
+    if (_isViewingVacation) {
+      // 放假页面时不需要响应 currentWeek 变化，避免覆盖放假导航
       return;
     }
     final targetPage = courseProvider.currentWeek.value - 1;
@@ -104,6 +131,18 @@ class _CoursePageState extends State<CoursePage> with WidgetsBindingObserver {
   }
 
   void _onScheduleConfigChanged() {
+    // 切换课表或导入时绝不进入放假页面。
+    // 注意：不手动调 updateCurrentWeek，由 _loadData 随后设置，避免二次触发
+    // _onCurrentWeekChanged 覆盖页面位置。
+    final config = courseProvider.scheduleConfig.value;
+    final totalWeeks = config.totalWeeks;
+
+    _isViewingVacation = false;
+    _visibleWeek = totalWeeks;
+    if (_pageController.hasClients) {
+      _pageController.jumpToPage(totalWeeks - 1);
+    }
+    setState(() {});
     _syncToCurrentWeek();
   }
 
@@ -123,6 +162,7 @@ class _CoursePageState extends State<CoursePage> with WidgetsBindingObserver {
   }
 
   void _navigateToVacation() {
+    if (!_computeShowVacationPage()) return;
     final totalWeeks = courseProvider.scheduleConfig.value.totalWeeks;
     if (!_isViewingVacation && _pageController.hasClients) {
       _isViewingVacation = true;
@@ -256,12 +296,14 @@ class _CoursePageState extends State<CoursePage> with WidgetsBindingObserver {
       );
     }
 
+    final showVacationPage = _computeShowVacationPage();
+
     return _SwipePageView(
       controller: _pageController,
-      itemCount: totalWeeks + 1,
+      itemCount: showVacationPage ? totalWeeks + 1 : totalWeeks,
       onPageChanged: _onPageChanged,
       itemBuilder: (context, index) {
-        if (index >= totalWeeks) {
+        if (showVacationPage && index >= totalWeeks) {
           return _VacationView(
             scheduleConfig: config,
             allSchedules: courseProvider.allSchedules.value,

--- a/lib/pages/course/course_page.dart
+++ b/lib/pages/course/course_page.dart
@@ -101,7 +101,20 @@ class _CoursePageState extends State<CoursePage> with WidgetsBindingObserver {
   void _updateVacationAvailability() {
     final next = _computeShowVacationPage();
     if (next == _showVacationPage) return;
-    setState(() => _showVacationPage = next);
+    setState(() {
+      _showVacationPage = next;
+      // 放假页在被查看时消失（如跨夜后下学期开始）：itemCount 缩水，
+      // 控制器会停在越界索引上，退回末周兜底。
+      if (!next && _isViewingVacation) {
+        _isViewingVacation = false;
+      }
+    });
+    if (!next && _pageController.hasClients) {
+      final maxPage = courseProvider.scheduleConfig.value.totalWeeks - 1;
+      if ((_pageController.page ?? 0).round() > maxPage) {
+        _pageController.jumpToPage(maxPage);
+      }
+    }
   }
 
   @override
@@ -138,6 +151,16 @@ class _CoursePageState extends State<CoursePage> with WidgetsBindingObserver {
     courseProvider.allSchedules.removeListener(_updateVacationAvailability);
     _pageController.dispose();
     super.dispose();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state != AppLifecycleState.resumed) return;
+    // 跨天或长时间后台后回前台：刷新依赖「今天」的派生状态
+    // （顶栏日期、放假页可用性、假期徽章）。
+    // 刻意不调 _syncToCurrentWeek —— 回前台不自动跳周。
+    _updateVacationAvailability();
+    setState(() {});
   }
 
   void _onCurrentWeekChanged() {
@@ -234,6 +257,7 @@ class _CoursePageState extends State<CoursePage> with WidgetsBindingObserver {
               totalWeeks: courseProvider.scheduleConfig.value.totalWeeks,
               visibleWeek: _visibleWeek,
               isViewingVacation: _isViewingVacation,
+              hasVacationPage: _showVacationPage,
               onPreviousWeek: () => _isViewingVacation
                   ? _changeWeek(courseProvider.scheduleConfig.value.totalWeeks)
                   : _changeWeek(courseProvider.currentWeek.value - 1),
@@ -396,6 +420,19 @@ class _CoursePageState extends State<CoursePage> with WidgetsBindingObserver {
       setState(() => _isViewingVacation = false);
     }
     courseProvider.updateCurrentWeek(newWeek);
+    // currentWeek 本来就等于 newWeek 时 ValueNotifier 不会通知（int 相等），
+    // _onCurrentWeekChanged 不触发，页面停在原地 —— 典型场景：放假期间
+    // currentWeek 已被 clamp 成 totalWeeks，从放假页点左箭头回末周。
+    // 这里显式驱动 PageController 兜底。
+    final targetPage = newWeek - 1;
+    if (_pageController.hasClients &&
+        _pageController.page?.round() != targetPage) {
+      _pageController.animateToPage(
+        targetPage,
+        duration: appConfig.cardSizeAnimationDuration.value,
+        curve: AppCurves.quick,
+      );
+    }
   }
 
   void _goToCurrentWeek() {

--- a/lib/pages/course/course_page.dart
+++ b/lib/pages/course/course_page.dart
@@ -45,6 +45,30 @@ class _CoursePageState extends State<CoursePage> with WidgetsBindingObserver {
   bool _isViewingVacation = false;
   bool _promptedNextSemester = false;
 
+  /// [_computeShowVacationPage] 的缓存值。该判定只取决于课表配置和全部课表列表
+  /// （外加「今天」），没必要每帧重算 —— 它会分配 DateTime 并遍历 allSchedules，
+  /// 而 PageView 的 itemCount 依赖它。
+  bool _showVacationPage = false;
+
+  /// 顶部栏只关心当前周和课表配置；课程列表变化不影响它。
+  late final Listenable _topBarListenable = Listenable.merge([
+    courseProvider.currentWeek,
+    courseProvider.scheduleConfig,
+  ]);
+
+  /// 课表网格不读 currentWeek —— 翻页由 [_pageController] 驱动，
+  /// 把 currentWeek 混进来会导致每次滑动都重建整个 PageView。
+  late final Listenable _gridListenable = Listenable.merge([
+    courseProvider.courses,
+    courseProvider.scheduleConfig,
+    courseProvider.allSchedules,
+  ]);
+
+  late final Listenable _bgImageListenable = Listenable.merge([
+    appConfig.backgroundImagePath,
+    appConfig.backgroundImageOpacity,
+  ]);
+
   /// 判断当前课表是否应该显示放假页。
   /// 规则：当前学期已结束，且下学期还未开始（今天在两个学期之间）时显示。
   bool _computeShowVacationPage() {
@@ -72,6 +96,14 @@ class _CoursePageState extends State<CoursePage> with WidgetsBindingObserver {
     return today.isBefore(next.semesterStartDate);
   }
 
+  /// 重算放假页可用性；仅在结果变化时 setState。
+  /// 只允许在非 build 阶段调用（监听器回调、手势、postFrame）。
+  void _updateVacationAvailability() {
+    final next = _computeShowVacationPage();
+    if (next == _showVacationPage) return;
+    setState(() => _showVacationPage = next);
+  }
+
   @override
   void initState() {
     super.initState();
@@ -79,8 +111,8 @@ class _CoursePageState extends State<CoursePage> with WidgetsBindingObserver {
     final config = courseProvider.scheduleConfig.value;
     final actualWeek = config.getCurrentWeek();
     final totalWeeks = config.totalWeeks;
-    final showVacation = _computeShowVacationPage();
-    _isViewingVacation = showVacation && actualWeek > totalWeeks;
+    _showVacationPage = _computeShowVacationPage();
+    _isViewingVacation = _showVacationPage && actualWeek > totalWeeks;
     _visibleWeek = _isViewingVacation
         ? totalWeeks
         : courseProvider.currentWeek.value;
@@ -89,6 +121,9 @@ class _CoursePageState extends State<CoursePage> with WidgetsBindingObserver {
     );
     courseProvider.currentWeek.addListener(_onCurrentWeekChanged);
     courseProvider.scheduleConfig.addListener(_onScheduleConfigChanged);
+    // allSchedules 可以脱离 scheduleConfig 单独变化（新增/删除课表），
+    // 而放假页判定依赖它，所以单独监听。
+    courseProvider.allSchedules.addListener(_updateVacationAvailability);
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
       _syncToCurrentWeek();
@@ -100,6 +135,7 @@ class _CoursePageState extends State<CoursePage> with WidgetsBindingObserver {
     WidgetsBinding.instance.removeObserver(this);
     courseProvider.currentWeek.removeListener(_onCurrentWeekChanged);
     courseProvider.scheduleConfig.removeListener(_onScheduleConfigChanged);
+    courseProvider.allSchedules.removeListener(_updateVacationAvailability);
     _pageController.dispose();
     super.dispose();
   }
@@ -130,17 +166,24 @@ class _CoursePageState extends State<CoursePage> with WidgetsBindingObserver {
     // _onCurrentWeekChanged 覆盖页面位置。
     final config = courseProvider.scheduleConfig.value;
     final totalWeeks = config.totalWeeks;
+    _showVacationPage = _computeShowVacationPage();
+
+    // 直接落到 _syncToCurrentWeek 稍后要去的那一周。以前先 jumpToPage 到末周，
+    // 紧接着同一个 microtask 里 _onCurrentWeekChanged 又 animateToPage 回当前周 ——
+    // 跳的那帧画不出来，但动画起点已是末周，于是会横扫中间十几周并逐页 build。
+    final targetWeek = config.getCurrentWeek().clamp(1, totalWeeks);
 
     _isViewingVacation = false;
-    _visibleWeek = totalWeeks;
+    _visibleWeek = targetWeek;
     if (_pageController.hasClients) {
-      _pageController.jumpToPage(totalWeeks - 1);
+      _pageController.jumpToPage(targetWeek - 1);
     }
     setState(() {});
     _syncToCurrentWeek();
   }
 
   void _syncToCurrentWeek() {
+    _updateVacationAvailability();
     final config = courseProvider.scheduleConfig.value;
     final actualWeek = config.getCurrentWeek();
     final totalWeeks = config.totalWeeks;
@@ -156,7 +199,7 @@ class _CoursePageState extends State<CoursePage> with WidgetsBindingObserver {
   }
 
   void _navigateToVacation() {
-    if (!_computeShowVacationPage()) return;
+    if (!_showVacationPage) return;
     final totalWeeks = courseProvider.scheduleConfig.value.totalWeeks;
     if (!_isViewingVacation && _pageController.hasClients) {
       _isViewingVacation = true;
@@ -181,22 +224,11 @@ class _CoursePageState extends State<CoursePage> with WidgetsBindingObserver {
 
   @override
   Widget build(BuildContext context) {
-    final courseDataListenable = Listenable.merge([
-      courseProvider.courses,
-      courseProvider.scheduleConfig,
-      courseProvider.currentWeek,
-      courseProvider.allSchedules,
-    ]);
-    final bgImageListenable = Listenable.merge([
-      appConfig.backgroundImagePath,
-      appConfig.backgroundImageOpacity,
-    ]);
-
     return Column(
       children: [
         if (!widget.demoMode)
           ListenableBuilder(
-            listenable: courseDataListenable,
+            listenable: _topBarListenable,
             builder: (context, _) => _TopBar(
               week: courseProvider.currentWeek.value,
               totalWeeks: courseProvider.scheduleConfig.value.totalWeeks,
@@ -217,11 +249,11 @@ class _CoursePageState extends State<CoursePage> with WidgetsBindingObserver {
           child: Stack(
             children: [
               ListenableBuilder(
-                listenable: bgImageListenable,
+                listenable: _bgImageListenable,
                 builder: _buildBackgroundImage,
               ),
               ListenableBuilder(
-                listenable: courseDataListenable,
+                listenable: _gridListenable,
                 builder: (context, _) =>
                     widget.demoMode || courseProvider.hasSchedule
                     ? _buildCourseGrid(context, null)
@@ -290,14 +322,12 @@ class _CoursePageState extends State<CoursePage> with WidgetsBindingObserver {
       );
     }
 
-    final showVacationPage = _computeShowVacationPage();
-
     return _SwipePageView(
       controller: _pageController,
-      itemCount: showVacationPage ? totalWeeks + 1 : totalWeeks,
+      itemCount: _showVacationPage ? totalWeeks + 1 : totalWeeks,
       onPageChanged: _onPageChanged,
       itemBuilder: (context, index) {
-        if (showVacationPage && index >= totalWeeks) {
+        if (_showVacationPage && index >= totalWeeks) {
           return _VacationView(
             scheduleConfig: config,
             allSchedules: courseProvider.allSchedules.value,

--- a/lib/pages/course/course_page_top_bar.dart
+++ b/lib/pages/course/course_page_top_bar.dart
@@ -69,10 +69,15 @@ class _TopBar extends StatelessWidget {
                             : Theme.of(context).disabledColor,
                       ),
                     ),
-                    SizedBox(
-                      width: isInVacation || isViewingVacation ? 80 : 60,
+                    const SizedBox(width: 5),
+                    AnimatedSize(
+                      duration:
+                          appConfigService.cardSizeAnimationDuration.value,
+                      curve: appCurve,
                       child: Text(
-                        isInVacation ? l10n.onVacation : l10n.currentWeek(week),
+                        isViewingVacation
+                            ? l10n.onVacation
+                            : l10n.currentWeek(week),
                         textAlign: TextAlign.center,
                         style: Theme.of(context).textTheme.bodySmall?.copyWith(
                           fontWeight: FontWeight.w500,
@@ -80,6 +85,7 @@ class _TopBar extends StatelessWidget {
                         ),
                       ),
                     ),
+                    const SizedBox(width: 5),
                     GestureDetector(
                       onTap: canGoRight ? onNextWeek : null,
                       child: Icon(

--- a/lib/pages/course/course_page_top_bar.dart
+++ b/lib/pages/course/course_page_top_bar.dart
@@ -5,6 +5,10 @@ class _TopBar extends StatelessWidget {
   final int totalWeeks;
   final int visibleWeek;
   final bool isViewingVacation;
+
+  /// 放假页是否存在（与 _CoursePageState._showVacationPage 同源）。
+  /// 徽章和右箭头都以它为准，避免「显示假期中却无放假页可翻」的脱节。
+  final bool hasVacationPage;
   final VoidCallback onPreviousWeek;
   final VoidCallback? onNextWeek;
   final VoidCallback onGoToCurrentWeek;
@@ -17,6 +21,7 @@ class _TopBar extends StatelessWidget {
     required this.totalWeeks,
     required this.visibleWeek,
     this.isViewingVacation = false,
+    this.hasVacationPage = false,
     required this.onPreviousWeek,
     required this.onNextWeek,
     required this.onGoToCurrentWeek,
@@ -29,13 +34,18 @@ class _TopBar extends StatelessWidget {
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
     final config = getIt<CourseProvider>().scheduleConfig.value;
-    final isCurrentCalendarWeek = visibleWeek == config.getCurrentWeek();
-    final isInVacation = config.getCurrentWeek() > config.totalWeeks;
+    final actualWeek = config.getCurrentWeek();
+    final isCurrentCalendarWeek = visibleWeek == actualWeek;
+    // 与放假页共用同一判定：没有放假页时不显示「假期中」徽章，
+    // 避免徽章提示假期但右箭头无处可去。
+    final isInVacation = hasVacationPage && actualWeek > config.totalWeeks;
 
     final now = DateTime.now();
     final dateStr = '${now.year}/${now.month}/${now.day}';
     final canGoLeft = isViewingVacation || week > 1;
-    final canGoRight = !isViewingVacation && week <= totalWeeks;
+    // 最后一周时只有存在放假页才能继续往右翻。
+    final canGoRight =
+        !isViewingVacation && (week < totalWeeks || hasVacationPage);
 
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 2),
@@ -102,7 +112,12 @@ class _TopBar extends StatelessWidget {
                     else
                       _WeekBadge(
                         isCurrentCalendarWeek: isCurrentCalendarWeek,
-                        actualCurrentWeek: config.getCurrentWeek(),
+                        // 无放假页时学期过末 actualWeek 会超过 totalWeeks，
+                        // clamp 避免徽章显示越界周数。
+                        actualCurrentWeek: actualWeek.clamp(
+                          1,
+                          config.totalWeeks,
+                        ),
                       ),
                   ],
                 ),

--- a/lib/pages/course/course_page_top_bar.dart
+++ b/lib/pages/course/course_page_top_bar.dart
@@ -32,8 +32,8 @@ class _TopBar extends StatelessWidget {
     final isCurrentCalendarWeek = visibleWeek == config.getCurrentWeek();
     final isInVacation = config.getCurrentWeek() > config.totalWeeks;
 
-    final now = DateTime.now();
-    final dateStr = '${now.year}/${now.month}/${now.day}';
+    final weekDate = config.dateForCourseDay(visibleWeek, DateTime.monday);
+    final dateStr = '${weekDate.year}/${weekDate.month}/${weekDate.day}';
     final canGoLeft = isViewingVacation || week > 1;
     final canGoRight = !isViewingVacation && week <= totalWeeks;
 

--- a/lib/pages/course/course_page_top_bar.dart
+++ b/lib/pages/course/course_page_top_bar.dart
@@ -32,8 +32,8 @@ class _TopBar extends StatelessWidget {
     final isCurrentCalendarWeek = visibleWeek == config.getCurrentWeek();
     final isInVacation = config.getCurrentWeek() > config.totalWeeks;
 
-    final weekDate = config.dateForCourseDay(visibleWeek, DateTime.monday);
-    final dateStr = '${weekDate.year}/${weekDate.month}/${weekDate.day}';
+    final now = DateTime.now();
+    final dateStr = '${now.year}/${now.month}/${now.day}';
     final canGoLeft = isViewingVacation || week > 1;
     final canGoRight = !isViewingVacation && week <= totalWeeks;
 

--- a/lib/pages/course/course_page_top_bar.dart
+++ b/lib/pages/course/course_page_top_bar.dart
@@ -30,6 +30,7 @@ class _TopBar extends StatelessWidget {
     final l10n = AppLocalizations.of(context)!;
     final config = getIt<CourseProvider>().scheduleConfig.value;
     final isCurrentCalendarWeek = visibleWeek == config.getCurrentWeek();
+    final isInVacation = config.getCurrentWeek() > config.totalWeeks;
 
     final now = DateTime.now();
     final dateStr = '${now.year}/${now.month}/${now.day}';
@@ -69,11 +70,9 @@ class _TopBar extends StatelessWidget {
                       ),
                     ),
                     SizedBox(
-                      width: isViewingVacation ? 80 : 60,
+                      width: isInVacation || isViewingVacation ? 80 : 60,
                       child: Text(
-                        isViewingVacation
-                            ? l10n.onVacation
-                            : l10n.currentWeek(week),
+                        isInVacation ? l10n.onVacation : l10n.currentWeek(week),
                         textAlign: TextAlign.center,
                         style: Theme.of(context).textTheme.bodySmall?.copyWith(
                           fontWeight: FontWeight.w500,
@@ -92,7 +91,7 @@ class _TopBar extends StatelessWidget {
                       ),
                     ),
                     const SizedBox(width: 3),
-                    if (isViewingVacation)
+                    if (isInVacation)
                       _VacationBadge()
                     else
                       _WeekBadge(

--- a/lib/pages/course/course_preview_data.dart
+++ b/lib/pages/course/course_preview_data.dart
@@ -1,0 +1,73 @@
+part of 'course_page.dart';
+
+/// 课程表样式预览中使用的示例课程。
+/// 覆盖周一至周五，分布在上午和下午时段，便于在 [SetCourseStylePage] 中预览样式变化。
+final List<Course> _kDemoCourses = [
+  Course(
+    name: '高等数学',
+    teacher: '张教授',
+    location: '综C407',
+    startWeek: 1,
+    endWeek: 20,
+    dayOfWeek: 1,
+    startSection: 1,
+    endSection: 2,
+    colorValue: 0xFF1976D2,
+  ),
+  Course(
+    name: '大学英语（三）',
+    teacher: '李老师',
+    location: '综B207',
+    startWeek: 1,
+    endWeek: 20,
+    dayOfWeek: 2,
+    startSection: 3,
+    endSection: 4,
+    colorValue: 0xFF388E3C,
+  ),
+  Course(
+    name: '程序设计基础',
+    teacher: '王老师',
+    location: '二基楼B501',
+    startWeek: 1,
+    endWeek: 20,
+    dayOfWeek: 3,
+    startSection: 6,
+    endSection: 8,
+    colorValue: 0xFFE64A19,
+  ),
+  Course(
+    name: '线性代数',
+    teacher: '赵教授',
+    location: '综C103',
+    startWeek: 1,
+    endWeek: 20,
+    dayOfWeek: 4,
+    startSection: 1,
+    endSection: 2,
+    colorValue: 0xFF7B1FA2,
+  ),
+  Course(
+    name: '大学物理（下）',
+    teacher: '陈老师',
+    location: '综B307',
+    startWeek: 1,
+    endWeek: 20,
+    dayOfWeek: 5,
+    startSection: 3,
+    endSection: 4,
+    colorValue: 0xFF00838F,
+  ),
+  // 第15周才开始的课程，用于展示「显示非本周课程」开关效果
+  Course(
+    name: '体育',
+    teacher: '刘老师',
+    location: '江安体育馆',
+    startWeek: 15,
+    endWeek: 20,
+    dayOfWeek: 1,
+    startSection: 5,
+    endSection: 6,
+    colorValue: 0xFFF9A825,
+  ),
+];

--- a/lib/pages/course/import_schedule_page.dart
+++ b/lib/pages/course/import_schedule_page.dart
@@ -455,20 +455,22 @@ class _ImportSchedulePageState extends State<ImportSchedulePage> {
       }
 
       if (mounted) {
-        // 静默根据校历自动计算周数
+        // 静默根据校历自动设置学期开始日期和周数
         for (final imported in importedSchedules) {
           try {
-            final weeks =
-                await AcademicCalendarService.findTotalWeeksFromCalendar(
-                  imported.name,
-                );
-            if (weeks != null) {
+            final semester = await AcademicCalendarService.findMatchingSemester(
+              imported.name,
+            );
+            if (semester != null) {
               final allSchedules = widget.courseProvider.allSchedules.value;
               final schedule = allSchedules
                   .where((s) => s.id == imported.id)
                   .firstOrNull;
               if (schedule != null) {
-                final updated = schedule.copyWith(totalWeeks: weeks);
+                final updated = schedule.copyWith(
+                  semesterStartDate: semester.startDate,
+                  totalWeeks: semester.totalWeeks,
+                );
                 await widget.courseProvider.updateScheduleConfig(updated);
               }
             }
@@ -481,50 +483,6 @@ class _ImportSchedulePageState extends State<ImportSchedulePage> {
         ScaffoldMessenger.of(
           context,
         ).showSnackBar(SnackBar(content: Text(l10n.importSuccess)));
-
-        // 导入成功后，询问是否自动设置当前教学周
-        if (!mounted) return;
-        final setWeek = await showDialog<bool>(
-          context: context,
-          builder: (ctx) => AlertDialog(
-            title: Text(l10n.autoSetCurrentWeekTitle),
-            content: Text(l10n.autoSetCurrentWeekContent),
-            actions: [
-              TextButton(
-                onPressed: () => Navigator.pop(ctx, false),
-                child: Text(l10n.cancel),
-              ),
-              TextButton(
-                onPressed: () => Navigator.pop(ctx, true),
-                child: Text(l10n.confirm),
-              ),
-            ],
-          ),
-        );
-        if (setWeek == true && mounted) {
-          try {
-            final week = await getIt<ZhjwApiService>().fetchCurrentWeek();
-            if (!mounted) return;
-            final now = DateTime.now();
-            final today = DateTime(now.year, now.month, now.day);
-            final currentSunday = today.toSunday();
-            final newStartDate = currentSunday.subtract(
-              Duration(days: (week - 1) * 7),
-            );
-            final currentConfig = widget.courseProvider.scheduleConfig.value;
-            final updatedConfig = currentConfig.copyWith(
-              semesterStartDate: newStartDate,
-            );
-            await widget.courseProvider.updateScheduleConfig(updatedConfig);
-            if (mounted) {
-              ScaffoldMessenger.of(context).showSnackBar(
-                SnackBar(content: Text(l10n.autoSetCurrentWeekSuccess)),
-              );
-            }
-          } catch (_) {
-            // 获取失败不阻断流程，静默忽略
-          }
-        }
 
         if (logicRootContext.mounted &&
             Navigator.of(logicRootContext).canPop()) {

--- a/lib/services/api/academic_calendar_service.dart
+++ b/lib/services/api/academic_calendar_service.dart
@@ -122,13 +122,24 @@ class AcademicCalendarService {
     return null;
   }
 
+  /// 解析后的内置校历缓存。rootBundle 只缓存资源的原始字符串，
+  /// jsonDecode + expandCalendarJson + 模型构造每次调用都会重跑；
+  /// 而 bundle 资源在进程生命周期内不会变，解析一次即可。
+  static AcademicCalendarData? _bundledCalendarCache;
+
   /// Load and parse the bundled academic calendar JSON asset.
   static Future<AcademicCalendarData> loadBundledCalendar() async {
+    final cached = _bundledCalendarCache;
+    if (cached != null) return cached;
+
     final assetContent = await rootBundle.loadString(
       'assets/academic_calendar.json',
     );
     final decoded = jsonDecode(assetContent) as Map<String, dynamic>;
-    return AcademicCalendarData.fromJson(expandCalendarJson(decoded));
+    // 只在解析成功后写缓存；抛异常时缓存保持为空，下次调用会重试。
+    final data = AcademicCalendarData.fromJson(expandCalendarJson(decoded));
+    _bundledCalendarCache = data;
+    return data;
   }
 
   /// 根据课表名称从校历中匹配学期并返回总周数，未匹配则返回 null。

--- a/lib/services/api/academic_calendar_service.dart
+++ b/lib/services/api/academic_calendar_service.dart
@@ -162,6 +162,37 @@ class AcademicCalendarService {
     }
   }
 
+  /// 根据课表名称从校历中匹配完整的学期信息。
+  /// 匹配逻辑与 [findTotalWeeksFromCalendar] 一致，但返回整个 [AcademicCalendarSemester]。
+  static Future<AcademicCalendarSemester?> findMatchingSemester(
+    String scheduleName,
+  ) async {
+    try {
+      final data = await loadBundledCalendar();
+
+      final yearMatch = RegExp(r'(\d{4})-(\d{4})').firstMatch(scheduleName);
+      if (yearMatch == null) return null;
+
+      final academicYear = '${yearMatch.group(1)}-${yearMatch.group(2)}';
+      final isSpring = scheduleName.contains('春');
+      final isFall = scheduleName.contains('秋');
+
+      for (final semester in data.semesters) {
+        if (semester.name.contains(academicYear)) {
+          if (isSpring && semester.name.contains('春')) return semester;
+          if (isFall && semester.name.contains('秋')) return semester;
+          if (!isSpring && !isFall) return semester;
+        }
+      }
+      return null;
+    } catch (e) {
+      debugPrint(
+        'AcademicCalendarService: failed to find matching semester: $e',
+      );
+      return null;
+    }
+  }
+
   CalendarExportPayload genExportPayload(AcademicCalendarSemester semester) {
     final events = <CalendarEventPayload>[];
     for (final event in semester.events) {

--- a/lib/widgets/course/course_grid.dart
+++ b/lib/widgets/course/course_grid.dart
@@ -45,6 +45,18 @@ class _CourseGridState extends State<CourseGrid> {
   int? _selectedEmptySection;
   final appConfig = getIt<AppConfigProvider>();
 
+  /// build 里读到的所有 AppConfig 字段。提成字段避免每帧新建 merge 导致
+  /// ListenableBuilder 反复解绑重绑订阅。
+  late final Listenable _configListenable = Listenable.merge([
+    appConfig.showCourseGrid,
+    appConfig.courseRowHeight,
+    appConfig.showWeekend,
+    appConfig.showNonCurrentWeekCourses,
+    // build 里读了 backgroundImagePath（hasBackground），必须一并订阅，
+    // 否则设置/清除背景图后网格样式不会刷新。
+    appConfig.backgroundImagePath,
+  ]);
+
   static const double _sectionWidth = 35;
 
   void _handleEmptyTap(int day, int section) {
@@ -75,12 +87,7 @@ class _CourseGridState extends State<CourseGrid> {
     final sections = widget.config.sectionsPerDay;
 
     return ListenableBuilder(
-      listenable: Listenable.merge([
-        appConfig.showCourseGrid,
-        appConfig.courseRowHeight,
-        appConfig.showWeekend,
-        appConfig.showNonCurrentWeekCourses,
-      ]),
+      listenable: _configListenable,
       builder: (context, _) {
         final showWeekend =
             widget.showWeekendOverride ?? appConfig.showWeekend.value;


### PR DESCRIPTION
### 主要变更

#### 放假页显示逻辑重构
- 新增 `_computeShowVacationPage()`：当前学期已结束 **且** 下学期还未开始时才显示放假页
- `PageView.itemCount` 根据上述条件动态决定是否包含放假页
- 所有进入放假页的入口（`_navigateToVacation`、`_onPageChanged`、`_syncToCurrentWeek`）统一受其保护
- 已结束且无下学期的课表不再有放假页，避免「距离上课 -140天」等无意义内容

#### 切换课表行为修复
- 切换课表时 `_onScheduleConfigChanged` 不再手动调 `updateCurrentWeek`，避免 `_loadData` 随后覆写导致 `_onCurrentWeekChanged` 重复触发覆盖页面位置
- 切换后自动重评估：两个学期中间 → 进入放假页；进行中 → 定位当前周；已结束 → 最后教学周
- `_onCurrentWeekChanged` 守卫从 `config.getCurrentWeek() > totalWeeks` 改用 `_isViewingVacation` 标志，更精确匹配 UI 状态

#### 导入体验改进
- 导入课表时自动从校历匹配学期开始日期（`semesterStartDate`）
- 移除重复的自动设置弹窗

#### 其他
- 左上角日期固定显示今天，不再随周滑动变化
- 移除死代码（`allowVacation` 参数、重复的 `_checkAndPromptNextSemester` 调用）