### PR TITLE
fix: 补齐保存图片的相册权限

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 修复预览版更新检查可能匹配到错误版本的问题
 - 修复导出空课表时失败的问题
 - 修复了一些小问题
+- 修复低版本安卓、苹果系统上保存图片到相册相关权限的问题
 
 ## [2.2.0] - 2026-07-13
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -2,6 +2,9 @@
     
     xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission
+        android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+        android:maxSdkVersion="29" />
     <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES"/>
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS"/>

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -32,6 +32,8 @@
 	<string>用于将导出的课表和考表写入系统日历。</string>
 	<key>NSCalendarsWriteOnlyAccessUsageDescription</key>
 	<string>用于将导出的课表和考表写入系统日历。</string>
+	<key>NSPhotoLibraryAddUsageDescription</key>
+	<string>用于将您选择保存的图片添加到系统相册。</string>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/lib/widgets/common/image_viewer.dart
+++ b/lib/widgets/common/image_viewer.dart
@@ -109,6 +109,9 @@ class ImageViewerPage extends StatelessWidget {
     AppLocalizations l10n,
   ) async {
     try {
+      final granted = await Gal.requestAccess();
+      if (!granted) throw StateError('Gallery access denied');
+
       final response = await http.get(Uri.parse(imageUrl), headers: headers);
       if (response.statusCode != 200) throw Exception('Download failed');
       await Gal.putImageBytes(response.bodyBytes);

--- a/macos/Runner/Info.plist
+++ b/macos/Runner/Info.plist
@@ -34,5 +34,7 @@
 	<string>用于读取可写日历列表并将导出的课表和考表写入您选择的系统日历。</string>
 	<key>NSCalendarsWriteOnlyAccessUsageDescription</key>
 	<string>用于将导出的课表和考表写入系统日历。</string>
+	<key>NSPhotoLibraryAddUsageDescription</key>
+	<string>用于将您选择保存的图片添加到系统相册。</string>
 </dict>
 </plist>


### PR DESCRIPTION
## 修改内容

- 为 iOS 和 macOS 增加 `NSPhotoLibraryAddUsageDescription`，仅声明向系统相册添加图片的用途。
- 为 Android API 29 及以下增加 Gal 所需的 `WRITE_EXTERNAL_STORAGE` 限定声明。
- 保存图片前调用 `Gal.requestAccess()`；用户拒绝授权时直接复用现有失败提示，不再继续下载或写入。

## 原因

图片查看器调用 Gal 保存图片，但各平台缺少 Gal 要求的权限声明。Apple 平台可能因此拒绝照片库写入，Android 26–28 也无法完成旧版共享存储授权。

本次修复保持当前 add-only 行为，不读取已有照片，也不创建或管理专属相册。

Closes #142

## 验证

- `dart format --output=none --set-exit-if-changed lib/widgets/common/image_viewer.dart`
- `plutil -lint ios/Runner/Info.plist macos/Runner/Info.plist`
- `xmllint --noout android/app/src/main/AndroidManifest.xml`
- `flutter analyze`
- `flutter test`

以上检查均通过。

## 权限边界

未增加 `NSPhotoLibraryUsageDescription`、`READ_EXTERNAL_STORAGE`、`READ_MEDIA_IMAGES`、`MANAGE_EXTERNAL_STORAGE` 或 `requestLegacyExternalStorage`。
