### PR TITLE
fix: 修复试图下载文件却下载到验证码界面

### DIFF
--- a/lib/pages/campus/downloads/file_utils.dart
+++ b/lib/pages/campus/downloads/file_utils.dart
@@ -232,8 +232,56 @@ String sanitizeDownloadFileName(String rawName) {
   return fileName.isEmpty ? 'download' : fileName;
 }
 
+/// Exception thrown when the server returns a CAPTCHA page instead of a file.
+class CaptchaRequiredException implements Exception {
+  const CaptchaRequiredException({
+    required this.originalUrl,
+    required this.captchaImagePath,
+  });
+
+  final String originalUrl;
+  final String captchaImagePath;
+
+  /// Resolve the CAPTCHA image path to an absolute URL.
+  String get captchaAbsoluteUrl {
+    if (captchaImagePath.startsWith('http://') ||
+        captchaImagePath.startsWith('https://')) {
+      return captchaImagePath;
+    }
+    final base = Uri.parse(originalUrl).origin;
+    return '$base$captchaImagePath';
+  }
+}
+
+/// Detects if [bodyBytes] is a CAPTCHA HTML page.
+/// Returns [CaptchaRequiredException] if CAPTCHA is detected, null otherwise.
+CaptchaRequiredException? detectCaptcha(List<int> bodyBytes, String url) {
+  // Only small responses can be CAPTCHA pages; real files are larger.
+  if (bodyBytes.length > 256 * 1024) return null;
+
+  final head = utf8.decode(
+    bodyBytes.take(4096).toList(),
+    allowMalformed: true,
+  );
+
+  // Must look like HTML containing a CAPTCHA input.
+  if (!head.contains('codeValue')) return null;
+
+  // Extract the image src path — either relative or a known JSP path.
+  String imgPath;
+  final srcMatch = RegExp(r'''id="codeimg"[^>]*src="([^"]+)"''').firstMatch(head);
+  if (srcMatch != null) {
+    imgPath = srcMatch.group(1)!;
+  } else {
+    imgPath = '/system/resource/js/filedownload/createimage.jsp';
+  }
+
+  return CaptchaRequiredException(originalUrl: url, captchaImagePath: imgPath);
+}
+
 /// Downloads a file from [url] into `Bugaoshan/{dirName}/`.
 /// Returns the final local path.
+/// Throws [CaptchaRequiredException] if the server returns a CAPTCHA page.
 Future<String> downloadFile(
   String url,
   String dirName,
@@ -256,6 +304,10 @@ Future<String> downloadFile(
   if (cancelToken?.isCancelled ?? false) throw DownloadCancelledException();
 
   final bytes = response.bodyBytes;
+
+  // Detect CAPTCHA page — server may return 200 with a verification form.
+  final captcha = detectCaptcha(bytes, url);
+  if (captcha != null) throw captcha;
 
   // Prefer filename from Content-Disposition header.
   var actualFileName = sanitizeDownloadFileName(fileName);

--- a/lib/pages/campus/downloads/file_utils.dart
+++ b/lib/pages/campus/downloads/file_utils.dart
@@ -237,9 +237,9 @@ class CaptchaRequiredException implements Exception {
   const CaptchaRequiredException();
 }
 
-/// Detects if [bodyBytes] is a CAPTCHA HTML page.
-bool isCaptchaResponse(List<int> bodyBytes) {
-  if (bodyBytes.length > 256 * 1024) return false;
+/// Detects if the HTTP response is a CAPTCHA HTML page.
+bool isCaptchaResponse(String? contentType, List<int> bodyBytes) {
+  if (contentType == null || !contentType.contains('text/html')) return false;
   final head = utf8.decode(bodyBytes.take(4096).toList(), allowMalformed: true);
   return head.contains('codeValue');
 }
@@ -271,7 +271,9 @@ Future<String> downloadFile(
   final bytes = response.bodyBytes;
 
   // Detect CAPTCHA page — server may return 200 with a verification form.
-  if (isCaptchaResponse(bytes)) throw const CaptchaRequiredException();
+  if (isCaptchaResponse(response.headers['content-type'], bytes)) {
+    throw const CaptchaRequiredException();
+  }
 
   // Prefer filename from Content-Disposition header.
   var actualFileName = sanitizeDownloadFileName(fileName);

--- a/lib/pages/campus/downloads/file_utils.dart
+++ b/lib/pages/campus/downloads/file_utils.dart
@@ -234,49 +234,14 @@ String sanitizeDownloadFileName(String rawName) {
 
 /// Exception thrown when the server returns a CAPTCHA page instead of a file.
 class CaptchaRequiredException implements Exception {
-  const CaptchaRequiredException({
-    required this.originalUrl,
-    required this.captchaImagePath,
-  });
-
-  final String originalUrl;
-  final String captchaImagePath;
-
-  /// Resolve the CAPTCHA image path to an absolute URL.
-  String get captchaAbsoluteUrl {
-    if (captchaImagePath.startsWith('http://') ||
-        captchaImagePath.startsWith('https://')) {
-      return captchaImagePath;
-    }
-    final base = Uri.parse(originalUrl).origin;
-    return '$base$captchaImagePath';
-  }
+  const CaptchaRequiredException();
 }
 
 /// Detects if [bodyBytes] is a CAPTCHA HTML page.
-/// Returns [CaptchaRequiredException] if CAPTCHA is detected, null otherwise.
-CaptchaRequiredException? detectCaptcha(List<int> bodyBytes, String url) {
-  // Only small responses can be CAPTCHA pages; real files are larger.
-  if (bodyBytes.length > 256 * 1024) return null;
-
-  final head = utf8.decode(
-    bodyBytes.take(4096).toList(),
-    allowMalformed: true,
-  );
-
-  // Must look like HTML containing a CAPTCHA input.
-  if (!head.contains('codeValue')) return null;
-
-  // Extract the image src path — either relative or a known JSP path.
-  String imgPath;
-  final srcMatch = RegExp(r'''id="codeimg"[^>]*src="([^"]+)"''').firstMatch(head);
-  if (srcMatch != null) {
-    imgPath = srcMatch.group(1)!;
-  } else {
-    imgPath = '/system/resource/js/filedownload/createimage.jsp';
-  }
-
-  return CaptchaRequiredException(originalUrl: url, captchaImagePath: imgPath);
+bool isCaptchaResponse(List<int> bodyBytes) {
+  if (bodyBytes.length > 256 * 1024) return false;
+  final head = utf8.decode(bodyBytes.take(4096).toList(), allowMalformed: true);
+  return head.contains('codeValue');
 }
 
 /// Downloads a file from [url] into `Bugaoshan/{dirName}/`.
@@ -306,8 +271,7 @@ Future<String> downloadFile(
   final bytes = response.bodyBytes;
 
   // Detect CAPTCHA page — server may return 200 with a verification form.
-  final captcha = detectCaptcha(bytes, url);
-  if (captcha != null) throw captcha;
+  if (isCaptchaResponse(bytes)) throw const CaptchaRequiredException();
 
   // Prefer filename from Content-Disposition header.
   var actualFileName = sanitizeDownloadFileName(fileName);

--- a/lib/pages/campus/notice/jwc/campus_notice_page.dart
+++ b/lib/pages/campus/notice/jwc/campus_notice_page.dart
@@ -17,7 +17,9 @@ class CampusNoticePage extends StatelessWidget {
       heroTag: 'jwc_attach_fab',
       debugLabel: 'JwcNotice',
       downloadOptions: DownloadOptions(
+        useWebViewDownload: true,
         attachmentDir: kNoticeAttachmentDir,
+        downloadHeaders: {'Referer': 'https://jwc.scu.edu.cn'},
         initialTab: 0,
       ),
     );

--- a/lib/pages/campus/notice/xgb/party_notice_page.dart
+++ b/lib/pages/campus/notice/xgb/party_notice_page.dart
@@ -18,7 +18,9 @@ class PartyNoticePage extends StatelessWidget {
       heroTag: 'party_attach_fab',
       debugLabel: 'PartyNotice',
       downloadOptions: DownloadOptions(
+        useWebViewDownload: true,
         attachmentDir: kPartyAttachmentDir,
+        downloadHeaders: {'Referer': 'https://xgb.scu.edu.cn'},
         initialTab: 1,
       ),
     );

--- a/lib/pages/dev/dev_page.dart
+++ b/lib/pages/dev/dev_page.dart
@@ -74,6 +74,20 @@ class _DevPageState extends State<DevPage> {
   ) {
     return [
       const SizedBox(height: 16),
+      ValueListenableBuilder<bool>(
+        valueListenable: _appConfig.forceCaptchaForDownload,
+        builder: (context, value, _) => SwitchListTile(
+          contentPadding: EdgeInsets.zero,
+          title: const Text('强制下载验证码'),
+          subtitle: Text(
+            '开启后点击附件下载将直接弹出验证码弹窗，用于测试验证码流程',
+            style: Theme.of(context).textTheme.bodySmall,
+          ),
+          value: value,
+          onChanged: (v) => _appConfig.forceCaptchaForDownload.value = v,
+        ),
+      ),
+      const Divider(),
       Padding(
         padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
         child: Text(

--- a/lib/providers/app_config_provider.dart
+++ b/lib/providers/app_config_provider.dart
@@ -31,6 +31,7 @@ const String _keyShowNonCurrentWeekCourses = 'showNonCurrentWeekCourses';
 const String _keyUseGoogleFonts = 'useGoogleFonts';
 const String _keyCampusGridView = 'campusGridView';
 const String _keyAutoSampleBalanceOnLogin = 'autoSampleBalanceOnLogin';
+const String _keyForceCaptchaForDownload = 'forceCaptchaForDownload';
 const Curve appCurve = Curves.easeOutQuart;
 
 enum ThemeColorMode { system, backgroundImage, custom }
@@ -82,6 +83,9 @@ class AppConfigProvider {
   final ValueNotifier<bool> campusGridView = ValueNotifier<bool>(false);
   final ValueNotifier<bool> autoSampleBalanceOnLogin = ValueNotifier<bool>(
     true,
+  );
+  final ValueNotifier<bool> forceCaptchaForDownload = ValueNotifier<bool>(
+    false,
   );
 
   Future<void> _loadPreferences() async {
@@ -138,6 +142,8 @@ class AppConfigProvider {
         _sharedPreferences.getBool(_keyCampusGridView) ?? false;
     autoSampleBalanceOnLogin.value =
         _sharedPreferences.getBool(_keyAutoSampleBalanceOnLogin) ?? false;
+    forceCaptchaForDownload.value =
+        _sharedPreferences.getBool(_keyForceCaptchaForDownload) ?? false;
   }
 
   void _addSaveCallback() {
@@ -254,6 +260,12 @@ class AppConfigProvider {
       _sharedPreferences.setBool(
         _keyAutoSampleBalanceOnLogin,
         autoSampleBalanceOnLogin.value,
+      );
+    });
+    forceCaptchaForDownload.addListener(() {
+      _sharedPreferences.setBool(
+        _keyForceCaptchaForDownload,
+        forceCaptchaForDownload.value,
       );
     });
   }

--- a/lib/widgets/webview/webview_notice_handlers.dart
+++ b/lib/widgets/webview/webview_notice_handlers.dart
@@ -5,6 +5,7 @@ import 'package:bugaoshan/l10n/app_localizations.dart';
 import 'package:bugaoshan/pages/campus/downloads/shared_notice_downloads.dart';
 import 'package:bugaoshan/services/download_manager.dart';
 import 'package:bugaoshan/widgets/common/image_viewer.dart';
+import 'package:bugaoshan/widgets/dialog/dialog.dart'; // for appConfigService
 import 'package:flutter/material.dart';
 import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -142,6 +143,9 @@ mixin WebViewNoticeHandlers<T extends StatefulWidget> on State<T> {
     String fileName,
     DownloadOptions options,
   ) async {
+    if (appConfigService.forceCaptchaForDownload.value) {
+      throw const CaptchaRequiredException();
+    }
     final cookieHeader = await getDownloadCookieHeader(url);
     final headers = mergeDownloadHeaders(
       options.downloadHeaders,

--- a/lib/widgets/webview/webview_notice_handlers.dart
+++ b/lib/widgets/webview/webview_notice_handlers.dart
@@ -96,8 +96,8 @@ mixin WebViewNoticeHandlers<T extends StatefulWidget> on State<T> {
   // ── CAPTCHA-aware download ────────────────────────────────────────────────────
 
   /// Downloads [url] and updates [task] in DownloadManager.
-  /// If the server returns a CAPTCHA page, shows a dialog and retries with the
-  /// user-supplied verification code.
+  /// On CAPTCHA, opens a WebView dialog so the user can complete verification
+  /// directly on the server page.
   Future<void> _downloadWithCaptchaHandling(
     String url,
     String fileName,
@@ -114,59 +114,16 @@ mixin WebViewNoticeHandlers<T extends StatefulWidget> on State<T> {
         status: DownloadStatus.done,
         downloadedPath: path,
       );
-      if (mounted) {
-        final l10n = AppLocalizations.of(context)!;
-        ScaffoldMessenger.of(
-          context,
-        ).showSnackBar(SnackBar(content: Text(l10n.downloadComplete)));
-      }
-    } on CaptchaRequiredException catch (e) {
+    } on CaptchaRequiredException catch (_) {
       if (!mounted) return;
-      final code = await _showCaptchaDialog(e);
-      if (code == null || code.isEmpty) {
-        if (mounted) {
-          manager.updateTask(
-            task,
-            status: DownloadStatus.error,
-            errorMessage: '验证码已取消',
-          );
-        }
-        return;
-      }
-      if (!mounted) return;
-      // Retry with the verification code appended.
-      final codeUrl = '${e.originalUrl}&codeValue=$code';
-      try {
-        manager.updateTask(task, status: DownloadStatus.downloading);
-        final path = await _doDownload(codeUrl, fileName, options);
+      // Let the user complete the CAPTCHA in a WebView — it handles the rest.
+      final ok = await _showCaptchaWebViewDialog(url, options, task);
+      if (!ok && mounted) {
         manager.updateTask(
           task,
-          status: DownloadStatus.done,
-          downloadedPath: path,
+          status: DownloadStatus.error,
+          errorMessage: '验证码已取消',
         );
-        if (mounted) {
-          final l10n = AppLocalizations.of(context)!;
-          ScaffoldMessenger.of(
-            context,
-          ).showSnackBar(SnackBar(content: Text(l10n.downloadComplete)));
-        }
-      } on CaptchaRequiredException catch (_) {
-        // Wrong code — server returned CAPTCHA again.
-        if (mounted) {
-          manager.updateTask(
-            task,
-            status: DownloadStatus.error,
-            errorMessage: '验证码错误，请重试',
-          );
-        }
-      } catch (retryErr) {
-        if (mounted) {
-          manager.updateTask(
-            task,
-            status: DownloadStatus.error,
-            errorMessage: retryErr.toString(),
-          );
-        }
       }
     } catch (e) {
       if (mounted) {
@@ -193,17 +150,38 @@ mixin WebViewNoticeHandlers<T extends StatefulWidget> on State<T> {
     return downloadFile(url, options.attachmentDir, fileName, headers: headers);
   }
 
-  /// Shows a dialog that displays the CAPTCHA image and collects the code.
-  Future<String?> _showCaptchaDialog(CaptchaRequiredException e) {
-    return showDialog<String>(
+  /// Opens a dialog with a WebView that loads the CAPTCHA page.
+  /// Returns true if the user completed the CAPTCHA and the file was downloaded.
+  Future<bool> _showCaptchaWebViewDialog(
+    String url,
+    DownloadOptions options,
+    DownloadTask task,
+  ) async {
+    final result = await showDialog<bool>(
       context: context,
       barrierDismissible: false,
-      builder: (ctx) => _CaptchaDialog(
-        captchaException: e,
-        getCookies: () => getDownloadCookieHeader(e.originalUrl),
-        downloadHeaders: downloadOptions?.downloadHeaders,
+      builder: (ctx) => _CaptchaWebViewDialog(
+        url: url,
+        onDownloadComplete: (String filePath) {
+          getIt<DownloadManager>().updateTask(
+            task,
+            status: DownloadStatus.done,
+            downloadedPath: filePath,
+          );
+          if (mounted) {
+            final l10n = AppLocalizations.of(context)!;
+            ScaffoldMessenger.of(
+              context,
+            ).showSnackBar(SnackBar(content: Text(l10n.downloadComplete)));
+          }
+          Navigator.pop(ctx, true);
+        },
+        getCookies: () => getDownloadCookieHeader(url),
+        downloadHeaders: options.downloadHeaders,
+        attachmentDir: options.attachmentDir,
       ),
     );
+    return result ?? false;
   }
 
   Future<String?> getDownloadCookieHeader(String url) async {
@@ -299,110 +277,95 @@ mixin WebViewNoticeHandlers<T extends StatefulWidget> on State<T> {
   }
 }
 
-// ── CAPTCHA Dialog ────────────────────────────────────────────────────────────
+// ── CAPTCHA WebView Dialog ────────────────────────────────────────────────────
 
-class _CaptchaDialog extends StatefulWidget {
-  const _CaptchaDialog({
-    required this.captchaException,
+/// Dialog that loads the CAPTCHA page directly in a WebView.
+///
+/// The user completes the verification form on the original server page. When
+/// the server returns the actual file after verification, [onDownloadStarting]
+/// intercepts it, downloads the file, and calls [onDownloadComplete].
+class _CaptchaWebViewDialog extends StatefulWidget {
+  const _CaptchaWebViewDialog({
+    required this.url,
+    required this.onDownloadComplete,
     required this.getCookies,
+    required this.attachmentDir,
     this.downloadHeaders,
   });
 
-  final CaptchaRequiredException captchaException;
+  final String url;
+  final void Function(String filePath) onDownloadComplete;
   final Future<String?> Function() getCookies;
+  final String attachmentDir;
   final Map<String, String>? downloadHeaders;
 
   @override
-  State<_CaptchaDialog> createState() => _CaptchaDialogState();
+  State<_CaptchaWebViewDialog> createState() => _CaptchaWebViewDialogState();
 }
 
-class _CaptchaDialogState extends State<_CaptchaDialog> {
-  final _controller = TextEditingController();
-  int _refreshTick = 0;
+class _CaptchaWebViewDialogState extends State<_CaptchaWebViewDialog> {
+  bool _loading = true;
 
-  @override
-  void dispose() {
-    _controller.dispose();
-    super.dispose();
-  }
-
-  Future<Map<String, String>> _buildHeaders() async {
+  Future<DownloadStartResponse?> _onDownloadStarting(
+    InAppWebViewController controller,
+    DownloadStartRequest request,
+  ) async {
     final cookieHeader = await widget.getCookies();
-    return <String, String>{
-      ...?widget.downloadHeaders,
-      if (cookieHeader != null && cookieHeader.isNotEmpty)
-        'Cookie': cookieHeader,
-    };
+    final headers = mergeDownloadHeaders(
+      widget.downloadHeaders,
+      cookieHeader: cookieHeader,
+    );
+    try {
+      final path = await downloadFile(
+        request.url.toString(),
+        widget.attachmentDir,
+        request.suggestedFilename ?? 'download',
+        headers: headers,
+      );
+      widget.onDownloadComplete(path);
+    } catch (_) {
+      // Download failed — let the WebView keep showing whatever the server returned.
+    }
+    return DownloadStartResponse(handled: true);
   }
 
   @override
   Widget build(BuildContext context) {
-    // Append a cache-busting random parameter so each refresh loads a fresh image.
-    final now = DateTime.now().millisecondsSinceEpoch;
-    final captchaUrl =
-        '${widget.captchaException.captchaAbsoluteUrl}&randnum=$now$_refreshTick';
-
-    return AlertDialog(
-      title: const Text('请输入验证码'),
-      content: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          GestureDetector(
-            onTap: () => setState(() => _refreshTick++),
-            child: FutureBuilder<Map<String, String>>(
-              future: _buildHeaders(),
-              builder: (ctx, snap) {
-                final headers = snap.data ?? {};
-                return Image.network(
-                  captchaUrl,
-                  headers: headers,
-                  height: 42,
-                  fit: BoxFit.fitHeight,
-                  errorBuilder: (_, err, stack) => const SizedBox(
-                    height: 42,
-                    child: Center(child: Icon(Icons.error_outline)),
-                  ),
-                );
-              },
+    return Dialog(
+      child: SizedBox(
+        width: 420,
+        height: 260,
+        child: Column(
+          children: [
+            AppBar(
+              title: Text('请输入验证码'),
+              leading: IconButton(
+                icon: const Icon(Icons.close),
+                onPressed: () => Navigator.pop(context, false),
+              ),
+              toolbarHeight: 44,
             ),
-          ),
-          const SizedBox(height: 4),
-          GestureDetector(
-            onTap: () => setState(() => _refreshTick++),
-            child: Text(
-              '看不清？点我换一张',
-              style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                color: Theme.of(context).colorScheme.primary,
+            Expanded(
+              child: Stack(
+                children: [
+                  InAppWebView(
+                    initialUrlRequest: URLRequest(url: WebUri(widget.url)),
+                    initialSettings: InAppWebViewSettings(
+                      javaScriptEnabled: true,
+                    ),
+                    onDownloadStarting: _onDownloadStarting,
+                    onLoadStop: (ctrl, uri) {
+                      if (mounted) setState(() => _loading = false);
+                    },
+                  ),
+                  if (_loading)
+                    const Center(child: CircularProgressIndicator()),
+                ],
               ),
             ),
-          ),
-          const SizedBox(height: 12),
-          TextField(
-            controller: _controller,
-            maxLength: 4,
-            autofocus: true,
-            keyboardType: TextInputType.number,
-            decoration: const InputDecoration(
-              hintText: '验证码',
-              border: OutlineInputBorder(),
-              isDense: true,
-            ),
-            onSubmitted: (value) {
-              if (value.isNotEmpty) Navigator.pop(context, value);
-            },
-          ),
-        ],
+          ],
+        ),
       ),
-      actions: [
-        TextButton(
-          onPressed: () => Navigator.pop(context),
-          child: const Text('取消'),
-        ),
-        TextButton(
-          onPressed: () => Navigator.pop(context, _controller.text),
-          child: const Text('确定'),
-        ),
-      ],
     );
   }
 }

--- a/lib/widgets/webview/webview_notice_handlers.dart
+++ b/lib/widgets/webview/webview_notice_handlers.dart
@@ -37,8 +37,23 @@ mixin WebViewNoticeHandlers<T extends StatefulWidget> on State<T> {
     }
   }
 
-  void onWebViewDownload(String url) {
-    controller?.loadUrl(urlRequest: URLRequest(url: WebUri(url)));
+  /// Downloads a file through the WebView session with CAPTCHA handling.
+  /// Called from the attachment sheet when [DownloadOptions.useWebViewDownload] is true.
+  /// The task must already be enqueued in [DownloadManager].
+  Future<void> onWebViewDownload(String url) async {
+    final options = downloadOptions;
+    if (options == null) return;
+
+    final manager = getIt<DownloadManager>();
+    final task = manager.taskFor(url, options.attachmentDir);
+    if (task == null) return;
+
+    await _downloadWithCaptchaHandling(
+      url,
+      task.fileName,
+      options,
+      task,
+    );
   }
 
   void onOpenImage(List<dynamic> args) {
@@ -78,6 +93,119 @@ mixin WebViewNoticeHandlers<T extends StatefulWidget> on State<T> {
     });
   }
 
+  // ── CAPTCHA-aware download ────────────────────────────────────────────────────
+
+  /// Downloads [url] and updates [task] in DownloadManager.
+  /// If the server returns a CAPTCHA page, shows a dialog and retries with the
+  /// user-supplied verification code.
+  Future<void> _downloadWithCaptchaHandling(
+    String url,
+    String fileName,
+    DownloadOptions options,
+    DownloadTask task,
+  ) async {
+    final manager = getIt<DownloadManager>();
+    manager.updateTask(task, status: DownloadStatus.downloading);
+
+    try {
+      final path = await _doDownload(url, fileName, options);
+      manager.updateTask(
+        task,
+        status: DownloadStatus.done,
+        downloadedPath: path,
+      );
+      if (mounted) {
+        final l10n = AppLocalizations.of(context)!;
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(SnackBar(content: Text(l10n.downloadComplete)));
+      }
+    } on CaptchaRequiredException catch (e) {
+      if (!mounted) return;
+      final code = await _showCaptchaDialog(e);
+      if (code == null || code.isEmpty) {
+        if (mounted) {
+          manager.updateTask(
+            task,
+            status: DownloadStatus.error,
+            errorMessage: '验证码已取消',
+          );
+        }
+        return;
+      }
+      if (!mounted) return;
+      // Retry with the verification code appended.
+      final codeUrl = '${e.originalUrl}&codeValue=$code';
+      try {
+        manager.updateTask(task, status: DownloadStatus.downloading);
+        final path = await _doDownload(codeUrl, fileName, options);
+        manager.updateTask(
+          task,
+          status: DownloadStatus.done,
+          downloadedPath: path,
+        );
+        if (mounted) {
+          final l10n = AppLocalizations.of(context)!;
+          ScaffoldMessenger.of(
+            context,
+          ).showSnackBar(SnackBar(content: Text(l10n.downloadComplete)));
+        }
+      } on CaptchaRequiredException catch (_) {
+        // Wrong code — server returned CAPTCHA again.
+        if (mounted) {
+          manager.updateTask(
+            task,
+            status: DownloadStatus.error,
+            errorMessage: '验证码错误，请重试',
+          );
+        }
+      } catch (retryErr) {
+        if (mounted) {
+          manager.updateTask(
+            task,
+            status: DownloadStatus.error,
+            errorMessage: retryErr.toString(),
+          );
+        }
+      }
+    } catch (e) {
+      if (mounted) {
+        manager.updateTask(
+          task,
+          status: DownloadStatus.error,
+          errorMessage: e.toString(),
+        );
+      }
+    }
+  }
+
+  /// Downloads a file via HTTP with WebView session cookies.
+  Future<String> _doDownload(
+    String url,
+    String fileName,
+    DownloadOptions options,
+  ) async {
+    final cookieHeader = await getDownloadCookieHeader(url);
+    final headers = mergeDownloadHeaders(
+      options.downloadHeaders,
+      cookieHeader: cookieHeader,
+    );
+    return downloadFile(url, options.attachmentDir, fileName, headers: headers);
+  }
+
+  /// Shows a dialog that displays the CAPTCHA image and collects the code.
+  Future<String?> _showCaptchaDialog(CaptchaRequiredException e) {
+    return showDialog<String>(
+      context: context,
+      barrierDismissible: false,
+      builder: (ctx) => _CaptchaDialog(
+        captchaException: e,
+        getCookies: () => getDownloadCookieHeader(e.originalUrl),
+        downloadHeaders: downloadOptions?.downloadHeaders,
+      ),
+    );
+  }
+
   Future<String?> getDownloadCookieHeader(String url) async {
     final cookies = await CookieManager.instance().getCookies(url: WebUri(url));
     if (cookies.isEmpty) return null;
@@ -104,23 +232,24 @@ mixin WebViewNoticeHandlers<T extends StatefulWidget> on State<T> {
     final url = args[0] as String;
     final name = args[1] as String;
     final options = downloadOptions!;
+
+    // Enqueue a task so the sheet (if opened) shows progress.
+    final manager = getIt<DownloadManager>();
+    final task = manager.enqueue(
+      url,
+      options.attachmentDir,
+      name,
+      headers: mergeDownloadHeaders(options.downloadHeaders, cookieHeader: null),
+    );
+
     try {
-      final headers = mergeDownloadHeaders(
-        options.downloadHeaders,
-        cookieHeader: await getDownloadCookieHeader(url),
-      );
-      await downloadNoticeFile(
-        url,
-        options.attachmentDir,
-        name,
-        headers: headers,
-      );
+      await _downloadWithCaptchaHandling(url, name, options, task);
       if (mounted) {
         showAttachmentsSheet(
           context,
           items: pageAttachments,
           dirName: options.attachmentDir,
-          downloadHeaders: headers,
+          downloadHeaders: null, // headers already embedded in task
           onWebViewDownload: options.useWebViewDownload
               ? onWebViewDownload
               : null,
@@ -166,6 +295,114 @@ mixin WebViewNoticeHandlers<T extends StatefulWidget> on State<T> {
     if (downloadOptions == null) return null;
     return DownloadStartResponse(
       handled: await handleDownloadStartRequest(request),
+    );
+  }
+}
+
+// ── CAPTCHA Dialog ────────────────────────────────────────────────────────────
+
+class _CaptchaDialog extends StatefulWidget {
+  const _CaptchaDialog({
+    required this.captchaException,
+    required this.getCookies,
+    this.downloadHeaders,
+  });
+
+  final CaptchaRequiredException captchaException;
+  final Future<String?> Function() getCookies;
+  final Map<String, String>? downloadHeaders;
+
+  @override
+  State<_CaptchaDialog> createState() => _CaptchaDialogState();
+}
+
+class _CaptchaDialogState extends State<_CaptchaDialog> {
+  final _controller = TextEditingController();
+  int _refreshTick = 0;
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  Future<Map<String, String>> _buildHeaders() async {
+    final cookieHeader = await widget.getCookies();
+    return <String, String>{
+      ...?widget.downloadHeaders,
+      if (cookieHeader != null && cookieHeader.isNotEmpty)
+        'Cookie': cookieHeader,
+    };
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // Append a cache-busting random parameter so each refresh loads a fresh image.
+    final now = DateTime.now().millisecondsSinceEpoch;
+    final captchaUrl =
+        '${widget.captchaException.captchaAbsoluteUrl}&randnum=$now$_refreshTick';
+
+    return AlertDialog(
+      title: const Text('请输入验证码'),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          GestureDetector(
+            onTap: () => setState(() => _refreshTick++),
+            child: FutureBuilder<Map<String, String>>(
+              future: _buildHeaders(),
+              builder: (ctx, snap) {
+                final headers = snap.data ?? {};
+                return Image.network(
+                  captchaUrl,
+                  headers: headers,
+                  height: 42,
+                  fit: BoxFit.fitHeight,
+                  errorBuilder: (_, err, stack) => const SizedBox(
+                    height: 42,
+                    child: Center(child: Icon(Icons.error_outline)),
+                  ),
+                );
+              },
+            ),
+          ),
+          const SizedBox(height: 4),
+          GestureDetector(
+            onTap: () => setState(() => _refreshTick++),
+            child: Text(
+              '看不清？点我换一张',
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                color: Theme.of(context).colorScheme.primary,
+              ),
+            ),
+          ),
+          const SizedBox(height: 12),
+          TextField(
+            controller: _controller,
+            maxLength: 4,
+            autofocus: true,
+            keyboardType: TextInputType.number,
+            decoration: const InputDecoration(
+              hintText: '验证码',
+              border: OutlineInputBorder(),
+              isDense: true,
+            ),
+            onSubmitted: (value) {
+              if (value.isNotEmpty) Navigator.pop(context, value);
+            },
+          ),
+        ],
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context),
+          child: const Text('取消'),
+        ),
+        TextButton(
+          onPressed: () => Navigator.pop(context, _controller.text),
+          child: const Text('确定'),
+        ),
+      ],
     );
   }
 }


### PR DESCRIPTION
## 修复通知公告附件下载的三个问题

### 1. 下载得到验证码 HTML 而非目标文件

JWC/XGB 附件下载走纯 HTTP 请求，无会话 Cookie，服务器返回验证码页面（200 OK）被当成文件写入磁盘。

→ JWC/XGB 启用 `useWebViewDownload`，下载携带 WebView Cookie；`downloadFile` 增加 HTML 检测，识别验证码页面后抛异常而非存盘。

### 2. 验证码页面在背景 WebView 中静默显示

`onWebViewDownload` 直接在 WebView 中加载 URL，若返回验证码 HTML，用户看不到也无法操作。

→ 改为 HTTP 下载 + Cookie，检测到验证码则弹窗展示验证码界面、输入验证码后重试。（写了弹窗但是当前没法测试，因为自己在Windows虚拟机和Android模拟器中均无法再触发验证码相关内容）