### PR TITLE
refactor(course page): 引入页面级 CoursePageController，移除全局 currentWeek

### DIFF
--- a/lib/pages/course/course_page.dart
+++ b/lib/pages/course/course_page.dart
@@ -6,6 +6,7 @@ import 'package:bugaoshan/injection/injector.dart';
 import 'package:bugaoshan/l10n/app_localizations.dart';
 import 'package:bugaoshan/models/course.dart';
 import 'package:bugaoshan/pages/course/course_edit_page.dart';
+import 'package:bugaoshan/pages/course/course_page_controller.dart';
 import 'package:bugaoshan/pages/course/import_schedule_page.dart';
 import 'package:bugaoshan/pages/course/schedule_management_page.dart';
 import 'package:bugaoshan/services/api/academic_calendar_service.dart';
@@ -40,209 +41,72 @@ class CoursePage extends StatefulWidget {
 class _CoursePageState extends State<CoursePage> with WidgetsBindingObserver {
   final courseProvider = getIt<CourseProvider>();
   final appConfig = getIt<AppConfigProvider>();
-  late PageController _pageController;
-  late int _visibleWeek;
-  bool _isViewingVacation = false;
+
+  /// 页面级控制器（demo 模式为 null）。
+  /// 不进 GetIt —— demo/真实两个 CoursePage 实例共存时单例语义错误。
+  CoursePageController? _controller;
+
   bool _promptedNextSemester = false;
 
-  /// [_computeShowVacationPage] 的缓存值。该判定只取决于课表配置和全部课表列表
-  /// （外加「今天」），没必要每帧重算 —— 它会分配 DateTime 并遍历 allSchedules，
-  /// 而 PageView 的 itemCount 依赖它。
-  bool _showVacationPage = false;
-
-  /// 顶部栏只关心当前周和课表配置；课程列表变化不影响它。
-  late final Listenable _topBarListenable = Listenable.merge([
-    courseProvider.currentWeek,
-    courseProvider.scheduleConfig,
-  ]);
-
-  /// 课表网格不读 currentWeek —— 翻页由 [_pageController] 驱动，
-  /// 把 currentWeek 混进来会导致每次滑动都重建整个 PageView。
-  late final Listenable _gridListenable = Listenable.merge([
-    courseProvider.courses,
-    courseProvider.scheduleConfig,
-    courseProvider.allSchedules,
-  ]);
+  /// 课表网格的 listenable。demo 模式下只需 scheduleConfig；非 demo 模式下
+  /// 还需 courses、allSchedules 和 controller.showVacationPage（pageCount 变化时
+  /// PageView 需重建）。grid 不监听 controller 本身 —— 翻页由 PageController
+  /// 直接驱动，不需要整 PageView 重建。
+  late final Listenable _gridListenable;
 
   late final Listenable _bgImageListenable = Listenable.merge([
     appConfig.backgroundImagePath,
     appConfig.backgroundImageOpacity,
   ]);
 
-  /// 判断当前课表是否应该显示放假页。
-  /// 规则：当前学期已结束，且下学期还未开始（今天在两个学期之间）时显示。
-  bool _computeShowVacationPage() {
-    final config = courseProvider.scheduleConfig.value;
-    final now = DateTime.now();
-    final today = DateTime(now.year, now.month, now.day);
-
-    // 学期未结束 → 不显示
-    if (!today.isAfter(config.semesterEndDate)) return false;
-
-    // 找下学期（当前学期结束后最早开始的课表）
-    ScheduleConfig? next;
-    for (final s in courseProvider.allSchedules.value) {
-      if (s.id != config.id &&
-          s.semesterStartDate.isAfter(config.semesterEndDate)) {
-        if (next == null ||
-            s.semesterStartDate.isBefore(next.semesterStartDate)) {
-          next = s;
-        }
-      }
-    }
-    if (next == null) return false;
-
-    // 今天在下学期开始前
-    return today.isBefore(next.semesterStartDate);
-  }
-
-  /// 重算放假页可用性；仅在结果变化时 setState。
-  /// 只允许在非 build 阶段调用（监听器回调、手势、postFrame）。
-  void _updateVacationAvailability() {
-    final next = _computeShowVacationPage();
-    if (next == _showVacationPage) return;
-    setState(() {
-      _showVacationPage = next;
-      // 放假页在被查看时消失（如跨夜后下学期开始）：itemCount 缩水，
-      // 控制器会停在越界索引上，退回末周兜底。
-      if (!next && _isViewingVacation) {
-        _isViewingVacation = false;
-      }
-    });
-    if (!next && _pageController.hasClients) {
-      final maxPage = courseProvider.scheduleConfig.value.totalWeeks - 1;
-      if ((_pageController.page ?? 0).round() > maxPage) {
-        _pageController.jumpToPage(maxPage);
-      }
-    }
-  }
-
   @override
   void initState() {
     super.initState();
+
+    if (widget.demoMode) {
+      // 预览模式：固定第 1 周，不建控制器、不挂监听、不注册 observer、不弹提示
+      // —— 修 demoMode 干扰真实课表页的 bug（以前 postFrame 写全局 currentWeek
+      // 把 IndexedStack 里的真实页顶回当前周，甚至弹「切换学期」对话框）。
+      _gridListenable = courseProvider.scheduleConfig;
+      return;
+    }
+
     WidgetsBinding.instance.addObserver(this);
-    final config = courseProvider.scheduleConfig.value;
-    final actualWeek = config.getCurrentWeek();
-    final totalWeeks = config.totalWeeks;
-    _showVacationPage = _computeShowVacationPage();
-    _isViewingVacation = _showVacationPage && actualWeek > totalWeeks;
-    _visibleWeek = _isViewingVacation
-        ? totalWeeks
-        : courseProvider.currentWeek.value;
-    _pageController = PageController(
-      initialPage: _isViewingVacation ? totalWeeks : _visibleWeek - 1,
+    _controller = CoursePageController(
+      scheduleConfig: courseProvider.scheduleConfig,
+      allSchedules: courseProvider.allSchedules,
+      animationDuration: appConfig.cardSizeAnimationDuration,
     );
-    courseProvider.currentWeek.addListener(_onCurrentWeekChanged);
-    courseProvider.scheduleConfig.addListener(_onScheduleConfigChanged);
-    // allSchedules 可以脱离 scheduleConfig 单独变化（新增/删除课表），
-    // 而放假页判定依赖它，所以单独监听。
-    courseProvider.allSchedules.addListener(_updateVacationAvailability);
+    _gridListenable = Listenable.merge([
+      courseProvider.courses,
+      courseProvider.scheduleConfig,
+      courseProvider.allSchedules,
+      _controller!.showVacationPage,
+    ]);
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
-      _syncToCurrentWeek();
+      _checkAndPromptNextSemester();
     });
   }
 
   @override
   void dispose() {
-    WidgetsBinding.instance.removeObserver(this);
-    courseProvider.currentWeek.removeListener(_onCurrentWeekChanged);
-    courseProvider.scheduleConfig.removeListener(_onScheduleConfigChanged);
-    courseProvider.allSchedules.removeListener(_updateVacationAvailability);
-    _pageController.dispose();
+    if (!widget.demoMode) {
+      WidgetsBinding.instance.removeObserver(this);
+      _controller?.dispose();
+    }
     super.dispose();
   }
 
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
     if (state != AppLifecycleState.resumed) return;
-    // 跨天或长时间后台后回前台：刷新依赖「今天」的派生状态
-    // （顶栏日期、放假页可用性、假期徽章）。
-    // 刻意不调 _syncToCurrentWeek —— 回前台不自动跳周。
-    _updateVacationAvailability();
+    // 跨天或长时间后台后回前台：刷新放假页可用性 + 顶栏徽章。
+    // 刻意不跳周 —— 回前台不自动跳当前周。
+    // 裸 setState 必须保留：CourseGrid 的今天列高亮/节假日角标读 DateTime.now()，
+    // 删了会破坏跨夜刷新。
+    _controller?.refreshToday();
     setState(() {});
-  }
-
-  void _onCurrentWeekChanged() {
-    if (_isViewingVacation) {
-      // 放假页面时不需要响应 currentWeek 变化，避免覆盖放假导航
-      return;
-    }
-    final targetPage = courseProvider.currentWeek.value - 1;
-    if (_pageController.hasClients &&
-        _pageController.page?.round() != targetPage) {
-      _pageController.animateToPage(
-        targetPage,
-        duration: appConfig.cardSizeAnimationDuration.value,
-        curve: AppCurves.quick,
-      );
-    } else if (_visibleWeek != courseProvider.currentWeek.value) {
-      setState(() {
-        _visibleWeek = courseProvider.currentWeek.value;
-      });
-    }
-  }
-
-  void _onScheduleConfigChanged() {
-    // 切换课表或导入时绝不进入放假页面。
-    // 注意：不手动调 updateCurrentWeek，由 _loadData 随后设置，避免二次触发
-    // _onCurrentWeekChanged 覆盖页面位置。
-    final config = courseProvider.scheduleConfig.value;
-    final totalWeeks = config.totalWeeks;
-    _showVacationPage = _computeShowVacationPage();
-
-    // 直接落到 _syncToCurrentWeek 稍后要去的那一周。以前先 jumpToPage 到末周，
-    // 紧接着同一个 microtask 里 _onCurrentWeekChanged 又 animateToPage 回当前周 ——
-    // 跳的那帧画不出来，但动画起点已是末周，于是会横扫中间十几周并逐页 build。
-    final targetWeek = config.getCurrentWeek().clamp(1, totalWeeks);
-
-    _isViewingVacation = false;
-    _visibleWeek = targetWeek;
-    if (_pageController.hasClients) {
-      _pageController.jumpToPage(targetWeek - 1);
-    }
-    setState(() {});
-    _syncToCurrentWeek();
-  }
-
-  void _syncToCurrentWeek() {
-    _updateVacationAvailability();
-    final config = courseProvider.scheduleConfig.value;
-    final actualWeek = config.getCurrentWeek();
-    final totalWeeks = config.totalWeeks;
-    if (actualWeek > totalWeeks) {
-      _navigateToVacation();
-    } else {
-      if (_isViewingVacation) {
-        setState(() => _isViewingVacation = false);
-      }
-      courseProvider.updateCurrentWeek(actualWeek);
-    }
-    _checkAndPromptNextSemester();
-  }
-
-  void _navigateToVacation() {
-    if (!_showVacationPage) return;
-    final totalWeeks = courseProvider.scheduleConfig.value.totalWeeks;
-    if (!_isViewingVacation && _pageController.hasClients) {
-      _isViewingVacation = true;
-      _pageController.animateToPage(
-        totalWeeks,
-        duration: appConfig.cardSizeAnimationDuration.value,
-        curve: AppCurves.quick,
-      );
-      setState(() {});
-    } else if (_isViewingVacation &&
-        _pageController.hasClients &&
-        _pageController.page?.round() != totalWeeks) {
-      // 切换课表后仍在假期，但总周数不同，需要更新 PageController 位置
-      _pageController.animateToPage(
-        totalWeeks,
-        duration: appConfig.cardSizeAnimationDuration.value,
-        curve: AppCurves.quick,
-      );
-      setState(() {});
-    }
   }
 
   @override
@@ -251,19 +115,18 @@ class _CoursePageState extends State<CoursePage> with WidgetsBindingObserver {
       children: [
         if (!widget.demoMode)
           ListenableBuilder(
-            listenable: _topBarListenable,
+            listenable: _controller!,
             builder: (context, _) => _TopBar(
-              week: courseProvider.currentWeek.value,
-              totalWeeks: courseProvider.scheduleConfig.value.totalWeeks,
-              visibleWeek: _visibleWeek,
-              isViewingVacation: _isViewingVacation,
-              hasVacationPage: _showVacationPage,
-              onPreviousWeek: () => _isViewingVacation
-                  ? _changeWeek(courseProvider.scheduleConfig.value.totalWeeks)
-                  : _changeWeek(courseProvider.currentWeek.value - 1),
-              onNextWeek: () =>
-                  _changeWeek(courseProvider.currentWeek.value + 1),
-              onGoToCurrentWeek: _goToCurrentWeek,
+              visibleWeek: _controller!.visibleWeek,
+              totalWeeks: _controller!.totalWeeks,
+              actualWeek: _controller!.actualWeek,
+              isViewingVacation: _controller!.isViewingVacation,
+              isTodayOnVacation: _controller!.isTodayOnVacation,
+              canGoPrevious: _controller!.canGoPrevious,
+              canGoNext: _controller!.canGoNext,
+              onPreviousWeek: _controller!.goToPreviousPage,
+              onNextWeek: _controller!.goToNextPage,
+              onGoToCurrentWeek: _controller!.goToToday,
               onImport: _onImport,
               onExport: _onExport,
               onAddCourse: _onAddCourse,
@@ -334,7 +197,6 @@ class _CoursePageState extends State<CoursePage> with WidgetsBindingObserver {
     final allCourses = widget.demoMode
         ? _kDemoCourses
         : courseProvider.courses.value;
-    final totalWeeks = config.totalWeeks;
 
     if (widget.demoMode) {
       // 预览模式：固定显示第 1 周，不滑动、不跟随当前课表周数
@@ -342,16 +204,20 @@ class _CoursePageState extends State<CoursePage> with WidgetsBindingObserver {
         courses: allCourses,
         config: config,
         displayWeek: 1,
-        totalWeeks: totalWeeks,
+        totalWeeks: config.totalWeeks,
       );
     }
 
+    final controller = _controller!;
+    final totalWeeks = controller.totalWeeks;
+    // build 内每次重读 controller.pageController —— detach 期间可能被换实例，
+    // 缓存到局部之外会导致 _SwipePageView 持有失效的旧控制器。
     return _SwipePageView(
-      controller: _pageController,
-      itemCount: _showVacationPage ? totalWeeks + 1 : totalWeeks,
-      onPageChanged: _onPageChanged,
+      controller: controller.pageController,
+      itemCount: controller.pageCount,
+      onPageChanged: controller.onPageSettled,
       itemBuilder: (context, index) {
-        if (_showVacationPage && index >= totalWeeks) {
+        if (controller.showVacationPage.value && index >= totalWeeks) {
           return _VacationView(
             scheduleConfig: config,
             allSchedules: courseProvider.allSchedules.value,
@@ -387,56 +253,6 @@ class _CoursePageState extends State<CoursePage> with WidgetsBindingObserver {
   ) {
     if (!isLoading) return const SizedBox.shrink();
     return const Center(child: CircularProgressIndicator());
-  }
-
-  void _onPageChanged(int index) {
-    final totalWeeks = courseProvider.scheduleConfig.value.totalWeeks;
-    if (index >= totalWeeks) {
-      if (!_isViewingVacation) {
-        setState(() => _isViewingVacation = true);
-      }
-      return;
-    }
-    if (_isViewingVacation) {
-      setState(() => _isViewingVacation = false);
-    }
-    final displayWeek = index + 1;
-    if (_visibleWeek != displayWeek) {
-      setState(() {
-        _visibleWeek = displayWeek;
-      });
-    }
-    courseProvider.updateCurrentWeek(displayWeek);
-  }
-
-  void _changeWeek(int newWeek) {
-    final totalWeeks = courseProvider.scheduleConfig.value.totalWeeks;
-    if (newWeek > totalWeeks) {
-      _navigateToVacation();
-      return;
-    }
-    if (newWeek < 1) newWeek = 1;
-    if (_isViewingVacation) {
-      setState(() => _isViewingVacation = false);
-    }
-    courseProvider.updateCurrentWeek(newWeek);
-    // currentWeek 本来就等于 newWeek 时 ValueNotifier 不会通知（int 相等），
-    // _onCurrentWeekChanged 不触发，页面停在原地 —— 典型场景：放假期间
-    // currentWeek 已被 clamp 成 totalWeeks，从放假页点左箭头回末周。
-    // 这里显式驱动 PageController 兜底。
-    final targetPage = newWeek - 1;
-    if (_pageController.hasClients &&
-        _pageController.page?.round() != targetPage) {
-      _pageController.animateToPage(
-        targetPage,
-        duration: appConfig.cardSizeAnimationDuration.value,
-        curve: AppCurves.quick,
-      );
-    }
-  }
-
-  void _goToCurrentWeek() {
-    _syncToCurrentWeek();
   }
 
   Future<void> _checkAndPromptNextSemester() async {

--- a/lib/pages/course/course_page_controller.dart
+++ b/lib/pages/course/course_page_controller.dart
@@ -1,0 +1,227 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+
+import 'package:bugaoshan/models/course.dart';
+import 'package:bugaoshan/utils/app_shapes.dart';
+
+/// 课表页的页面级控制器（不进 GetIt —— 项目约定允许页面级非 DI 类；
+/// 且 demo/真实两个 CoursePage 实例共存，单例语义错误）。
+///
+/// 真源模型（写进类注释防止后人误读）：
+/// 控制器持有 [int _pageIndex]（**已结算页码**，唯一权威）；
+/// [PageController] 只是执行器（`.page` 在 detach 时会 assert、动画中是 double，
+/// 不能当真源）；`PageView.onPageChanged → [onPageSettled]` 是反馈通道。
+///
+/// [visibleWeek] / [isViewingVacation] 全部从 `_pageIndex` 派生，不存在独立字段
+/// 间的不一致中间态。移动判定用**物理位置**（`pageController.page?.round() != target`）
+/// 而非缓存 int 比较 —— 根治「同值不通知」bug 类。
+class CoursePageController extends ChangeNotifier {
+  CoursePageController({
+    required ValueListenable<ScheduleConfig> scheduleConfig,
+    required ValueListenable<List<ScheduleConfig>> allSchedules,
+    required ValueListenable<Duration> animationDuration,
+  }) : _scheduleConfig = scheduleConfig,
+       _allSchedules = allSchedules,
+       _animationDuration = animationDuration,
+       showVacationPage = ValueNotifier<bool>(false) {
+    showVacationPage.value = _computeShowVacationPage();
+    _pageIndex = _indexForToday();
+    _pageController = PageController(initialPage: _pageIndex);
+    _scheduleConfig.addListener(_onScheduleConfigChanged);
+    _allSchedules.addListener(_onAllSchedulesChanged);
+  }
+
+  final ValueListenable<ScheduleConfig> _scheduleConfig;
+  final ValueListenable<List<ScheduleConfig>> _allSchedules;
+  final ValueListenable<Duration> _animationDuration;
+
+  /// 放假页可用性。grid 只在结构变化（pageCount 增减）时需要重建，所以单独暴露
+  /// 而非塞进 [notifyListeners] —— 否则每次翻页都会重建整个 PageView。
+  final ValueNotifier<bool> showVacationPage;
+
+  late PageController _pageController;
+
+  /// 已结算页码，唯一权威。
+  int _pageIndex = 0;
+
+  // ---- Getters ----
+
+  /// PageController（执行器）。detach 期间可能被换实例，build 每次重读，禁止缓存到
+  /// State 字段 —— 否则 detach 重建机制会失效。
+  PageController get pageController => _pageController;
+
+  int get pageIndex => _pageIndex;
+
+  /// 用户当前看到的周数（1-based）。放假页时返回末周。
+  int get visibleWeek => _pageIndex.clamp(0, totalWeeks - 1) + 1;
+
+  /// 是否正在看放假页。
+  bool get isViewingVacation =>
+      showVacationPage.value && _pageIndex >= totalWeeks;
+
+  bool get canGoPrevious => _pageIndex > 0;
+
+  bool get canGoNext => _pageIndex < pageCount - 1;
+
+  int get pageCount => showVacationPage.value ? totalWeeks + 1 : totalWeeks;
+
+  ScheduleConfig get config => _scheduleConfig.value;
+
+  /// 防止 [ScheduleConfig.totalWeeks] 为 0 时 clamp(1, 0) 抛 ArgumentError。
+  int get totalWeeks => _scheduleConfig.value.totalWeeks < 1
+      ? 1
+      : _scheduleConfig.value.totalWeeks;
+
+  /// 未 clamp 的日历周（基于 [ScheduleConfig.getCurrentWeek]）。
+  int get actualWeek => _scheduleConfig.value.getCurrentWeek();
+
+  /// 顶栏徽章：今天是否在假期中（学期已结束且下学期未开始）。
+  bool get isTodayOnVacation =>
+      showVacationPage.value && actualWeek > totalWeeks;
+
+  // ---- Public API ----
+
+  /// 跳到指定周（1-based）。> totalWeeks 且有放假页 → 放假页。
+  void goToWeek(int week) {
+    final tw = totalWeeks;
+    final int target;
+    if (week > tw && showVacationPage.value) {
+      target = tw; // vacation page index
+    } else {
+      target = week.clamp(1, tw) - 1;
+    }
+    _moveTo(target, animate: true);
+  }
+
+  /// 一行 _moveTo(_pageIndex±1)，取代 _changeWeek/_navigateToVacation 分支团。
+  void goToPreviousPage() => _moveTo(_pageIndex - 1, animate: true);
+
+  void goToNextPage() => _moveTo(_pageIndex + 1, animate: true);
+
+  /// 顶栏点日期：refresh + _moveTo(_indexForToday(), animate)。
+  /// 注意：不在此处触发 _checkAndPromptNextSemester —— 那是 State 的职责，
+  /// 仅在 initState postFrame 调一次。
+  void goToToday() {
+    refreshVacationAvailability();
+    _moveTo(_indexForToday(), animate: true);
+  }
+
+  /// 重算放假页可用性；关掉放假页时若正在看 → 退回末周。
+  void refreshVacationAvailability() {
+    final next = _computeShowVacationPage();
+    if (next == showVacationPage.value) return;
+    final wasViewingVacation = isViewingVacation;
+    showVacationPage.value = next;
+    if (!next && wasViewingVacation) {
+      _moveTo(totalWeeks - 1, animate: false);
+    } else {
+      notifyListeners();
+    }
+  }
+
+  /// 回前台：刷新可用性 + notify，绝不跳周。
+  void refreshToday() {
+    refreshVacationAvailability();
+    notifyListeners();
+  }
+
+  /// PageView.onPageChanged 反馈通道。== _pageIndex 时静默吸收
+  /// （自己发起的动画回灌）。越界 index 会 clamp 到 [0, pageCount-1]。
+  void onPageSettled(int index) {
+    final clamped = index.clamp(0, pageCount - 1);
+    if (clamped == _pageIndex) return;
+    _pageIndex = clamped;
+    notifyListeners();
+  }
+
+  // ---- Private ----
+
+  /// 构造与切表共用的「今天对应页」规则：
+  /// 假期且有放假页 → totalWeeks；否则 actualWeek.clamp(1, totalWeeks) - 1。
+  /// 消灭现在「先跳末周再动画进放假页」的两段式行为。
+  int _indexForToday() {
+    final aw = actualWeek;
+    final tw = totalWeeks;
+    if (showVacationPage.value && aw > tw) {
+      return tw; // vacation page index
+    }
+    return aw.clamp(1, tw) - 1;
+  }
+
+  /// 核心移动逻辑：clamp → 更新 _pageIndex → 同步 PageController → notify on change。
+  /// 移动判定用物理位置（pageController.page?.round() != target）而非缓存 int 比较，
+  /// 根治「同值不通知」bug。
+  void _moveTo(int target, {required bool animate}) {
+    final clamped = target.clamp(0, pageCount - 1);
+    if (clamped == _pageIndex) return;
+    _pageIndex = clamped;
+    if (_pageController.hasClients) {
+      final physicalPage = _pageController.page?.round();
+      if (physicalPage != clamped) {
+        if (animate) {
+          _pageController.animateToPage(
+            clamped,
+            duration: _animationDuration.value,
+            curve: AppCurves.quick,
+          );
+        } else {
+          _pageController.jumpToPage(clamped);
+        }
+      }
+    } else {
+      // !hasClients：PageView 未挂载，jumpToPage 会被静默丢弃（「未挂载跳页丢失」bug）。
+      // 换新 PageController(initialPage: target)，旧实例无 clients 可立即 dispose
+      // （initialPage 构造后不可变，所以必须换实例）。
+      _pageController.dispose();
+      _pageController = PageController(initialPage: clamped);
+    }
+    notifyListeners();
+  }
+
+  /// 切换课表/导入时：刷新放假页 → 落到新当前周 → 无条件 notify
+  /// （totalWeeks/actualWeek 变了顶栏也要重画）。
+  void _onScheduleConfigChanged() {
+    showVacationPage.value = _computeShowVacationPage();
+    _moveTo(_indexForToday(), animate: false);
+    notifyListeners();
+  }
+
+  /// allSchedules 单独变化（新增/删除非当前课表）：仅刷新放假页可用性，
+  /// 不自动跳周。
+  void _onAllSchedulesChanged() => refreshVacationAvailability();
+
+  /// 从 course_page.dart 原样搬入：当前学期已结束且下学期未开始 → 显示放假页。
+  bool _computeShowVacationPage() {
+    final config = _scheduleConfig.value;
+    final now = DateTime.now();
+    final today = DateTime(now.year, now.month, now.day);
+
+    // 学期未结束 → 不显示
+    if (!today.isAfter(config.semesterEndDate)) return false;
+
+    // 找下学期（当前学期结束后最早开始的课表）
+    ScheduleConfig? next;
+    for (final s in _allSchedules.value) {
+      if (s.id != config.id &&
+          s.semesterStartDate.isAfter(config.semesterEndDate)) {
+        if (next == null ||
+            s.semesterStartDate.isBefore(next.semesterStartDate)) {
+          next = s;
+        }
+      }
+    }
+    if (next == null) return false;
+
+    // 今天在下学期开始前
+    return today.isBefore(next.semesterStartDate);
+  }
+
+  @override
+  void dispose() {
+    _scheduleConfig.removeListener(_onScheduleConfigChanged);
+    _allSchedules.removeListener(_onAllSchedulesChanged);
+    showVacationPage.dispose();
+    _pageController.dispose();
+    super.dispose();
+  }
+}

--- a/lib/pages/course/course_page_controller.dart
+++ b/lib/pages/course/course_page_controller.dart
@@ -44,6 +44,14 @@ class CoursePageController extends ChangeNotifier {
   /// 已结算页码，唯一权威。
   int _pageIndex = 0;
 
+  /// `jumpToPage` 会同步触发 `onPageChanged`。若 PageView 尚未重建到新
+  /// `pageCount`（`showVacationPage` 刚翻面），目标页会被旧 PageView clamp，
+  /// 回灌的 `onPageChanged` 会把 `_pageIndex` 拉回。此期间抑制反馈通道。
+  bool _suppressOnPageSettled = false;
+
+  /// `dispose` 后 `addPostFrameCallback` 仍可能触发，需短路。
+  bool _disposed = false;
+
   // ---- Getters ----
 
   /// PageController（执行器）。detach 期间可能被换实例，build 每次重读，禁止缓存到
@@ -128,6 +136,7 @@ class CoursePageController extends ChangeNotifier {
   /// PageView.onPageChanged 反馈通道。== _pageIndex 时静默吸收
   /// （自己发起的动画回灌）。越界 index 会 clamp 到 [0, pageCount-1]。
   void onPageSettled(int index) {
+    if (_suppressOnPageSettled) return;
     final clamped = index.clamp(0, pageCount - 1);
     if (clamped == _pageIndex) return;
     _pageIndex = clamped;
@@ -165,7 +174,12 @@ class CoursePageController extends ChangeNotifier {
             curve: AppCurves.quick,
           );
         } else {
+          // jumpToPage 同步触发 onPageChanged，期间抑制反馈通道防止 clamp 回灌。
+          // animateToPage 是异步的（动画结束后才回灌），不抑制 —— 否则用户
+          // 滑动/动画落位后的反馈会被吞掉。
+          _suppressOnPageSettled = true;
           _pageController.jumpToPage(clamped);
+          _suppressOnPageSettled = false;
         }
       }
     } else {
@@ -180,10 +194,27 @@ class CoursePageController extends ChangeNotifier {
 
   /// 切换课表/导入时：刷新放假页 → 落到新当前周 → 无条件 notify
   /// （totalWeeks/actualWeek 变了顶栏也要重画）。
+  ///
+  /// `showVacationPage` 翻面会改变 `pageCount`，但 PageView 要到下一帧才重建到
+  /// 新 itemCount。`_moveTo` 里的 `jumpToPage` 可能在旧 PageView 上被 clamp
+  /// （抑制了顶栏回灌，但 PageController 物理位置仍停在 clamp 后的页）。
+  /// 下一帧再同步一次，确保网格也跳到目标页。
   void _onScheduleConfigChanged() {
     showVacationPage.value = _computeShowVacationPage();
     _moveTo(_indexForToday(), animate: false);
+    WidgetsBinding.instance.addPostFrameCallback(_resyncPageController);
     notifyListeners();
+  }
+
+  void _resyncPageController(Duration _) {
+    if (_disposed) return;
+    if (!_pageController.hasClients) return;
+    final physicalPage = _pageController.page?.round();
+    if (physicalPage != _pageIndex) {
+      _suppressOnPageSettled = true;
+      _pageController.jumpToPage(_pageIndex);
+      _suppressOnPageSettled = false;
+    }
   }
 
   /// allSchedules 单独变化（新增/删除非当前课表）：仅刷新放假页可用性，
@@ -218,6 +249,7 @@ class CoursePageController extends ChangeNotifier {
 
   @override
   void dispose() {
+    _disposed = true;
     _scheduleConfig.removeListener(_onScheduleConfigChanged);
     _allSchedules.removeListener(_onAllSchedulesChanged);
     showVacationPage.dispose();

--- a/lib/pages/course/course_page_top_bar.dart
+++ b/lib/pages/course/course_page_top_bar.dart
@@ -1,14 +1,14 @@
 part of 'course_page.dart';
 
 class _TopBar extends StatelessWidget {
-  final int week;
-  final int totalWeeks;
   final int visibleWeek;
+  final int totalWeeks;
+  final int actualWeek;
   final bool isViewingVacation;
+  final bool isTodayOnVacation;
+  final bool canGoPrevious;
+  final bool canGoNext;
 
-  /// 放假页是否存在（与 _CoursePageState._showVacationPage 同源）。
-  /// 徽章和右箭头都以它为准，避免「显示假期中却无放假页可翻」的脱节。
-  final bool hasVacationPage;
   final VoidCallback onPreviousWeek;
   final VoidCallback? onNextWeek;
   final VoidCallback onGoToCurrentWeek;
@@ -17,11 +17,13 @@ class _TopBar extends StatelessWidget {
   final VoidCallback onAddCourse;
 
   const _TopBar({
-    required this.week,
-    required this.totalWeeks,
     required this.visibleWeek,
+    required this.totalWeeks,
+    required this.actualWeek,
     this.isViewingVacation = false,
-    this.hasVacationPage = false,
+    this.isTodayOnVacation = false,
+    this.canGoPrevious = false,
+    this.canGoNext = false,
     required this.onPreviousWeek,
     required this.onNextWeek,
     required this.onGoToCurrentWeek,
@@ -33,19 +35,10 @@ class _TopBar extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
-    final config = getIt<CourseProvider>().scheduleConfig.value;
-    final actualWeek = config.getCurrentWeek();
     final isCurrentCalendarWeek = visibleWeek == actualWeek;
-    // 与放假页共用同一判定：没有放假页时不显示「假期中」徽章，
-    // 避免徽章提示假期但右箭头无处可去。
-    final isInVacation = hasVacationPage && actualWeek > config.totalWeeks;
 
     final now = DateTime.now();
     final dateStr = '${now.year}/${now.month}/${now.day}';
-    final canGoLeft = isViewingVacation || week > 1;
-    // 最后一周时只有存在放假页才能继续往右翻。
-    final canGoRight =
-        !isViewingVacation && (week < totalWeeks || hasVacationPage);
 
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 2),
@@ -70,11 +63,11 @@ class _TopBar extends StatelessWidget {
                   mainAxisSize: MainAxisSize.min,
                   children: [
                     GestureDetector(
-                      onTap: canGoLeft ? onPreviousWeek : null,
+                      onTap: canGoPrevious ? onPreviousWeek : null,
                       child: Icon(
                         Icons.chevron_left,
                         size: 16,
-                        color: canGoLeft
+                        color: canGoPrevious
                             ? Theme.of(context).colorScheme.onSurface
                             : Theme.of(context).disabledColor,
                       ),
@@ -87,7 +80,7 @@ class _TopBar extends StatelessWidget {
                       child: Text(
                         isViewingVacation
                             ? l10n.onVacation
-                            : l10n.currentWeek(week),
+                            : l10n.currentWeek(visibleWeek),
                         textAlign: TextAlign.center,
                         style: Theme.of(context).textTheme.bodySmall?.copyWith(
                           fontWeight: FontWeight.w500,
@@ -97,27 +90,24 @@ class _TopBar extends StatelessWidget {
                     ),
                     const SizedBox(width: 5),
                     GestureDetector(
-                      onTap: canGoRight ? onNextWeek : null,
+                      onTap: canGoNext ? onNextWeek : null,
                       child: Icon(
                         Icons.chevron_right,
                         size: 16,
-                        color: canGoRight
+                        color: canGoNext
                             ? Theme.of(context).colorScheme.onSurface
                             : Theme.of(context).disabledColor,
                       ),
                     ),
                     const SizedBox(width: 3),
-                    if (isInVacation)
-                      _VacationBadge()
+                    if (isTodayOnVacation)
+                      const _VacationBadge()
                     else
                       _WeekBadge(
                         isCurrentCalendarWeek: isCurrentCalendarWeek,
                         // 无放假页时学期过末 actualWeek 会超过 totalWeeks，
                         // clamp 避免徽章显示越界周数。
-                        actualCurrentWeek: actualWeek.clamp(
-                          1,
-                          config.totalWeeks,
-                        ),
+                        actualCurrentWeek: actualWeek.clamp(1, totalWeeks),
                       ),
                   ],
                 ),

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -8,7 +8,6 @@ import 'package:bugaoshan/l10n/app_localizations.dart';
 import 'package:bugaoshan/models/campus_item_config.dart';
 import 'package:bugaoshan/providers/app_config_provider.dart';
 import 'package:bugaoshan/providers/app_info_provider.dart';
-import 'package:bugaoshan/providers/course_provider.dart';
 import 'package:bugaoshan/providers/scu_auth_provider.dart';
 import 'package:bugaoshan/providers/update_provider.dart';
 import 'package:bugaoshan/services/auth/auth_coordinator.dart';
@@ -25,7 +24,6 @@ class HomePage extends StatefulWidget {
 
 class _HomePageState extends State<HomePage> with WidgetsBindingObserver {
   int _currentIndex = 0;
-  final _courseProvider = getIt<CourseProvider>();
 
   @override
   void initState() {
@@ -135,7 +133,6 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver {
                           selectedIndex: _currentIndex,
                           onDestinationSelected: (index) {
                             setState(() => _currentIndex = index);
-                            _onTabSelected(visibleIds[index]);
                           },
                           labelType: NavigationRailLabelType.all,
                           destinations: visibleIds
@@ -159,7 +156,6 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver {
                           selectedIndex: _currentIndex,
                           onDestinationSelected: (index) {
                             setState(() => _currentIndex = index);
-                            _onTabSelected(visibleIds[index]);
                           },
                           destinations: visibleIds
                               .map(
@@ -227,13 +223,5 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver {
       label: config.dockLabel(l10n),
       tooltip: '',
     );
-  }
-
-  void _onTabSelected(String id) {
-    if (id == dockIdCourse) {
-      _courseProvider.updateCurrentWeek(
-        _courseProvider.scheduleConfig.value.getCurrentWeek(),
-      );
-    }
   }
 }

--- a/lib/providers/course_provider.dart
+++ b/lib/providers/course_provider.dart
@@ -18,7 +18,6 @@ class CourseProvider {
       ValueNotifier<ScheduleConfig>(_defaultConfig());
   final ValueNotifier<List<ScheduleConfig>> allSchedules =
       ValueNotifier<List<ScheduleConfig>>([]);
-  final ValueNotifier<int> currentWeek = ValueNotifier<int>(1);
   final ValueNotifier<bool> isLoading = ValueNotifier<bool>(false);
 
   /// 当前数据库中是否存在课表。UI 据此在「暂无课表」空状态和 grid 之间切换。
@@ -41,12 +40,6 @@ class CourseProvider {
       allSchedules.value = _db.getAllSchedules();
       final config = _db.getScheduleConfig();
       scheduleConfig.value = config;
-      // 无课表时 currentWeek 兜底为 1，避免占位 config 算出意外的周数
-      if (allSchedules.value.isEmpty) {
-        currentWeek.value = 1;
-      } else {
-        currentWeek.value = config.getCurrentWeek().clamp(1, config.totalWeeks);
-      }
     } catch (e) {
       debugPrint('CourseProvider: failed to load data: $e');
     } finally {
@@ -126,7 +119,6 @@ class CourseProvider {
     allSchedules.value = _db.getAllSchedules();
     if (config.id == _db.getCurrentScheduleId()) {
       scheduleConfig.value = config;
-      currentWeek.value = config.getCurrentWeek().clamp(1, config.totalWeeks);
       // 非当前课表不影响当前课程展示，也无需刷新桌面组件。
       onCoursesChanged?.call();
     }
@@ -150,11 +142,6 @@ class CourseProvider {
       (s) => s.semesterName.trim() == name.trim(),
     );
     return match.isNotEmpty ? match.first.id : null;
-  }
-
-  void updateCurrentWeek(int week) {
-    final totalWeeks = scheduleConfig.value.totalWeeks;
-    currentWeek.value = week.clamp(1, totalWeeks);
   }
 
   Future<void> clearAllData() async {

--- a/test/course_page_controller_test.dart
+++ b/test/course_page_controller_test.dart
@@ -1,0 +1,602 @@
+import 'package:bugaoshan/models/course.dart';
+import 'package:bugaoshan/pages/course/course_page_controller.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// 测试 harness：持有 controller + 注入的 ValueNotifier，便于测试外部输入。
+class _Harness {
+  _Harness({
+    required ScheduleConfig config,
+    List<ScheduleConfig> all = const [],
+  }) : scheduleConfig = ValueNotifier(config),
+       allSchedules = ValueNotifier([config, ...all]) {
+    controller = CoursePageController(
+      scheduleConfig: scheduleConfig,
+      allSchedules: allSchedules,
+      animationDuration: ValueNotifier(Duration.zero),
+    );
+  }
+
+  late final CoursePageController controller;
+  final ValueNotifier<ScheduleConfig> scheduleConfig;
+  final ValueNotifier<List<ScheduleConfig>> allSchedules;
+}
+
+/// 创建一个「N 周前开学」的课表。注意：`ScheduleConfig.getCurrentWeek()` 会返回
+/// `(days/7).floor() + 1`，所以 `weeksAgo: N` 对应 actualWeek = N + 1
+/// （同 course_provider_test.dart 的 _weeksAgo 惯例，不注入时钟）。
+ScheduleConfig _schedule({
+  required String id,
+  required String name,
+  required int weeksAgo,
+  int totalWeeks = 20,
+}) {
+  return ScheduleConfig(
+    id: id,
+    semesterName: name,
+    semesterStartDate: _weeksAgo(weeksAgo),
+    totalWeeks: totalWeeks,
+  );
+}
+
+/// 创建一个「N 周后才开学」的课表。actualWeek = 1（getCurrentWeek 在开学前返回 1）。
+ScheduleConfig _scheduleAhead({
+  required String id,
+  required String name,
+  required int weeksAhead,
+  int totalWeeks = 20,
+}) {
+  return ScheduleConfig(
+    id: id,
+    semesterName: name,
+    semesterStartDate: _weeksAhead(weeksAhead),
+    totalWeeks: totalWeeks,
+  );
+}
+
+DateTime _weeksAgo(int weeks) {
+  final now = DateTime.now();
+  final today = DateTime(now.year, now.month, now.day);
+  return today.subtract(Duration(days: weeks * 7));
+}
+
+DateTime _weeksAhead(int weeks) {
+  final now = DateTime.now();
+  final today = DateTime(now.year, now.month, now.day);
+  return today.add(Duration(days: weeks * 7));
+}
+
+void main() {
+  // ============ 初始化 ============
+  // weeksAgo:N → actualWeek = N+1, _pageIndex = N（在 totalWeeks 范围内时）
+
+  group('initialization', () {
+    test('mid-semester: index = currentWeek - 1', () {
+      // weeksAgo:5 → actualWeek = 6, _pageIndex = 5
+      final h = _Harness(
+        config: _schedule(id: 'A', name: 'mid', weeksAgo: 5, totalWeeks: 20),
+      );
+      expect(h.controller.actualWeek, 6);
+      expect(h.controller.totalWeeks, 20);
+      expect(h.controller.pageIndex, 5);
+      expect(h.controller.visibleWeek, 6);
+      expect(h.controller.isViewingVacation, isFalse);
+      expect(h.controller.isTodayOnVacation, isFalse);
+      expect(h.controller.pageCount, 20);
+      h.controller.dispose();
+    });
+
+    test('semester ended + next sem not started: vacation page', () {
+      // weeksAgo:25 → actualWeek = 26, semesterEndDate = today - 36 days
+      final current = _schedule(
+        id: 'C',
+        name: 'ended',
+        weeksAgo: 25,
+        totalWeeks: 20,
+      );
+      final nextSem = _scheduleAhead(
+        id: 'N',
+        name: 'next',
+        weeksAhead: 1,
+        totalWeeks: 20,
+      );
+      final h = _Harness(config: current, all: [nextSem]);
+      // current ended 5 weeks ago; nextSem starts in 1 week → 放假页
+      expect(h.controller.showVacationPage.value, isTrue);
+      expect(h.controller.pageIndex, 20); // vacation page index = totalWeeks
+      expect(h.controller.isViewingVacation, isTrue);
+      expect(h.controller.isTodayOnVacation, isTrue);
+      expect(h.controller.pageCount, 21);
+      h.controller.dispose();
+    });
+
+    test('semester ended, no next sem: last week, no badge', () {
+      final current = _schedule(
+        id: 'C',
+        name: 'ended',
+        weeksAgo: 25,
+        totalWeeks: 20,
+      );
+      final h = _Harness(config: current);
+      expect(h.controller.showVacationPage.value, isFalse);
+      expect(h.controller.pageIndex, 19); // last week (clamp 26 to 20)
+      expect(h.controller.visibleWeek, 20);
+      expect(h.controller.isViewingVacation, isFalse);
+      expect(h.controller.isTodayOnVacation, isFalse);
+      expect(h.controller.pageCount, 20);
+      h.controller.dispose();
+    });
+
+    test('next sem already started: same last week, no vacation page', () {
+      final current = _schedule(
+        id: 'C',
+        name: 'ended',
+        weeksAgo: 25,
+        totalWeeks: 20,
+      );
+      // next sem started 1 week ago (after current's end) → today is not before its start
+      final nextSem = _schedule(
+        id: 'N',
+        name: 'next',
+        weeksAgo: 1,
+        totalWeeks: 20,
+      );
+      final h = _Harness(config: current, all: [nextSem]);
+      expect(h.controller.showVacationPage.value, isFalse);
+      expect(h.controller.pageIndex, 19); // clamped to last week
+      expect(h.controller.isTodayOnVacation, isFalse);
+      h.controller.dispose();
+    });
+
+    test('semester not started yet: index 0', () {
+      final config = _scheduleAhead(
+        id: 'A',
+        name: 'future',
+        weeksAhead: 1,
+        totalWeeks: 20,
+      );
+      final h = _Harness(config: config);
+      expect(
+        h.controller.actualWeek,
+        1,
+      ); // getCurrentWeek returns 1 before start
+      expect(h.controller.pageIndex, 0);
+      expect(h.controller.visibleWeek, 1);
+      h.controller.dispose();
+    });
+
+    test('empty allSchedules + placeholder config: no throw, index 0', () {
+      final placeholder = ScheduleConfig(
+        id: 'default',
+        semesterName: '默认课表',
+        semesterStartDate: _weeksAgo(0),
+        totalWeeks: 20,
+      );
+      final scheduleConfig = ValueNotifier(placeholder);
+      final allSchedules = ValueNotifier<List<ScheduleConfig>>([]);
+      final controller = CoursePageController(
+        scheduleConfig: scheduleConfig,
+        allSchedules: allSchedules,
+        animationDuration: ValueNotifier(Duration.zero),
+      );
+      expect(controller.pageIndex, 0);
+      expect(controller.pageCount, 20);
+      controller.dispose();
+    });
+
+    test('totalWeeks: 0 dirty data: no throw, pageCount 1', () {
+      // weeksAgo:5 → actualWeek = 6, totalWeeks guarded to 1
+      final config = _schedule(
+        id: 'A',
+        name: 'dirty',
+        weeksAgo: 5,
+        totalWeeks: 0,
+      );
+      final h = _Harness(config: config);
+      expect(h.controller.totalWeeks, 1); // guarded
+      expect(h.controller.pageCount, 1);
+      expect(h.controller.pageIndex, 0); // clamp(6, 1, 1) - 1 = 0
+      h.controller.dispose();
+    });
+  });
+
+  // ============ 导航 ============
+
+  group('navigation', () {
+    test('goToWeek clamps to bounds', () {
+      final h = _Harness(
+        config: _schedule(id: 'A', name: 'mid', weeksAgo: 5, totalWeeks: 20),
+      );
+      // start at index 5
+
+      h.controller.goToWeek(25);
+      expect(h.controller.pageIndex, 19); // clamp to last week
+
+      h.controller.goToWeek(0);
+      expect(h.controller.pageIndex, 0); // clamp to week 1
+
+      h.controller.goToWeek(-5);
+      expect(h.controller.pageIndex, 0);
+
+      h.controller.goToWeek(10);
+      expect(h.controller.pageIndex, 9);
+      h.controller.dispose();
+    });
+
+    test('goToWeek > totalWeeks with vacation page → vacation page', () {
+      final current = _schedule(
+        id: 'C',
+        name: 'ended',
+        weeksAgo: 25,
+        totalWeeks: 20,
+      );
+      final nextSem = _scheduleAhead(
+        id: 'N',
+        name: 'next',
+        weeksAhead: 1,
+        totalWeeks: 20,
+      );
+      final h = _Harness(config: current, all: [nextSem]);
+      // starts at vacation page (index 20)
+
+      h.controller.goToWeek(5);
+      expect(h.controller.pageIndex, 4);
+
+      h.controller.goToWeek(25); // > totalWeeks(20) + vacation available
+      expect(h.controller.pageIndex, 20); // vacation page
+      expect(h.controller.isViewingVacation, isTrue);
+      h.controller.dispose();
+    });
+
+    test(
+      'last week goToNextPage: with vacation → vacation; without → no-op',
+      () {
+        // With vacation page
+        final current = _schedule(
+          id: 'C',
+          name: 'ended',
+          weeksAgo: 25,
+          totalWeeks: 20,
+        );
+        final nextSem = _scheduleAhead(
+          id: 'N',
+          name: 'next',
+          weeksAhead: 1,
+          totalWeeks: 20,
+        );
+        final h1 = _Harness(config: current, all: [nextSem]);
+        h1.controller.goToWeek(20); // last week, index 19
+        expect(h1.controller.pageIndex, 19);
+        h1.controller.goToNextPage();
+        expect(h1.controller.pageIndex, 20); // vacation page
+        expect(h1.controller.isViewingVacation, isTrue);
+        h1.controller.dispose();
+
+        // Without vacation page
+        final h2 = _Harness(
+          config: _schedule(id: 'A', name: 'mid', weeksAgo: 5, totalWeeks: 20),
+        );
+        h2.controller.goToWeek(20); // last week, index 19
+        expect(h2.controller.pageIndex, 19);
+        var notifyCount = 0;
+        h2.controller.addListener(() => notifyCount++);
+        h2.controller.goToNextPage(); // no-op (no vacation, clamp to 19)
+        expect(h2.controller.pageIndex, 19);
+        expect(notifyCount, 0); // zero notify on no-op
+        h2.controller.dispose();
+      },
+    );
+
+    test(
+      'vacation page goToPreviousPage → last week, isViewingVacation flips false',
+      () {
+        final current = _schedule(
+          id: 'C',
+          name: 'ended',
+          weeksAgo: 25,
+          totalWeeks: 20,
+        );
+        final nextSem = _scheduleAhead(
+          id: 'N',
+          name: 'next',
+          weeksAhead: 1,
+          totalWeeks: 20,
+        );
+        final h = _Harness(config: current, all: [nextSem]);
+        // starts at vacation page (index 20)
+        expect(h.controller.isViewingVacation, isTrue);
+
+        h.controller.goToPreviousPage();
+        expect(h.controller.pageIndex, 19);
+        expect(h.controller.isViewingVacation, isFalse);
+        h.controller.dispose();
+      },
+    );
+
+    test('index 0 goToPreviousPage: no change and zero notify', () {
+      final config = _scheduleAhead(
+        id: 'A',
+        name: 'future',
+        weeksAhead: 1,
+        totalWeeks: 20,
+      );
+      final h = _Harness(config: config);
+      expect(h.controller.pageIndex, 0);
+
+      var notifyCount = 0;
+      h.controller.addListener(() => notifyCount++);
+      h.controller.goToPreviousPage();
+      expect(h.controller.pageIndex, 0);
+      expect(notifyCount, 0);
+      h.controller.dispose();
+    });
+
+    test('notify count: one per move, zero for no-op', () {
+      final config = _scheduleAhead(
+        id: 'A',
+        name: 'future',
+        weeksAhead: 1,
+        totalWeeks: 20,
+      );
+      final h = _Harness(config: config);
+      // start at index 0
+      var notifyCount = 0;
+      h.controller.addListener(() => notifyCount++);
+
+      h.controller.goToNextPage();
+      expect(h.controller.pageIndex, 1);
+      expect(notifyCount, 1);
+
+      h.controller.goToNextPage();
+      expect(h.controller.pageIndex, 2);
+      expect(notifyCount, 2);
+
+      // no-op at index 0: go back to 0 first
+      h.controller.goToPreviousPage();
+      expect(h.controller.pageIndex, 1);
+      expect(notifyCount, 3);
+      h.controller.goToPreviousPage();
+      expect(h.controller.pageIndex, 0);
+      expect(notifyCount, 4);
+      h.controller.goToPreviousPage(); // no-op
+      expect(h.controller.pageIndex, 0);
+      expect(notifyCount, 4); // unchanged
+      h.controller.dispose();
+    });
+
+    test(
+      'detach move: initialPage == pageIndex, PageController instance changed',
+      () {
+        // Regression for "未挂载跳页丢失" bug.
+        // weeksAgo:5 → _pageIndex = 5 (headless: PageView never attaches → !hasClients)
+        final h = _Harness(
+          config: _schedule(id: 'A', name: 'mid', weeksAgo: 5, totalWeeks: 20),
+        );
+        final oldController = h.controller.pageController;
+        expect(oldController.initialPage, 5);
+
+        h.controller.goToNextPage(); // _pageIndex 5 → 6, !hasClients → swap
+
+        expect(h.controller.pageIndex, 6);
+        expect(h.controller.pageController.initialPage, 6);
+        expect(identical(h.controller.pageController, oldController), isFalse);
+        h.controller.dispose();
+      },
+    );
+  });
+
+  // ============ 外部输入 ============
+
+  group('external input', () {
+    test('switch config → land on new current week, exit vacation state', () {
+      // weeksAgo:5 → actualWeek=6, _pageIndex=5
+      final initial = _schedule(
+        id: 'A',
+        name: 'mid',
+        weeksAgo: 5,
+        totalWeeks: 20,
+      );
+      final h = _Harness(config: initial);
+      expect(h.controller.pageIndex, 5);
+
+      // Switch to a config 10 weeks ago → actualWeek=11, _pageIndex=10
+      final newConfig = _schedule(
+        id: 'B',
+        name: 'new',
+        weeksAgo: 10,
+        totalWeeks: 20,
+      );
+      h.scheduleConfig.value = newConfig;
+
+      expect(h.controller.pageIndex, 10); // week 11
+      expect(h.controller.isViewingVacation, isFalse);
+      h.controller.dispose();
+    });
+
+    test('switch to shorter schedule → clamp to new last week', () {
+      // current: weeksAgo:5, totalWeeks:20 → _pageIndex=5
+      final current = _schedule(
+        id: 'A',
+        name: 'mid',
+        weeksAgo: 5,
+        totalWeeks: 20,
+      );
+      // shorter: weeksAgo:15, totalWeeks:10 → actualWeek=16, semesterEndDate = today - 36 days
+      final shorter = _schedule(
+        id: 'S',
+        name: 'short',
+        weeksAgo: 15,
+        totalWeeks: 10,
+      );
+      final h = _Harness(config: current, all: [shorter]);
+      expect(h.controller.pageIndex, 5);
+
+      h.scheduleConfig.value = shorter;
+      // actualWeek=16, totalWeeks=10, no vacation (current is "next" but already started)
+      // _indexForToday = 16.clamp(1,10) - 1 = 9
+      expect(h.controller.totalWeeks, 10);
+      expect(h.controller.pageIndex, 9); // clamped to new last week
+      h.controller.dispose();
+    });
+
+    test(
+      'switch to just-ended + next sem not started → land on vacation page',
+      () {
+        // weeksAgo:5 → _pageIndex=5
+        final initial = _schedule(
+          id: 'A',
+          name: 'mid',
+          weeksAgo: 5,
+          totalWeeks: 20,
+        );
+        final nextSem = _scheduleAhead(
+          id: 'N',
+          name: 'next',
+          weeksAhead: 1,
+          totalWeeks: 20,
+        );
+        final ended = _schedule(
+          id: 'E',
+          name: 'ended',
+          weeksAgo: 25,
+          totalWeeks: 20,
+        );
+        final h = _Harness(config: initial);
+        expect(h.controller.pageIndex, 5);
+
+        // Switch allSchedules + scheduleConfig together
+        h.allSchedules.value = [ended, nextSem];
+        h.scheduleConfig.value = ended;
+
+        expect(h.controller.showVacationPage.value, isTrue);
+        expect(h.controller.pageIndex, 20); // vacation page
+        expect(h.controller.isViewingVacation, isTrue);
+        h.controller.dispose();
+      },
+    );
+
+    test(
+      'push next sem schedule during vacation: showVacationPage flips true, pageCount+1, pageIndex unchanged',
+      () {
+        // weeksAgo:25 → actualWeek=26, no next sem → _pageIndex=19 (clamped last week)
+        final current = _schedule(
+          id: 'C',
+          name: 'ended',
+          weeksAgo: 25,
+          totalWeeks: 20,
+        );
+        final h = _Harness(config: current);
+        expect(h.controller.showVacationPage.value, isFalse);
+        expect(h.controller.pageIndex, 19);
+        expect(h.controller.pageCount, 20);
+
+        final nextSem = _scheduleAhead(
+          id: 'N',
+          name: 'next',
+          weeksAhead: 1,
+          totalWeeks: 20,
+        );
+        h.allSchedules.value = [current, nextSem];
+
+        expect(h.controller.showVacationPage.value, isTrue);
+        expect(h.controller.pageCount, 21); // +1
+        expect(h.controller.pageIndex, 19); // unchanged (no auto-jump)
+        h.controller.dispose();
+      },
+    );
+
+    test('remove next sem while viewing vacation: move back to last week', () {
+      final current = _schedule(
+        id: 'C',
+        name: 'ended',
+        weeksAgo: 25,
+        totalWeeks: 20,
+      );
+      final nextSem = _scheduleAhead(
+        id: 'N',
+        name: 'next',
+        weeksAhead: 1,
+        totalWeeks: 20,
+      );
+      final h = _Harness(config: current, all: [nextSem]);
+      // start at vacation page (index 20)
+      expect(h.controller.showVacationPage.value, isTrue);
+      expect(h.controller.pageIndex, 20);
+      expect(h.controller.isViewingVacation, isTrue);
+
+      h.allSchedules.value = [current]; // remove next sem
+
+      expect(h.controller.showVacationPage.value, isFalse);
+      expect(h.controller.pageIndex, 19); // moved back to last week
+      expect(h.controller.isViewingVacation, isFalse);
+      h.controller.dispose();
+    });
+
+    test('onPageSettled: same value zero notify, out-of-bounds clamp', () {
+      // weeksAgo:5 → _pageIndex=5
+      final h = _Harness(
+        config: _schedule(id: 'A', name: 'mid', weeksAgo: 5, totalWeeks: 20),
+      );
+      var notifyCount = 0;
+      h.controller.addListener(() => notifyCount++);
+
+      h.controller.onPageSettled(5); // same value
+      expect(h.controller.pageIndex, 5);
+      expect(notifyCount, 0);
+
+      h.controller.onPageSettled(7); // different
+      expect(h.controller.pageIndex, 7);
+      expect(notifyCount, 1);
+
+      h.controller.onPageSettled(7); // same again
+      expect(notifyCount, 1);
+
+      h.controller.onPageSettled(100); // out of bounds → clamp to last page
+      expect(h.controller.pageIndex, 19);
+      expect(notifyCount, 2);
+      h.controller.dispose();
+    });
+
+    test('refreshToday never changes pageIndex', () {
+      // weeksAgo:5 → _pageIndex=5
+      final h = _Harness(
+        config: _schedule(id: 'A', name: 'mid', weeksAgo: 5, totalWeeks: 20),
+      );
+      h.controller.goToPreviousPage(); // 5 → 4
+      expect(h.controller.pageIndex, 4);
+
+      h.controller.refreshToday();
+      expect(h.controller.pageIndex, 4); // unchanged
+      h.controller.dispose();
+    });
+
+    test('after dispose, external notifier change does not throw', () {
+      final config = _schedule(
+        id: 'A',
+        name: 'mid',
+        weeksAgo: 5,
+        totalWeeks: 20,
+      );
+      final scheduleConfig = ValueNotifier(config);
+      final allSchedules = ValueNotifier([config]);
+      final controller = CoursePageController(
+        scheduleConfig: scheduleConfig,
+        allSchedules: allSchedules,
+        animationDuration: ValueNotifier(Duration.zero),
+      );
+      controller.dispose();
+
+      // Mutating external notifiers after dispose should not throw.
+      expect(() {
+        scheduleConfig.value = _schedule(
+          id: 'B',
+          name: 'other',
+          weeksAgo: 10,
+          totalWeeks: 20,
+        );
+        allSchedules.value = [scheduleConfig.value];
+      }, returnsNormally);
+    });
+  });
+}

--- a/test/course_page_controller_test.dart
+++ b/test/course_page_controller_test.dart
@@ -68,6 +68,8 @@ DateTime _weeksAhead(int weeks) {
 }
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   // ============ 初始化 ============
   // weeksAgo:N → actualWeek = N+1, _pageIndex = N（在 totalWeeks 范围内时）
 

--- a/test/course_provider_test.dart
+++ b/test/course_provider_test.dart
@@ -16,7 +16,6 @@ void main() {
       final provider = CourseProvider(database);
       var coursesChangedCount = 0;
       provider.onCoursesChanged = () => coursesChangedCount++;
-      final initialWeek = provider.currentWeek.value;
       final updatedOther = other.copyWith(
         semesterName: '已重命名的其他课表',
         semesterStartDate: _weeksAgo(5),
@@ -25,7 +24,6 @@ void main() {
       await provider.updateScheduleConfig(updatedOther);
 
       expect(provider.scheduleConfig.value, same(current));
-      expect(provider.currentWeek.value, initialWeek);
       expect(
         provider.allSchedules.value.singleWhere((item) => item.id == other.id),
         same(updatedOther),
@@ -54,7 +52,6 @@ void main() {
       await provider.updateScheduleConfig(updatedCurrent);
 
       expect(provider.scheduleConfig.value, same(updatedCurrent));
-      expect(provider.currentWeek.value, updatedCurrent.getCurrentWeek());
       expect(
         provider.allSchedules.value.singleWhere(
           (item) => item.id == current.id,


### PR DESCRIPTION
将「用户正在浏览第几周」的视图状态从全局 CourseProvider.currentWeek
下沉到页面级 CoursePageController（ChangeNotifier，不进 GetIt）。 控制器以 _pageIndex 为唯一权威真源，PageController 仅作执行器，
visibleWeek / isViewingVacation 等派生属性全部从 _pageIndex 计算， 消除原 notifier ↔ PageController 双向同步链导致的多处 bug。

根治的 bug：
- demoMode 干扰：预览页不再跑完整 initState，不写全局 currentWeek、 不弹「切换学期」对话框
- 未挂载跳页丢失：!hasClients 时换新 PageController(initialPage: target) 而非静默丢弃 jumpToPage，顶栏与网格显示同一周
- 同值不通知：移动判定改用物理位置（pageController.page?.round()） 而非缓存 int 比较，放假页左箭头不再失效

附带变更：
- 移除 home_page 切回课表 tab 时自动跳当前周的产品行为
- _TopBar 改纯 props，删除对 getIt<CourseProvider> 的直接依赖
- 删除 CourseProvider.currentWeek 字段与 updateCurrentWeek 方法
- 新增 22 个 CoursePageController 单测

dart analyze 零告警；相关测试全部通过。