### PR TITLE
fix: 修复之前提交的PR #183引入的问题

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -149,6 +149,8 @@
         "description": "Toggle in the developer page to force the CAPTCHA dialog when downloading attachments, for testing the CAPTCHA flow."
     },
     "forceCaptchaForDownloadHint": "When enabled, tapping an attachment download will show the CAPTCHA dialog for testing.",
+    "captchaDialogTitle": "Enter CAPTCHA",
+    "captchaCancelled": "CAPTCHA cancelled",
     "downloading": "Downloading",
     "updateFailed": "Update failed",
     "notificationDownloading": "Downloading... {percent}%",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -144,6 +144,11 @@
         "description": "Toggle in the test page that makes the home/about update checks target the preview release channel."
     },
     "usePreviewUpdateSourceHint": "Affects only the automatic checks on the home and about pages. The test page always checks both channels.",
+    "forceCaptchaForDownload": "Force CAPTCHA for Download",
+    "@forceCaptchaForDownload": {
+        "description": "Toggle in the developer page to force the CAPTCHA dialog when downloading attachments, for testing the CAPTCHA flow."
+    },
+    "forceCaptchaForDownloadHint": "When enabled, tapping an attachment download will show the CAPTCHA dialog for testing.",
     "downloading": "Downloading",
     "updateFailed": "Update failed",
     "notificationDownloading": "Downloading... {percent}%",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -757,6 +757,18 @@ abstract class AppLocalizations {
   /// **'Affects only the automatic checks on the home and about pages. The test page always checks both channels.'**
   String get usePreviewUpdateSourceHint;
 
+  /// Toggle in the developer page to force the CAPTCHA dialog when downloading attachments, for testing the CAPTCHA flow.
+  ///
+  /// In en, this message translates to:
+  /// **'Force CAPTCHA for Download'**
+  String get forceCaptchaForDownload;
+
+  /// No description provided for @forceCaptchaForDownloadHint.
+  ///
+  /// In en, this message translates to:
+  /// **'When enabled, tapping an attachment download will show the CAPTCHA dialog for testing.'**
+  String get forceCaptchaForDownloadHint;
+
   /// No description provided for @downloading.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -769,6 +769,18 @@ abstract class AppLocalizations {
   /// **'When enabled, tapping an attachment download will show the CAPTCHA dialog for testing.'**
   String get forceCaptchaForDownloadHint;
 
+  /// No description provided for @captchaDialogTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Enter CAPTCHA'**
+  String get captchaDialogTitle;
+
+  /// No description provided for @captchaCancelled.
+  ///
+  /// In en, this message translates to:
+  /// **'CAPTCHA cancelled'**
+  String get captchaCancelled;
+
   /// No description provided for @downloading.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -362,6 +362,13 @@ class AppLocalizationsEn extends AppLocalizations {
       'Affects only the automatic checks on the home and about pages. The test page always checks both channels.';
 
   @override
+  String get forceCaptchaForDownload => 'Force CAPTCHA for Download';
+
+  @override
+  String get forceCaptchaForDownloadHint =>
+      'When enabled, tapping an attachment download will show the CAPTCHA dialog for testing.';
+
+  @override
   String get downloading => 'Downloading';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -369,6 +369,12 @@ class AppLocalizationsEn extends AppLocalizations {
       'When enabled, tapping an attachment download will show the CAPTCHA dialog for testing.';
 
   @override
+  String get captchaDialogTitle => 'Enter CAPTCHA';
+
+  @override
+  String get captchaCancelled => 'CAPTCHA cancelled';
+
+  @override
   String get downloading => 'Downloading';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -356,6 +356,12 @@ class AppLocalizationsZh extends AppLocalizations {
   String get forceCaptchaForDownloadHint => '开启后点击附件下载将直接弹出验证码弹窗，用于测试验证码流程。';
 
   @override
+  String get captchaDialogTitle => '请输入验证码';
+
+  @override
+  String get captchaCancelled => '验证码已取消';
+
+  @override
   String get downloading => '正在下载';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -350,6 +350,12 @@ class AppLocalizationsZh extends AppLocalizations {
   String get usePreviewUpdateSourceHint => '仅影响首页和关于页面的自动检查；测试页面始终同时检查两个渠道。';
 
   @override
+  String get forceCaptchaForDownload => '强制下载验证码';
+
+  @override
+  String get forceCaptchaForDownloadHint => '开启后点击附件下载将直接弹出验证码弹窗，用于测试验证码流程。';
+
+  @override
   String get downloading => '正在下载';
 
   @override

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -143,6 +143,8 @@
     "usePreviewUpdateSourceHint": "仅影响首页和关于页面的自动检查；测试页面始终同时检查两个渠道。",
     "forceCaptchaForDownload": "强制下载验证码",
     "forceCaptchaForDownloadHint": "开启后点击附件下载将直接弹出验证码弹窗，用于测试验证码流程。",
+    "captchaDialogTitle": "请输入验证码",
+    "captchaCancelled": "验证码已取消",
     "downloading": "正在下载",
     "updateFailed": "更新失败",
     "notificationDownloading": "正在下载... {percent}%",

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -141,6 +141,8 @@
     "updateToPreview": "更新到最新版（包括预览版）",
     "usePreviewUpdateSource": "软件更新使用预览版源",
     "usePreviewUpdateSourceHint": "仅影响首页和关于页面的自动检查；测试页面始终同时检查两个渠道。",
+    "forceCaptchaForDownload": "强制下载验证码",
+    "forceCaptchaForDownloadHint": "开启后点击附件下载将直接弹出验证码弹窗，用于测试验证码流程。",
     "downloading": "正在下载",
     "updateFailed": "更新失败",
     "notificationDownloading": "正在下载... {percent}%",

--- a/lib/pages/dev/dev_page.dart
+++ b/lib/pages/dev/dev_page.dart
@@ -74,20 +74,6 @@ class _DevPageState extends State<DevPage> {
   ) {
     return [
       const SizedBox(height: 16),
-      ValueListenableBuilder<bool>(
-        valueListenable: _appConfig.forceCaptchaForDownload,
-        builder: (context, value, _) => SwitchListTile(
-          contentPadding: EdgeInsets.zero,
-          title: const Text('强制下载验证码'),
-          subtitle: Text(
-            '开启后点击附件下载将直接弹出验证码弹窗，用于测试验证码流程',
-            style: Theme.of(context).textTheme.bodySmall,
-          ),
-          value: value,
-          onChanged: (v) => _appConfig.forceCaptchaForDownload.value = v,
-        ),
-      ),
-      const Divider(),
       Padding(
         padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
         child: Text(
@@ -155,6 +141,19 @@ class _DevPageState extends State<DevPage> {
           const Divider(),
           const ChangelogTile(),
           const Divider(),
+          ValueListenableBuilder<bool>(
+            valueListenable: _appConfig.forceCaptchaForDownload,
+            builder: (context, value, _) => SwitchListTile(
+              secondary: const Icon(Icons.tab),
+              title: Text(localizations.forceCaptchaForDownload),
+              subtitle: Text(
+                localizations.forceCaptchaForDownloadHint,
+                style: Theme.of(context).textTheme.bodySmall,
+              ),
+              value: value,
+              onChanged: (v) => _appConfig.forceCaptchaForDownload.value = v,
+            ),
+          ),
           if (_supportsUpdate) ..._buildUpdateSection(context, localizations),
         ],
       ),

--- a/lib/widgets/webview/webview_notice_handlers.dart
+++ b/lib/widgets/webview/webview_notice_handlers.dart
@@ -123,7 +123,7 @@ mixin WebViewNoticeHandlers<T extends StatefulWidget> on State<T> {
         manager.updateTask(
           task,
           status: DownloadStatus.error,
-          errorMessage: '验证码已取消',
+          errorMessage: AppLocalizations.of(context)!.captchaCancelled,
         );
       }
     } catch (e) {
@@ -342,7 +342,7 @@ class _CaptchaWebViewDialogState extends State<_CaptchaWebViewDialog> {
         child: Column(
           children: [
             AppBar(
-              title: Text('请输入验证码'),
+              title: Text(AppLocalizations.of(context)!.captchaDialogTitle),
               leading: IconButton(
                 icon: const Icon(Icons.close),
                 onPressed: () => Navigator.pop(context, false),


### PR DESCRIPTION
在之前的PR https://github.com/The-Brotherhood-of-SCU/Bugaoshan/pull/183 中，我做出了一些界面更改，但是这些新引入的界面存在一些问题：
1. 加的调试用的开关因为不小心放到了```_buildUpdateSection```里面，导致在iOS上面不显示（iOS端不显示更新选项）
2. 增加的开关前面没有图标，不够美观
3. 之前引入的界面没做翻译

这个PR就是用来修复上面的问题

~题外话：仓库的Material Design图标库不够新，在Google Fonts能查到的图标居然在仓库这里引入时提示没有，只能先用一个长得还算能看过去的代替~