### PR TITLE
feat(home): 新增主页 Tab 左右平移切页动画并联动全局动画时长配置

### DIFF
--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -116,12 +116,18 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver {
                 final isWide = constraints.maxWidth >= 600;
                 final showRail = isWide && visibleIds.length >= 2;
                 final showBar = !isWide && visibleIds.length >= 2;
-                final pageContent = AuthScopedIndexedStack(
-                  authListenable: authProvider,
-                  isAuthenticated: () => authProvider.isLoggedIn,
-                  visibleIds: visibleIds,
-                  selectedIndex: _currentIndex,
-                  pageBuilder: (id) => campusItemConfigById(id).page(),
+                final pageContent = ValueListenableBuilder<Duration>(
+                  valueListenable: appConfig.cardSizeAnimationDuration,
+                  builder: (context, animDuration, _) {
+                    return AuthScopedIndexedStack(
+                      authListenable: authProvider,
+                      isAuthenticated: () => authProvider.isLoggedIn,
+                      visibleIds: visibleIds,
+                      selectedIndex: _currentIndex,
+                      duration: animDuration,
+                      pageBuilder: (id) => campusItemConfigById(id).page(),
+                    );
+                  },
                 );
                 return Scaffold(
                   body: Row(

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -125,6 +125,7 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver {
                       visibleIds: visibleIds,
                       selectedIndex: _currentIndex,
                       duration: animDuration,
+                      axis: showRail ? Axis.vertical : Axis.horizontal,
                       pageBuilder: (id) => campusItemConfigById(id).page(),
                     );
                   },

--- a/lib/widgets/common/auth_scoped_indexed_stack.dart
+++ b/lib/widgets/common/auth_scoped_indexed_stack.dart
@@ -13,6 +13,8 @@ class AuthScopedIndexedStack extends StatefulWidget {
     required this.visibleIds,
     required this.selectedIndex,
     required this.pageBuilder,
+    this.duration = const Duration(milliseconds: 300),
+    this.enableAnimation = true,
   });
 
   final Listenable authListenable;
@@ -20,31 +22,72 @@ class AuthScopedIndexedStack extends StatefulWidget {
   final List<String> visibleIds;
   final int selectedIndex;
   final Widget Function(String id) pageBuilder;
+  final Duration duration;
+  final bool enableAnimation;
 
   @override
   State<AuthScopedIndexedStack> createState() => _AuthScopedIndexedStackState();
 }
 
-class _AuthScopedIndexedStackState extends State<AuthScopedIndexedStack> {
+class _AuthScopedIndexedStackState extends State<AuthScopedIndexedStack>
+    with SingleTickerProviderStateMixin {
   final Map<String, Widget> _pageCache = {};
   late bool _wasAuthenticated;
   int _authGeneration = 0;
+
+  late AnimationController _animController;
+  late Animation<double> _fadeAnim;
+  late Animation<Offset> _slideAnim;
+  bool _isMovingRight = true;
 
   @override
   void initState() {
     super.initState();
     _wasAuthenticated = widget.isAuthenticated();
     widget.authListenable.addListener(_handleAuthChanged);
+
+    _animController = AnimationController(
+      vsync: this,
+      duration: widget.duration,
+      value: 1.0,
+    );
+    _fadeAnim = CurvedAnimation(
+      parent: _animController,
+      curve: Curves.easeInOut,
+    );
+    _updateSlideAnim();
+  }
+
+  void _updateSlideAnim() {
+    final beginOffset = _isMovingRight ? const Offset(1.0, 0.0) : const Offset(-1.0, 0.0);
+    _slideAnim = Tween<Offset>(
+      begin: beginOffset,
+      end: Offset.zero,
+    ).animate(
+      CurvedAnimation(
+        parent: _animController,
+        curve: Curves.fastOutSlowIn,
+      ),
+    );
   }
 
   @override
   void didUpdateWidget(covariant AuthScopedIndexedStack oldWidget) {
     super.didUpdateWidget(oldWidget);
+    if (oldWidget.duration != widget.duration) {
+      _animController.duration = widget.duration;
+    }
     if (oldWidget.authListenable != widget.authListenable) {
       oldWidget.authListenable.removeListener(_handleAuthChanged);
       widget.authListenable.addListener(_handleAuthChanged);
     }
     _resetForAuthenticationBoundary();
+
+    if (oldWidget.selectedIndex != widget.selectedIndex && widget.enableAnimation) {
+      _isMovingRight = widget.selectedIndex > oldWidget.selectedIndex;
+      _updateSlideAnim();
+      _animController.forward(from: 0.0);
+    }
   }
 
   void _handleAuthChanged() {
@@ -65,6 +108,7 @@ class _AuthScopedIndexedStackState extends State<AuthScopedIndexedStack> {
   @override
   void dispose() {
     widget.authListenable.removeListener(_handleAuthChanged);
+    _animController.dispose();
     super.dispose();
   }
 
@@ -88,9 +132,23 @@ class _AuthScopedIndexedStackState extends State<AuthScopedIndexedStack> {
         .forEach(_pageCache.remove);
 
     final selectedIndex = widget.selectedIndex.clamp(0, visibleIds.length - 1);
+    final selectedId = visibleIds[selectedIndex];
+
     return IndexedStack(
       index: selectedIndex,
-      children: visibleIds.map((id) => _pageCache[id]!).toList(),
+      children: visibleIds.map((id) {
+        final child = _pageCache[id]!;
+        if (id == selectedId && widget.enableAnimation) {
+          return SlideTransition(
+            position: _slideAnim,
+            child: FadeTransition(
+              opacity: _fadeAnim,
+              child: child,
+            ),
+          );
+        }
+        return child;
+      }).toList(),
     );
   }
 }

--- a/lib/widgets/common/auth_scoped_indexed_stack.dart
+++ b/lib/widgets/common/auth_scoped_indexed_stack.dart
@@ -180,30 +180,18 @@ class _AuthScopedIndexedStackState extends State<AuthScopedIndexedStack>
         final isSelected = (id == selectedId);
         final isPrevious = (id == prevId);
 
-        if (isAnimating) {
-          if (isSelected) {
-            return SlideTransition(
-              position: _slideAnimIn,
-              child: FadeTransition(
-                opacity: _fadeAnimIn,
-                child: child,
-              ),
-            );
-          }
-          if (isPrevious) {
-            return SlideTransition(
-              position: _slideAnimOut,
-              child: FadeTransition(
-                opacity: _fadeAnimOut,
-                child: child,
-              ),
-            );
-          }
-        }
+        final slideAnim = isPrevious ? _slideAnimOut : _slideAnimIn;
+        final fadeAnim = isPrevious ? _fadeAnimOut : _fadeAnimIn;
 
         return Offstage(
-          offstage: !isSelected,
-          child: child,
+          offstage: !isSelected && !isPrevious,
+          child: SlideTransition(
+            position: slideAnim,
+            child: FadeTransition(
+              opacity: fadeAnim,
+              child: child,
+            ),
+          ),
         );
       }).toList(),
     );

--- a/lib/widgets/common/auth_scoped_indexed_stack.dart
+++ b/lib/widgets/common/auth_scoped_indexed_stack.dart
@@ -35,9 +35,13 @@ class _AuthScopedIndexedStackState extends State<AuthScopedIndexedStack>
   late bool _wasAuthenticated;
   int _authGeneration = 0;
 
+  int? _previousIndex;
   late AnimationController _animController;
-  late Animation<double> _fadeAnim;
-  late Animation<Offset> _slideAnim;
+  late CurvedAnimation _animationCurve;
+  late Animation<double> _fadeAnimIn;
+  late Animation<double> _fadeAnimOut;
+  late Animation<Offset> _slideAnimIn;
+  late Animation<Offset> _slideAnimOut;
   bool _isMovingRight = true;
 
   @override
@@ -51,24 +55,39 @@ class _AuthScopedIndexedStackState extends State<AuthScopedIndexedStack>
       duration: widget.duration,
       value: 1.0,
     );
-    _fadeAnim = CurvedAnimation(
+    _animController.addStatusListener((status) {
+      if (status == AnimationStatus.completed) {
+        if (mounted && _previousIndex != null) {
+          setState(() {
+            _previousIndex = null;
+          });
+        }
+      }
+    });
+
+    _animationCurve = CurvedAnimation(
       parent: _animController,
-      curve: Curves.easeInOut,
+      curve: Curves.fastOutSlowIn,
     );
-    _updateSlideAnim();
+
+    _fadeAnimIn = Tween<double>(begin: 0.0, end: 1.0).animate(_animationCurve);
+    _fadeAnimOut = Tween<double>(begin: 1.0, end: 0.0).animate(_animationCurve);
+    _updateAnimations();
   }
 
-  void _updateSlideAnim() {
-    final beginOffset = _isMovingRight ? const Offset(1.0, 0.0) : const Offset(-1.0, 0.0);
-    _slideAnim = Tween<Offset>(
-      begin: beginOffset,
+  void _updateAnimations() {
+    final beginIn = _isMovingRight ? const Offset(1.0, 0.0) : const Offset(-1.0, 0.0);
+    final endOut = _isMovingRight ? const Offset(-1.0, 0.0) : const Offset(1.0, 0.0);
+
+    _slideAnimIn = Tween<Offset>(
+      begin: beginIn,
       end: Offset.zero,
-    ).animate(
-      CurvedAnimation(
-        parent: _animController,
-        curve: Curves.fastOutSlowIn,
-      ),
-    );
+    ).animate(_animationCurve);
+
+    _slideAnimOut = Tween<Offset>(
+      begin: Offset.zero,
+      end: endOut,
+    ).animate(_animationCurve);
   }
 
   @override
@@ -83,10 +102,16 @@ class _AuthScopedIndexedStackState extends State<AuthScopedIndexedStack>
     }
     _resetForAuthenticationBoundary();
 
-    if (oldWidget.selectedIndex != widget.selectedIndex && widget.enableAnimation) {
-      _isMovingRight = widget.selectedIndex > oldWidget.selectedIndex;
-      _updateSlideAnim();
-      _animController.forward(from: 0.0);
+    if (oldWidget.selectedIndex != widget.selectedIndex) {
+      if (widget.enableAnimation && widget.duration > Duration.zero) {
+        _previousIndex = oldWidget.selectedIndex;
+        _isMovingRight = widget.selectedIndex > oldWidget.selectedIndex;
+        _updateAnimations();
+        _animController.forward(from: 0.0);
+      } else {
+        _previousIndex = null;
+        _animController.value = 1.0;
+      }
     }
   }
 
@@ -101,6 +126,7 @@ class _AuthScopedIndexedStackState extends State<AuthScopedIndexedStack>
 
     _wasAuthenticated = authenticated;
     _authGeneration++;
+    _previousIndex = null;
     _pageCache.clear();
     return true;
   }
@@ -108,6 +134,7 @@ class _AuthScopedIndexedStackState extends State<AuthScopedIndexedStack>
   @override
   void dispose() {
     widget.authListenable.removeListener(_handleAuthChanged);
+    _animationCurve.dispose();
     _animController.dispose();
     super.dispose();
   }
@@ -134,20 +161,50 @@ class _AuthScopedIndexedStackState extends State<AuthScopedIndexedStack>
     final selectedIndex = widget.selectedIndex.clamp(0, visibleIds.length - 1);
     final selectedId = visibleIds[selectedIndex];
 
-    return IndexedStack(
-      index: selectedIndex,
+    final isAnimating = widget.enableAnimation &&
+        _previousIndex != null &&
+        _previousIndex != selectedIndex &&
+        _animController.isAnimating;
+
+    final prevIndex = _previousIndex != null
+        ? _previousIndex!.clamp(0, visibleIds.length - 1)
+        : null;
+    final prevId = (prevIndex != null && prevIndex != selectedIndex)
+        ? visibleIds[prevIndex]
+        : null;
+
+    return Stack(
+      fit: StackFit.expand,
       children: visibleIds.map((id) {
         final child = _pageCache[id]!;
-        if (id == selectedId && widget.enableAnimation) {
-          return SlideTransition(
-            position: _slideAnim,
-            child: FadeTransition(
-              opacity: _fadeAnim,
-              child: child,
-            ),
-          );
+        final isSelected = (id == selectedId);
+        final isPrevious = (id == prevId);
+
+        if (isAnimating) {
+          if (isSelected) {
+            return SlideTransition(
+              position: _slideAnimIn,
+              child: FadeTransition(
+                opacity: _fadeAnimIn,
+                child: child,
+              ),
+            );
+          }
+          if (isPrevious) {
+            return SlideTransition(
+              position: _slideAnimOut,
+              child: FadeTransition(
+                opacity: _fadeAnimOut,
+                child: child,
+              ),
+            );
+          }
         }
-        return child;
+
+        return Offstage(
+          offstage: !isSelected,
+          child: child,
+        );
       }).toList(),
     );
   }

--- a/lib/widgets/common/auth_scoped_indexed_stack.dart
+++ b/lib/widgets/common/auth_scoped_indexed_stack.dart
@@ -15,6 +15,7 @@ class AuthScopedIndexedStack extends StatefulWidget {
     required this.pageBuilder,
     this.duration = const Duration(milliseconds: 300),
     this.enableAnimation = true,
+    this.axis = Axis.horizontal,
   });
 
   final Listenable authListenable;
@@ -24,6 +25,7 @@ class AuthScopedIndexedStack extends StatefulWidget {
   final Widget Function(String id) pageBuilder;
   final Duration duration;
   final bool enableAnimation;
+  final Axis axis;
 
   @override
   State<AuthScopedIndexedStack> createState() => _AuthScopedIndexedStackState();
@@ -76,8 +78,16 @@ class _AuthScopedIndexedStackState extends State<AuthScopedIndexedStack>
   }
 
   void _updateAnimations() {
-    final beginIn = _isMovingRight ? const Offset(1.0, 0.0) : const Offset(-1.0, 0.0);
-    final endOut = _isMovingRight ? const Offset(-1.0, 0.0) : const Offset(1.0, 0.0);
+    final Offset beginIn;
+    final Offset endOut;
+
+    if (widget.axis == Axis.vertical) {
+      beginIn = _isMovingRight ? const Offset(0.0, 1.0) : const Offset(0.0, -1.0);
+      endOut = _isMovingRight ? const Offset(0.0, -1.0) : const Offset(0.0, 1.0);
+    } else {
+      beginIn = _isMovingRight ? const Offset(1.0, 0.0) : const Offset(-1.0, 0.0);
+      endOut = _isMovingRight ? const Offset(-1.0, 0.0) : const Offset(1.0, 0.0);
+    }
 
     _slideAnimIn = Tween<Offset>(
       begin: beginIn,
@@ -102,15 +112,21 @@ class _AuthScopedIndexedStackState extends State<AuthScopedIndexedStack>
     }
     _resetForAuthenticationBoundary();
 
-    if (oldWidget.selectedIndex != widget.selectedIndex) {
-      if (widget.enableAnimation && widget.duration > Duration.zero) {
+    final bool axisChanged = oldWidget.axis != widget.axis;
+    final bool indexChanged = oldWidget.selectedIndex != widget.selectedIndex;
+
+    if (indexChanged || axisChanged) {
+      if (indexChanged && widget.enableAnimation && widget.duration > Duration.zero) {
         _previousIndex = oldWidget.selectedIndex;
         _isMovingRight = widget.selectedIndex > oldWidget.selectedIndex;
         _updateAnimations();
         _animController.forward(from: 0.0);
       } else {
-        _previousIndex = null;
-        _animController.value = 1.0;
+        if (indexChanged) {
+          _previousIndex = null;
+          _animController.value = 1.0;
+        }
+        _updateAnimations();
       }
     }
   }
@@ -161,11 +177,6 @@ class _AuthScopedIndexedStackState extends State<AuthScopedIndexedStack>
     final selectedIndex = widget.selectedIndex.clamp(0, visibleIds.length - 1);
     final selectedId = visibleIds[selectedIndex];
 
-    final isAnimating = widget.enableAnimation &&
-        _previousIndex != null &&
-        _previousIndex != selectedIndex &&
-        _animController.isAnimating;
-
     final prevIndex = _previousIndex != null
         ? _previousIndex!.clamp(0, visibleIds.length - 1)
         : null;
@@ -173,27 +184,30 @@ class _AuthScopedIndexedStackState extends State<AuthScopedIndexedStack>
         ? visibleIds[prevIndex]
         : null;
 
-    return Stack(
-      fit: StackFit.expand,
-      children: visibleIds.map((id) {
-        final child = _pageCache[id]!;
-        final isSelected = (id == selectedId);
-        final isPrevious = (id == prevId);
+    return ClipRect(
+      child: Stack(
+        fit: StackFit.expand,
+        clipBehavior: Clip.hardEdge,
+        children: visibleIds.map((id) {
+          final child = _pageCache[id]!;
+          final isSelected = (id == selectedId);
+          final isPrevious = (id == prevId);
 
-        final slideAnim = isPrevious ? _slideAnimOut : _slideAnimIn;
-        final fadeAnim = isPrevious ? _fadeAnimOut : _fadeAnimIn;
+          final slideAnim = isPrevious ? _slideAnimOut : _slideAnimIn;
+          final fadeAnim = isPrevious ? _fadeAnimOut : _fadeAnimIn;
 
-        return Offstage(
-          offstage: !isSelected && !isPrevious,
-          child: SlideTransition(
-            position: slideAnim,
-            child: FadeTransition(
-              opacity: fadeAnim,
-              child: child,
+          return Offstage(
+            offstage: !isSelected && !isPrevious,
+            child: SlideTransition(
+              position: slideAnim,
+              child: FadeTransition(
+                opacity: fadeAnim,
+                child: child,
+              ),
             ),
-          ),
-        );
-      }).toList(),
+          );
+        }).toList(),
+      ),
     );
   }
 }

--- a/test/auth_scoped_indexed_stack_test.dart
+++ b/test/auth_scoped_indexed_stack_test.dart
@@ -34,6 +34,45 @@ void main() {
     expect(disposed, 2);
     expect(find.text('probe-3'), findsOneWidget);
   });
+
+  testWidgets('切换 selectedIndex 时能正常播放左右滑动切页动画并保持页面状态', (tester) async {
+    final authenticated = ValueNotifier<bool>(true);
+    final selectedIndex = ValueNotifier<int>(0);
+
+    Widget buildStack() {
+      return MaterialApp(
+        home: ValueListenableBuilder<int>(
+          valueListenable: selectedIndex,
+          builder: (context, index, _) {
+            return AuthScopedIndexedStack(
+              authListenable: authenticated,
+              isAuthenticated: () => true,
+              visibleIds: const ['page-1', 'page-2'],
+              selectedIndex: index,
+              duration: const Duration(milliseconds: 300),
+              pageBuilder: (id) => Text('content-$id'),
+            );
+          },
+        ),
+      );
+    }
+
+    await tester.pumpWidget(buildStack());
+    expect(find.text('content-page-1'), findsOneWidget);
+
+    selectedIndex.value = 1;
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 150));
+    expect(find.text('content-page-2'), findsOneWidget);
+
+    await tester.pumpAndSettle();
+    expect(find.text('content-page-2'), findsOneWidget);
+
+    selectedIndex.value = 0;
+    await tester.pump();
+    await tester.pumpAndSettle();
+    expect(find.text('content-page-1'), findsOneWidget);
+  });
 }
 
 class _LifecycleProbe extends StatefulWidget {


### PR DESCRIPTION
## 📌 概述 (Overview)

为 `HomePage` 的底部导航栏 Tab 切换新增了平滑的 **方向性左右平移与淡入（Horizontal Slide & Fade）切页动画**，并将动画时长与全局配置项 `cardSizeAnimationDuration` 进行动态绑定。

---

## ✨ 主要变更 (Key Changes)

1. **`AuthScopedIndexedStack` 支持方向性左右平移切页动画**：
   - 切换至右侧 Tab 时，新页面从右向左滑动切入 (`Offset(1.0, 0) -> Offset(0, 0)`)。
   - 切换至左侧 Tab 时，新页面从左向右滑动切入 (`Offset(-1.0, 0) -> Offset(0, 0)`)。
   - 配合 `Curves.fastOutSlowIn` 曲线与 `FadeTransition`，切换体验直观润滑。
   - 完整保留了原有的页面状态缓存（如滚动位置、表单输入）与账号隔离安全机制。

2. **联动全局动画时长配置 (`cardSizeAnimationDuration`)**：
   - 在 `HomePage` 中监听 `appConfig.cardSizeAnimationDuration`，用户在「设置 -> 动画时长」中自定义的数值可即时作用于主页切页动画。

3. **单元测试与代码质量**：
   - 在 `test/auth_scoped_indexed_stack_test.dart` 中补充了左右平移切页动画与状态保留的测试用例。
   - 已通过 `flutter analyze` 静态分析与自动化单测。

---

## 🧪 验证方式 (Verification)

- 运行 `flutter test test/auth_scoped_indexed_stack_test.dart` 测试全部通过。
- 在应用中点击底部导航栏切换 Tab，确认新页面按点击方向流畅推入。
- 在「设置 -> 动画时长」中拖动调整数值（如 `150ms` / `400ms`），确认主页切页动画速度同步变化。
