### PR TITLE
fix: 修复 wfw 预热误报 ready 导致的用户信息取数死循环

### DIFF
--- a/lib/providers/user_info_provider.dart
+++ b/lib/providers/user_info_provider.dart
@@ -47,6 +47,7 @@ class UserInfoProvider extends ChangeNotifier {
   final UserInfoPersistence _persistUserInfo;
   int _requestGeneration = 0;
   Future<void> _persistenceTail = Future<void>.value();
+  AuthState _lastAuthState = AuthState.unknown;
 
   UserInfoProvider(
     this._wfwAuth,
@@ -56,6 +57,7 @@ class UserInfoProvider extends ChangeNotifier {
     _wfwAuth.addListener(_onAuthChanged);
     // ScuAuth.init() 在 DI 阶段完成，此时本 Provider 还没创建，
     // init() 的 notifyListeners 没人接收。构造后主动检查一次。
+    _lastAuthState = _wfwAuth.state;
     if (_wfwAuth.isReady) {
       _scheduleFetch(Duration.zero);
     }
@@ -76,13 +78,22 @@ class UserInfoProvider extends ChangeNotifier {
   String? get userNumber => _userNumber;
 
   void _onAuthChanged() {
-    if (_wfwAuth.state == AuthState.ready) {
+    final current = _wfwAuth.state;
+    // 只在 unknown→ready 边沿触发取数。会话失效后的自动重试路径
+    // （invalidate → 预热 → ready）会再次 notify ready，若按电平触发，
+    // 每次重试预热都会重新调度取数；一旦 wfw session 始终无法建立，
+    // 「ready → 取数失败 → invalidate → 预热误报 ready → 再取数」
+    // 就会无限循环。
+    final becameReady =
+        current == AuthState.ready && _lastAuthState != AuthState.ready;
+    _lastAuthState = current;
+    if (becameReady) {
       // SSO session 刚通过 session/save 建立，CookieClient 的 jar 里仅有
       // id.scu.edu.cn 域 cookie。立即访问 wfw.scu.edu.cn 会触发重定向链，
       // 重定向期间的并发请求可能被服务端限流或产生 session 竞态导致失败。
       // 给一个短延迟让重定向链完成，同时 _fetchAll 内部有一次自动重试兜底。
       _scheduleFetch(const Duration(milliseconds: 300));
-    } else if (_wfwAuth.state == AuthState.unknown) {
+    } else if (current == AuthState.unknown) {
       clear();
     }
   }
@@ -212,10 +223,22 @@ class UserInfoProvider extends ChangeNotifier {
     if (_wfwAuth.isReady) {
       _scheduleFetch(Duration.zero);
     } else {
-      // wfw 会话已失效：先刷新 UI 清除过期 error 帧，再主动预热恢复 ready，
-      // 成功后 _onAuthChanged 会重新取数。
+      // wfw 会话已失效：先刷新 UI 清除过期 error 帧，再主动预热恢复 ready。
       notifyListeners();
-      unawaited(_wfwAuth.ensureAuthenticated().catchError((Object _) {}));
+      unawaited(
+        _wfwAuth
+            .ensureAuthenticated()
+            .then((_) {
+              // 会话可能是「无声失效后重建」（invalidate 不发通知，
+              // _lastAuthState 仍停留在 ready）：此时 ready 重通知不构成
+              // 状态边沿，_onAuthChanged 不会再调度，这里显式兜底。
+              // 正常边沿路径下通知已调度过一次，generation 会去重。
+              if (_wfwAuth.isReady) {
+                _scheduleFetch(const Duration(milliseconds: 300));
+              }
+            })
+            .catchError((Object _) {}),
+      );
     }
   }
 

--- a/lib/services/auth/cookie_client.dart
+++ b/lib/services/auth/cookie_client.dart
@@ -46,6 +46,9 @@ class CookieClient extends http.BaseClient {
     return result;
   }
 
+  /// 判断 jar 中是否存在可发送给 [uri] 的 cookie
+  bool hasCookiesFor(Uri uri) => _cookiesFor(uri).isNotEmpty;
+
   /// 解析并存储响应中的 Set-Cookie
   void _storeCookies(Uri uri, http.BaseResponse response) {
     final raw = response.headers['set-cookie'];

--- a/lib/services/auth/wfw_auth.dart
+++ b/lib/services/auth/wfw_auth.dart
@@ -88,9 +88,10 @@ class WfwAuth extends ChangeNotifier implements SubsystemAuth {
     // 重定向链，在 CookieClient 中建立 wfw.scu.edu.cn 的 session cookie。
     // 不这么做的话，冷启动时页面带 X-Requested-With 的 API 请求会被
     // wfw 服务端直接返回 "用户信息已失效" 而不走 SSO 重定向。
+    const warmUpUrl = 'https://wfw.scu.edu.cn/';
     try {
       final response = await client.followRedirects(
-        Uri.parse('https://wfw.scu.edu.cn/'),
+        Uri.parse(warmUpUrl),
         headers: {'User-Agent': kDefaultUserAgent},
       );
       if (response.statusCode == 401 || response.statusCode == 403) {
@@ -98,6 +99,14 @@ class WfwAuth extends ChangeNotifier implements SubsystemAuth {
       }
       if (response.statusCode < 200 || response.statusCode >= 400) {
         throw ServiceException('微服务预热失败', statusCode: response.statusCode);
+      }
+      // 匿名访问首页也可能直接 200（不走 SSO 重定向、不下发 Set-Cookie）。
+      // 仅凭状态码会把「session 未建立」误判为 ready，随后业务请求必然失效：
+      // invalidate → 重新预热 → 再次误报 ready → 通知监听方重新取数，
+      // 形成死循环。必须确认 wfw 域 cookie 已实际写入 jar。
+      if (!client.hasCookiesFor(Uri.parse(warmUpUrl))) {
+        _log.w(_tag, 'warm-up: no wfw cookie bound, session not established');
+        throw const UnauthenticatedException('微服务 session 未建立');
       }
       _log.d(_tag, 'warm-up request ok');
       if (identical(client, _lastScuClient) && !_ready) {

--- a/test/user_info_provider_test.dart
+++ b/test/user_info_provider_test.dart
@@ -5,6 +5,7 @@ import 'package:bugaoshan/providers/scu_auth_provider.dart';
 import 'package:bugaoshan/providers/user_info_provider.dart';
 import 'package:bugaoshan/services/api/wfw_api_service.dart';
 import 'package:bugaoshan/services/auth/auth_state.dart';
+import 'package:bugaoshan/services/auth/scu_exceptions.dart';
 import 'package:bugaoshan/services/auth/wfw_auth.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -95,6 +96,60 @@ void main() {
     expect(persistence.storedRealname, isNull);
     expect(persistence.storedNumber, isNull);
   });
+
+  test(
+    'a repeated ready notification without a transition does not refetch',
+    () async {
+      final auth = _FakeWfwAuth(ready: true);
+      final api = _ControllableWfwApiService();
+      final provider = UserInfoProvider(auth, api);
+      await Future<void>.delayed(Duration.zero);
+      expect(api.profileRequests, hasLength(1));
+
+      // 自动重试路径里 invalidate（无声）→ 预热 → ready 会再次 notify；
+      // 同状态重复通知不得触发重新取数，否则一旦预热是误报（session 实际
+      // 未建立），「取数失败 → 预热 ready → 再取数」会无限循环。
+      auth.setReady(true);
+      await Future<void>.delayed(const Duration(milliseconds: 350));
+      expect(api.profileRequests, hasLength(1));
+
+      // 真正的 unknown→ready 边沿仍然触发取数。
+      auth.setReady(false);
+      auth.setReady(true);
+      await Future<void>.delayed(const Duration(milliseconds: 350));
+      expect(api.profileRequests, hasLength(2));
+
+      provider.dispose();
+    },
+  );
+
+  test(
+    'manual retry after a silently-rebuilt session still refetches',
+    () async {
+      final auth = _FakeWfwAuth(ready: true);
+      final api = _ControllableWfwApiService();
+      final provider = UserInfoProvider(auth, api);
+      await Future<void>.delayed(Duration.zero);
+      expect(api.profileRequests, hasLength(1));
+
+      // 首次取数因会话失效失败
+      api.fail(0, const UnauthenticatedException());
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+      expect(provider.error, isTrue);
+
+      // invalidate 无声：provider 记录的边沿状态仍停留在 ready，
+      // 此时 wfw 实际未就绪。手动重试走 ensureAuthenticated 预热，
+      // 成功后 ready 重通知不构成边沿，retry() 必须显式兜底调度取数。
+      auth.setReadySilently(false);
+      provider.retry();
+      await Future<void>.delayed(const Duration(milliseconds: 350));
+      expect(auth.ensureAuthenticatedCalls, 1);
+      expect(api.profileRequests, hasLength(2));
+
+      provider.dispose();
+    },
+  );
 }
 
 typedef _PersistenceRequest = ({
@@ -124,6 +179,7 @@ class _FakeWfwAuth extends ChangeNotifier implements WfwAuth {
   _FakeWfwAuth({required bool ready}) : _ready = ready;
 
   bool _ready;
+  int ensureAuthenticatedCalls = 0;
 
   @override
   bool get isReady => _ready;
@@ -134,6 +190,17 @@ class _FakeWfwAuth extends ChangeNotifier implements WfwAuth {
   void setReady(bool value) {
     _ready = value;
     notifyListeners();
+  }
+
+  /// 静默切换状态（不 notify）：模拟 invalidate() 的无声失效。
+  void setReadySilently(bool value) {
+    _ready = value;
+  }
+
+  @override
+  Future<void> ensureAuthenticated() async {
+    ensureAuthenticatedCalls++;
+    setReady(true);
   }
 
   @override
@@ -166,6 +233,11 @@ class _ControllableWfwApiService implements WfwApiService {
     labelRequests[index].complete([
       {'owner': number},
     ]);
+  }
+
+  void fail(int index, Object error) {
+    profileRequests[index].completeError(error);
+    labelRequests[index].completeError(error);
   }
 
   @override

--- a/test/wfw_auth_test.dart
+++ b/test/wfw_auth_test.dart
@@ -6,6 +6,7 @@ import 'package:bugaoshan/injection/injector.dart';
 import 'package:bugaoshan/services/api/wfw_api_service.dart';
 import 'package:bugaoshan/services/auth/cookie_client.dart';
 import 'package:bugaoshan/services/auth/scu_auth.dart';
+import 'package:bugaoshan/services/auth/scu_exceptions.dart';
 import 'package:bugaoshan/services/auth/wfw_auth.dart';
 import 'package:bugaoshan/utils/auth_logger.dart';
 
@@ -31,13 +32,23 @@ void main() {
     final firstClient = CookieClient(
       inner: MockClient((request) async {
         firstWarmUps++;
-        return http.Response('first ready', 200, request: request);
+        return http.Response(
+          'first ready',
+          200,
+          headers: {'set-cookie': 'JSESSIONID=first; Path=/'},
+          request: request,
+        );
       }),
     );
     final secondClient = CookieClient(
       inner: MockClient((request) async {
         secondWarmUps++;
-        return http.Response('second ready', 200, request: request);
+        return http.Response(
+          'second ready',
+          200,
+          headers: {'set-cookie': 'JSESSIONID=second; Path=/'},
+          request: request,
+        );
       }),
     );
     final scuAuth = _SwitchableScuAuth(
@@ -66,7 +77,12 @@ void main() {
       inner: MockClient((request) async {
         if (request.url.path == '/') {
           warmUps++;
-          return http.Response('ready', 200, request: request);
+          return http.Response(
+            'ready',
+            200,
+            headers: {'set-cookie': 'JSESSIONID=warm; Path=/'},
+            request: request,
+          );
         }
         if (request.url.path == '/uc/wap/user/get-info') {
           profileRequests++;
@@ -95,6 +111,30 @@ void main() {
     expect(profile?['realname'], 'Test User');
     expect(profileRequests, 2);
     expect(warmUps, 2);
+
+    wfwAuth.dispose();
+  });
+
+  test('warm-up that binds no wfw cookie is not treated as ready', () async {
+    var warmUps = 0;
+    final client = CookieClient(
+      inner: MockClient((request) async {
+        warmUps++;
+        // 匿名首页：200 但不走 SSO 重定向、不下发任何 cookie
+        return http.Response('anonymous homepage', 200, request: request);
+      }),
+    );
+    final scuAuth = _SwitchableScuAuth(prefs, logger: logger, client: client);
+    final wfwAuth = WfwAuth(scuAuth, logger: logger);
+
+    // 仅凭 200 不得标记 ready：否则业务请求必然失效，「invalidate →
+    // 预热误报 ready → 监听方重新取数 → 再失效」会无限循环。
+    await expectLater(
+      wfwAuth.getClient(),
+      throwsA(isA<UnauthenticatedException>()),
+    );
+    expect(wfwAuth.isReady, isFalse);
+    expect(warmUps, 1); // 有界：失败即停，不自旋
 
     wfwAuth.dispose();
   });


### PR DESCRIPTION
- wfw 首页匿名访问也直接返回 200（不走 SSO 重定向、不下发 cookie）， 预热仅凭状态码判就绪导致 session 未建立也误报 ready
- UserInfoProvider 对每次 ready 通知都重新取数（电平触发）， 与重试路径的 invalidate → 预热 → ready 重通知形成正反馈环， 每约 600ms 一轮无限请求 wfw 接口

修复：
- WfwAuth 预热后校验 wfw 域 cookie 已实际写入 jar，否则抛 UnauthenticatedException，杜绝误报 ready（新增 CookieClient.hasCookiesFor）
- UserInfoProvider 改为 unknown→ready 边沿触发取数，结构性斩断 「ready 重通知 → 取数失败 → 再 ready」循环
- retry() 对无声失效（invalidate 不发通知）后重建会话的场景显式 兜底调度，避免边沿触发下手动重试失效

测试：wfw_auth_test 新增「预热未绑定 cookie 不得就绪」用例；
user_info_provider_test 新增「ready 重复通知不重新取数」与
「静默失效后手动重试仍可恢复」用例