### PR TITLE
fix: 修复验证码下载弹窗与电费房间名显示问题，优化互动校历加载

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -553,6 +553,7 @@
     "networkDeviceOperationSuccess": "Operation successful",
     "captchaLoadFailed": "Failed to load captcha",
     "networkError": "Network error",
+    "calendarRefreshSuccess": "Calendar updated",
     "loginFailed": "Login failed",
     "invalidCaptcha": "Invalid captcha, please try again",
     "loginFailedWillLock": "Login failed, {count} more attempt(s) will lock your account",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -2845,6 +2845,12 @@ abstract class AppLocalizations {
   /// **'Network error'**
   String get networkError;
 
+  /// No description provided for @calendarRefreshSuccess.
+  ///
+  /// In en, this message translates to:
+  /// **'Calendar updated'**
+  String get calendarRefreshSuccess;
+
   /// No description provided for @loginFailed.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1471,6 +1471,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get networkError => 'Network error';
 
   @override
+  String get calendarRefreshSuccess => 'Calendar updated';
+
+  @override
   String get loginFailed => 'Login failed';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -1426,6 +1426,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get networkError => '网络错误';
 
   @override
+  String get calendarRefreshSuccess => '校历已更新';
+
+  @override
   String get loginFailed => '登录失败';
 
   @override

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -533,6 +533,7 @@
     "networkDeviceOperationSuccess": "操作成功",
     "captchaLoadFailed": "验证码加载失败",
     "networkError": "网络错误",
+    "calendarRefreshSuccess": "校历已更新",
     "loginFailed": "登录失败",
     "invalidCaptcha": "验证码错误，请重试",
     "loginFailedWillLock": "登录失败，再输错 {count} 次将锁定账户",

--- a/lib/pages/campus/academic_calendar/academic_calendar_page.dart
+++ b/lib/pages/campus/academic_calendar/academic_calendar_page.dart
@@ -241,6 +241,10 @@ class _AcademicCalendarPageState extends State<AcademicCalendarPage>
       _interactiveData = data;
       _selectedSemester = _pickInitialSemester(data);
     });
+    final l10n = AppLocalizations.of(context)!;
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(SnackBar(content: Text(l10n.calendarRefreshSuccess)));
   }
 
   Future<void> _importSemesterToSystem() async {

--- a/lib/pages/campus/academic_calendar/academic_calendar_page.dart
+++ b/lib/pages/campus/academic_calendar/academic_calendar_page.dart
@@ -196,29 +196,10 @@ class _AcademicCalendarPageState extends State<AcademicCalendarPage>
           : await getIt<AcademicCalendarService>().fetchCalendarData();
       if (!mounted) return;
 
-      AcademicCalendarSemester? initialSemester;
-      final now = DateTime.now();
-      for (final semester in data.semesters) {
-        if (semester.isDateInSemester(now)) {
-          initialSemester = semester;
-          break;
-        }
-      }
-
-      if (initialSemester == null && data.semesters.isNotEmpty) {
-        for (final semester in data.semesters) {
-          if (semester.startDate.isAfter(now)) {
-            initialSemester = semester;
-            break;
-          }
-        }
-        initialSemester ??= data.semesters.last;
-      }
-
       if (mounted) {
         setState(() {
           _interactiveData = data;
-          _selectedSemester = initialSemester;
+          _selectedSemester = _pickInitialSemester(data);
           _interactiveLoading = false;
         });
       }
@@ -230,6 +211,36 @@ class _AcademicCalendarPageState extends State<AcademicCalendarPage>
         });
       }
     }
+  }
+
+  /// 从校历数据中挑选默认展示的学期：优先当前学期，其次最近的下学期。
+  AcademicCalendarSemester? _pickInitialSemester(AcademicCalendarData data) {
+    final now = DateTime.now();
+    for (final semester in data.semesters) {
+      if (semester.isDateInSemester(now)) return semester;
+    }
+    for (final semester in data.semesters) {
+      if (semester.startDate.isAfter(now)) return semester;
+    }
+    return data.semesters.isEmpty ? null : data.semesters.last;
+  }
+
+  /// 下拉刷新：网络拉取最新校历，成功则更新数据，失败保留现有数据并提示。
+  Future<void> _refreshInteractiveData() async {
+    final service = getIt<AcademicCalendarService>();
+    final data = await service.refreshCalendarData();
+    if (!mounted) return;
+    if (data == null) {
+      final l10n = AppLocalizations.of(context)!;
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text(l10n.networkError)));
+      return;
+    }
+    setState(() {
+      _interactiveData = data;
+      _selectedSemester = _pickInitialSemester(data);
+    });
   }
 
   Future<void> _importSemesterToSystem() async {
@@ -293,6 +304,7 @@ class _AcademicCalendarPageState extends State<AcademicCalendarPage>
               setState(() => _selectedSemester = semester);
             },
             onRetry: _loadInteractiveData,
+            onRefresh: _refreshInteractiveData,
           ),
           OfficialCalendarView(
             entries: _entries,

--- a/lib/pages/campus/academic_calendar/interactive_calendar_view.dart
+++ b/lib/pages/campus/academic_calendar/interactive_calendar_view.dart
@@ -14,6 +14,7 @@ class InteractiveCalendarView extends StatelessWidget {
   final String? error;
   final ValueChanged<AcademicCalendarSemester> onSemesterChanged;
   final VoidCallback onRetry;
+  final Future<void> Function()? onRefresh;
 
   const InteractiveCalendarView({
     super.key,
@@ -23,6 +24,7 @@ class InteractiveCalendarView extends StatelessWidget {
     this.error,
     required this.onSemesterChanged,
     required this.onRetry,
+    this.onRefresh,
   });
 
   @override
@@ -194,30 +196,35 @@ class InteractiveCalendarView extends StatelessWidget {
     final sortedEvents = List<AcademicCalendarEvent>.from(semester.events)
       ..sort((a, b) => a.date.compareTo(b.date));
 
-    return ListView.builder(
-      padding: const EdgeInsets.fromLTRB(16, 8, 16, 32),
-      itemCount: sortedEvents.length,
-      itemBuilder: (context, index) {
-        final event = sortedEvents[index];
-        final isLast = index == sortedEvents.length - 1;
+    return RefreshIndicator(
+      onRefresh: onRefresh ?? () async {},
+      child: ListView.builder(
+        // 内容不足一屏时也允许下拉触发刷新
+        physics: const AlwaysScrollableScrollPhysics(),
+        padding: const EdgeInsets.fromLTRB(16, 8, 16, 32),
+        itemCount: sortedEvents.length,
+        itemBuilder: (context, index) {
+          final event = sortedEvents[index];
+          final isLast = index == sortedEvents.length - 1;
 
-        return IntrinsicHeight(
-          child: Row(
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
-              // Left Column: Dot & Line
-              _buildTimelineIndicator(context, event, isLast, now),
-              // Right Column: Card Content
-              Expanded(
-                child: Padding(
-                  padding: const EdgeInsets.only(left: 12, bottom: 16),
-                  child: _buildEventCard(context, l10n, event, now),
+          return IntrinsicHeight(
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                // Left Column: Dot & Line
+                _buildTimelineIndicator(context, event, isLast, now),
+                // Right Column: Card Content
+                Expanded(
+                  child: Padding(
+                    padding: const EdgeInsets.only(left: 12, bottom: 16),
+                    child: _buildEventCard(context, l10n, event, now),
+                  ),
                 ),
-              ),
-            ],
-          ),
-        );
-      },
+              ],
+            ),
+          );
+        },
+      ),
     );
   }
 

--- a/lib/pages/campus/balance_query/balance_query_page.dart
+++ b/lib/pages/campus/balance_query/balance_query_page.dart
@@ -180,7 +180,13 @@ class _BalanceQueryPageState extends State<BalanceQueryPage> {
                         else
                           const SizedBox(width: 20),
                         const SizedBox(width: 8),
-                        Expanded(child: Text(binding.displayName)),
+                        Expanded(
+                          child: Text(
+                            binding.displayName,
+                            maxLines: 2,
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                        ),
                         IconButton(
                           icon: Icon(
                             Icons.delete_outline,

--- a/lib/pages/campus/balance_query/widgets/balance_card.dart
+++ b/lib/pages/campus/balance_query/widgets/balance_card.dart
@@ -144,19 +144,23 @@ class BalanceCardState extends State<BalanceCard> {
                         child: Row(
                           mainAxisSize: MainAxisSize.min,
                           children: [
-                            Text(
-                              _privacyHidden
-                                  ? widget.binding.displayName
-                                        .split(' ')
-                                        .take(2)
-                                        .join(' ')
-                                  : widget.binding.displayName,
-                              style: Theme.of(context).textTheme.bodySmall
-                                  ?.copyWith(
-                                    color: Theme.of(
-                                      context,
-                                    ).colorScheme.onSurfaceVariant,
-                                  ),
+                            Flexible(
+                              child: Text(
+                                _privacyHidden
+                                    ? widget.binding.displayName
+                                          .split(' ')
+                                          .take(2)
+                                          .join(' ')
+                                    : widget.binding.displayName,
+                                maxLines: 2,
+                                overflow: TextOverflow.ellipsis,
+                                style: Theme.of(context).textTheme.bodySmall
+                                    ?.copyWith(
+                                      color: Theme.of(
+                                        context,
+                                      ).colorScheme.onSurfaceVariant,
+                                    ),
+                              ),
                             ),
                             const SizedBox(width: 4),
                             Icon(

--- a/lib/pages/campus/downloads/file_utils.dart
+++ b/lib/pages/campus/downloads/file_utils.dart
@@ -237,11 +237,16 @@ class CaptchaRequiredException implements Exception {
   const CaptchaRequiredException();
 }
 
+/// 验证码表单页中用于识别「需要人工验证」的 DOM 标识（类名/字段名）。
+/// 服务端若改版导致标志失效，请在此追加新的标识。
+const List<String> _captchaPageMarkers = ['codeValue'];
+
 /// Detects if the HTTP response is a CAPTCHA HTML page.
 bool isCaptchaResponse(String? contentType, List<int> bodyBytes) {
   if (contentType == null || !contentType.contains('text/html')) return false;
+  // 取响应前 4KB 扫描；验证码表单通常位于页面头部脚本区。
   final head = utf8.decode(bodyBytes.take(4096).toList(), allowMalformed: true);
-  return head.contains('codeValue');
+  return _captchaPageMarkers.any(head.contains);
 }
 
 /// Downloads a file from [url] into `Bugaoshan/{dirName}/`.

--- a/lib/services/api/academic_calendar_service.dart
+++ b/lib/services/api/academic_calendar_service.dart
@@ -68,13 +68,33 @@ class AcademicCalendarService {
     return {'semesters': semesters};
   }
 
+  /// 优先本地数据（缓存 → 内置 asset）快速返回，避免首次打开等网络；
+  /// 仅当本地无数据（首次安装）时才兜底走网络。
   Future<AcademicCalendarData> fetchCalendarData() async {
+    final local = await _loadLocalCalendar();
+    if (local != null) return local;
+
     final client = _client ?? http.Client();
     for (final url in [_mirrorUrl, _remoteUrl]) {
       final calendar = await _tryFetch(client, url);
       if (calendar != null) return calendar;
     }
+    return AcademicCalendarData(semesters: []);
+  }
 
+  /// 下拉刷新：仅走网络拉取最新校历，成功写缓存并返回新数据，失败返回 null。
+  Future<AcademicCalendarData?> refreshCalendarData() async {
+    final client = _client ?? http.Client();
+    for (final url in [_mirrorUrl, _remoteUrl]) {
+      final calendar = await _tryFetch(client, url);
+      if (calendar != null) return calendar;
+    }
+    return null;
+  }
+
+  /// 读取本地校历：优先 SharedPreferences 缓存，其次内置 asset。
+  /// 两者都不可用时返回 null。
+  Future<AcademicCalendarData?> _loadLocalCalendar() async {
     final cached = _prefs.getString(_cacheKey);
     if (cached != null && cached.isNotEmpty) {
       try {
@@ -93,7 +113,7 @@ class AcademicCalendarService {
       return _parseCalendarJson(assetContent);
     } catch (e) {
       debugPrint('AcademicCalendarService: failed to load bundled asset: $e');
-      return AcademicCalendarData(semesters: []);
+      return null;
     }
   }
 

--- a/lib/services/api/academic_calendar_service.dart
+++ b/lib/services/api/academic_calendar_service.dart
@@ -75,9 +75,14 @@ class AcademicCalendarService {
     if (local != null) return local;
 
     final client = _client ?? http.Client();
-    for (final url in [_mirrorUrl, _remoteUrl]) {
-      final calendar = await _tryFetch(client, url);
-      if (calendar != null) return calendar;
+    try {
+      for (final url in [_mirrorUrl, _remoteUrl]) {
+        final calendar = await _tryFetch(client, url);
+        if (calendar != null) return calendar;
+      }
+    } finally {
+      // 仅关闭本次自建的 client；注入的 _client 由注入方管理生命周期。
+      if (_client == null) client.close();
     }
     return AcademicCalendarData(semesters: []);
   }
@@ -85,9 +90,13 @@ class AcademicCalendarService {
   /// 下拉刷新：仅走网络拉取最新校历，成功写缓存并返回新数据，失败返回 null。
   Future<AcademicCalendarData?> refreshCalendarData() async {
     final client = _client ?? http.Client();
-    for (final url in [_mirrorUrl, _remoteUrl]) {
-      final calendar = await _tryFetch(client, url);
-      if (calendar != null) return calendar;
+    try {
+      for (final url in [_mirrorUrl, _remoteUrl]) {
+        final calendar = await _tryFetch(client, url);
+        if (calendar != null) return calendar;
+      }
+    } finally {
+      if (_client == null) client.close();
     }
     return null;
   }
@@ -130,6 +139,9 @@ class AcademicCalendarService {
         final data = jsonDecode(response.body);
         if (data is Map<String, dynamic> && data.containsKey('semesters')) {
           final calendar = _parseCalendarJson(response.body);
+          // 空校历（semesters 为空数组）不写缓存：本地优先策略下写入后
+          // 会一直展示「无校历数据」且不再回退到内置 asset，造成污染。
+          if (calendar.semesters.isEmpty) return null;
           await _prefs.setString(_cacheKey, response.body);
           return calendar;
         }

--- a/lib/widgets/common/auth_scoped_indexed_stack.dart
+++ b/lib/widgets/common/auth_scoped_indexed_stack.dart
@@ -153,6 +153,9 @@ class _AuthScopedIndexedStackState extends State<AuthScopedIndexedStack>
     _wasAuthenticated = authenticated;
     _authGeneration++;
     _previousIndex = null;
+    // 认证边界变化时若切页动画正播放到中间态，复位到完成态，
+    // 避免选中的新页面以半透明/偏移状态显示。
+    _animController.value = 1.0;
     _pageCache.clear();
     return true;
   }

--- a/lib/widgets/common/styled_widget.dart
+++ b/lib/widgets/common/styled_widget.dart
@@ -17,7 +17,10 @@ class ButtonWithMaxWidth extends StatelessWidget {
     Widget realChild;
     realChild = Row(
       mainAxisAlignment: MainAxisAlignment.spaceBetween,
-      children: [Container(), child, icon],
+      children: [
+        Expanded(child: child),
+        icon,
+      ],
     );
     return SizedBox(
       width: double.infinity,

--- a/lib/widgets/webview/captcha_webview_dialog.dart
+++ b/lib/widgets/webview/captcha_webview_dialog.dart
@@ -14,6 +14,7 @@ import 'download_options.dart';
 /// intercepts it, downloads the file, and calls [onDownloadComplete].
 class CaptchaWebViewDialog extends StatefulWidget {
   const CaptchaWebViewDialog({
+    super.key,
     required this.url,
     required this.onDownloadComplete,
     required this.getCookies,

--- a/lib/widgets/webview/captcha_webview_dialog.dart
+++ b/lib/widgets/webview/captcha_webview_dialog.dart
@@ -42,26 +42,33 @@ class _CaptchaWebViewDialogState extends State<CaptchaWebViewDialog> {
     InAppWebViewController controller,
     DownloadStartRequest request,
   ) async {
-    final cookieHeader = await widget.getCookies();
-    final headers = mergeDownloadHeaders(
-      widget.downloadHeaders,
-      cookieHeader: cookieHeader,
-    );
+    // getCookies 也在 try 内：CookieManager 抛异常时同样要关闭弹窗并返回
+    // 失败，不能静默卡住。
     try {
+      final cookieHeader = await widget.getCookies();
+      final headers = mergeDownloadHeaders(
+        widget.downloadHeaders,
+        cookieHeader: cookieHeader,
+      );
       final path = await downloadFile(
         request.url.toString(),
         widget.attachmentDir,
         request.suggestedFilename ?? 'download',
         headers: headers,
       );
-      // 只有弹窗仍打开时才回调（回调内会 pop 弹窗）；用户已关闭或弹窗
-      // 已被 dispose 时直接忽略，避免误关 dialog 之下的页面。
-      if (!_closed && mounted) {
+      // 无论弹窗是否已关闭，都回调更新任务状态为 done（文件确实已落盘，
+      // 状态必须一致，避免「任务显示失败但文件已写入」）；但只在弹窗仍
+      // 打开时才 pop，已关闭时不再触碰导航栈。
+      if (mounted) {
         widget.onDownloadComplete(path);
+        if (!_closed) {
+          Navigator.pop(context, true);
+        }
       }
     } catch (_) {
       // 下载失败：若弹窗仍打开则关闭它并返回 false，由调用方把任务标记
-      // 为失败；WebView 始终接管下载（handled: true）不落到默认行为。
+      // 为失败；已关闭时调用方已标记 captchaCancelled，无需处理。
+      // WebView 始终接管下载（handled: true）不落到默认行为。
       if (!_closed && mounted) {
         Navigator.pop(context, false);
       }

--- a/lib/widgets/webview/captcha_webview_dialog.dart
+++ b/lib/widgets/webview/captcha_webview_dialog.dart
@@ -33,6 +33,9 @@ class CaptchaWebViewDialog extends StatefulWidget {
 
 class _CaptchaWebViewDialogState extends State<CaptchaWebViewDialog> {
   bool _loading = true;
+  // 弹窗是否已被用户主动关闭。关闭后 WebView 的下载回调可能仍在途，
+  // 需要用 _closed + mounted 双重防护，避免对已关闭的弹窗执行 pop。
+  bool _closed = false;
 
   Future<DownloadStartResponse?> _onDownloadStarting(
     InAppWebViewController controller,
@@ -50,9 +53,17 @@ class _CaptchaWebViewDialogState extends State<CaptchaWebViewDialog> {
         request.suggestedFilename ?? 'download',
         headers: headers,
       );
-      widget.onDownloadComplete(path);
+      // 只有弹窗仍打开时才回调（回调内会 pop 弹窗）；用户已关闭或弹窗
+      // 已被 dispose 时直接忽略，避免误关 dialog 之下的页面。
+      if (!_closed && mounted) {
+        widget.onDownloadComplete(path);
+      }
     } catch (_) {
-      // Download failed — let the WebView keep showing whatever the server returned.
+      // 下载失败：若弹窗仍打开则关闭它并返回 false，由调用方把任务标记
+      // 为失败；WebView 始终接管下载（handled: true）不落到默认行为。
+      if (!_closed && mounted) {
+        Navigator.pop(context, false);
+      }
     }
     return DownloadStartResponse(handled: true);
   }
@@ -69,7 +80,10 @@ class _CaptchaWebViewDialogState extends State<CaptchaWebViewDialog> {
               title: Text(AppLocalizations.of(context)!.captchaDialogTitle),
               leading: IconButton(
                 icon: const Icon(Icons.close),
-                onPressed: () => Navigator.pop(context, false),
+                onPressed: () {
+                  _closed = true;
+                  Navigator.pop(context, false);
+                },
               ),
               toolbarHeight: 44,
             ),

--- a/lib/widgets/webview/webview_notice_handlers.dart
+++ b/lib/widgets/webview/webview_notice_handlers.dart
@@ -163,6 +163,8 @@ mixin WebViewNoticeHandlers<T extends StatefulWidget> on State<T> {
       builder: (ctx) => CaptchaWebViewDialog(
         url: url,
         onDownloadComplete: (String filePath) {
+          // 只更新任务状态与提示；弹窗的 pop 由 CaptchaWebViewDialog 内部
+          // 控制（仅在弹窗仍打开时触发），避免弹窗已关闭时误关底层页面。
           getIt<DownloadManager>().updateTask(
             task,
             status: DownloadStatus.done,
@@ -174,7 +176,6 @@ mixin WebViewNoticeHandlers<T extends StatefulWidget> on State<T> {
               context,
             ).showSnackBar(SnackBar(content: Text(l10n.downloadComplete)));
           }
-          Navigator.pop(ctx, true);
         },
         getCookies: () => getDownloadCookieHeader(url),
         downloadHeaders: options.downloadHeaders,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -69,18 +69,18 @@ packages:
     dependency: transitive
     description:
       name: build_config
-      sha256: f2c223156a26eea323e6244b85141d76413a80aeee9fe0b380773789fabaf8ae
+      sha256: "94eaf6708fe64408c632ef2689ca3777b112f9421306ccf4f8c84d7c5c9f83f8"
       url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.3.1"
+    version: "1.3.2"
   build_daemon:
     dependency: transitive
     description:
       name: build_daemon
-      sha256: fd754058c342243718d5171a95f352cfc9fcf0cba8cfa26df67cb13a5836db78
+      sha256: "57c62a6d85c39d2a8c984e3b73b29bf2775a865e690309405aeade647fb2184c"
       url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "4.1.2"
+    version: "4.1.4"
   build_runner:
     dependency: "direct dev"
     description:
@@ -101,10 +101,10 @@ packages:
     dependency: transitive
     description:
       name: built_value
-      sha256: "34e4067d30ce212937df995f03b69992eea683539ceeac7f679a1f1eba055b56"
+      sha256: "31b24be6615ec7fcf70b3aa5a7469fe35826485e639a16dd7eb83ba30e4cc6a8"
       url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "8.12.6"
+    version: "8.12.7"
   characters:
     dependency: transitive
     description:
@@ -487,10 +487,10 @@ packages:
     dependency: transitive
     description:
       name: flutter_secure_storage_platform_interface
-      sha256: "8ceea1223bee3c6ac1a22dabd8feefc550e4729b3675de4b5900f55afcb435d6"
+      sha256: "788060052712555182aba55ecb5f8b6e5cb9cfe8f776c83249a61fe3ce877db4"
       url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "2.0.1"
+    version: "2.0.3"
   flutter_secure_storage_web:
     dependency: transitive
     description:
@@ -534,10 +534,10 @@ packages:
     dependency: "direct main"
     description:
       name: gal
-      sha256: "969598f986789127fd407a750413249e1352116d4c2be66e81837ffeeaafdfee"
+      sha256: f71e79840fe023a21f2f949771375444b6efcd34b9e625d5f4f5504971380a77
       url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "2.3.2"
+    version: "2.3.3"
   get_it:
     dependency: "direct main"
     description:
@@ -558,10 +558,10 @@ packages:
     dependency: "direct main"
     description:
       name: google_fonts
-      sha256: d3f251381df389f7418d4dff416bd27c0a23138df22969aafd28c4a4b1bb3cd6
+      sha256: e3cb3ee6b47fd2472c23de6da5744796a4da195137759ddb3fbcc9467b7b3c7d
       url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "8.2.0"
+    version: "8.2.1"
   graphs:
     dependency: transitive
     description:
@@ -718,18 +718,26 @@ packages:
     dependency: transitive
     description:
       name: jni
-      sha256: c2230682d5bc2362c1c9e8d3c7f406d9cbba23ab3f2e203a025dd47e0fb2e68f
+      sha256: f038e58b4dc2c9037f50e233175086337e0b305e356d28211bf55f21c504cbd3
       url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.3"
   jni_flutter:
     dependency: transitive
     description:
       name: jni_flutter
-      sha256: "8b59e590786050b1cd866677dddaf76b1ade5e7bc751abe04b86e84d379d3ba6"
+      sha256: "7b717011ea40d04fd47c2731d3d1d36eb99eba3435c2753d62489e8c3c9991d5"
       url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.0.1"
+    version: "1.0.2"
+  jni_util:
+    dependency: transitive
+    description:
+      name: jni_util
+      sha256: "1ba86da04a5f2bf18fde2edb235587e70c5b0fc5bd4ba955f46b00942c3fc35f"
+      url: "https://pub.flutter-io.cn"
+    source: hosted
+    version: "1.0.0"
   json_annotation:
     dependency: "direct main"
     description:
@@ -742,10 +750,10 @@ packages:
     dependency: "direct dev"
     description:
       name: json_serializable
-      sha256: ffcd10cde35a93b2abbbcc26bd9971f4ca93763e8abe78d855e3c4177797e501
+      sha256: e45aefa0324f08c683caafbb94b72837aa6193c61822799c916e45f4a263113d
       url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "6.14.0"
+    version: "6.14.1"
   leak_tracker:
     dependency: transitive
     description:
@@ -846,10 +854,10 @@ packages:
     dependency: transitive
     description:
       name: objective_c
-      sha256: "6cb691c686fa2838c6deb34980d426145c2a5d537491cb83d463c33cdbc726ed"
+      sha256: b7fb95a6d9a4f009edd63dc5ac69f07420b23a16161c6dd8660290b59c602e8e
       url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "9.4.1"
+    version: "9.5.0"
   open_filex:
     dependency: "direct main"
     description:
@@ -990,10 +998,10 @@ packages:
     dependency: transitive
     description:
       name: posix
-      sha256: "185ef7606574f789b40f289c233efa52e96dead518aed988e040a10737febb07"
+      sha256: bc1bad54ad2b735816e31f8d4600cfde6c7839975085ddfbca48b6c9f7c4044e
       url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "6.5.0"
+    version: "6.5.2"
   process:
     dependency: transitive
     description:
@@ -1087,18 +1095,18 @@ packages:
     dependency: "direct main"
     description:
       name: share_plus
-      sha256: "02180b01c1237b9706b663d9402b2cf2402b3407f48cce99cc19e3200f095b8a"
+      sha256: "34f00f9becd2743c1fb05363d624f9f70d37f7ccdcdda47450bc0b8c9d327b8c"
       url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "13.2.1"
+    version: "13.3.0"
   share_plus_platform_interface:
     dependency: transitive
     description:
       name: share_plus_platform_interface
-      sha256: "7f7ae28cf400d13f811e297ff37742dba83b79e0a6f5dce14eec0248274e6ce9"
+      sha256: "365ef7379fc22507256adda3385152942ffce08935452bc972c2e52a0bebae41"
       url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "7.1.0"
+    version: "7.2.0"
   shared_preferences:
     dependency: "direct main"
     description:
@@ -1180,18 +1188,18 @@ packages:
     dependency: transitive
     description:
       name: source_gen
-      sha256: ec37cc0e6694374cbef59ed79685572c870a54ede6fa30a3e420feb3adffea02
+      sha256: a603f1fb984a7391ae5978d1b92bfaaa08b350dca5c825256f925818f7943bf5
       url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "4.2.3"
+    version: "4.2.4"
   source_helper:
     dependency: transitive
     description:
       name: source_helper
-      sha256: "4227d54ceefd0bb8ca4c8fcb96e1719dc53f1ee1b6e2ca9d7a6069da160e4eae"
+      sha256: "5e6f216fdf6376c9f3852381ae037499797a3385377d388b011dac98d303c67c"
       url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.3.12"
+    version: "1.3.13"
   source_span:
     dependency: transitive
     description:
@@ -1252,10 +1260,10 @@ packages:
     dependency: transitive
     description:
       name: sqlite3
-      sha256: c73fd75df1332d76a6257f4823ae4df9c791f522b97e4a60cbcad214de1becf4
+      sha256: "64b2c63c8232dd20d14b34105a81ebfd74320442e8451f836179ec89986aa478"
       url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "3.5.0"
+    version: "3.5.1"
   stack_trace:
     dependency: transitive
     description:
@@ -1300,10 +1308,10 @@ packages:
     dependency: transitive
     description:
       name: synchronized
-      sha256: "93b153dcb6a26dcddee6ca087dd634b53e38c10b5aa163e8e49501a776456153"
+      sha256: "61894a1956de6b4fc1aefd0892e109514a1a706cbece3ac59decd90ff5a7a423"
       url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "3.4.1"
+    version: "3.4.1+1"
   system_theme:
     dependency: "direct main"
     description:
@@ -1484,10 +1492,10 @@ packages:
     dependency: transitive
     description:
       name: win32
-      sha256: ba6f4bba816c8d7e3c1580e170f3786d216951cc6b94babc3b814c08d2cb2738
+      sha256: a0b93865d5644f11cf6a8c3f6db909f1ec168958b5805f6cc684adea957cd63d
       url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "6.3.0"
+    version: "6.4.0"
   win32_registry:
     dependency: transitive
     description:

--- a/test/academic_calendar_cache_test.dart
+++ b/test/academic_calendar_cache_test.dart
@@ -4,6 +4,25 @@ import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+/// 追踪 close() 调用，用于验证注入的 client 生命周期由注入方管理。
+class _TrackingClient extends http.BaseClient {
+  final http.Client _inner;
+  bool closed = false;
+
+  _TrackingClient(this._inner);
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) {
+    return _inner.send(request);
+  }
+
+  @override
+  void close() {
+    closed = true;
+    super.close();
+  }
+}
+
 void main() {
   const cacheKey = 'cached_academic_calendar_json';
   const validCalendar = '''
@@ -32,5 +51,71 @@ void main() {
     expect(calendar.semesters, hasLength(1));
     expect(calendar.semesters.single.name, '2026-2027学年秋季学期');
     expect(prefs.getString(cacheKey), validCalendar);
+  });
+
+  test('空校历响应不写入缓存', () async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    final client = MockClient(
+      (_) async => http.Response('{"semesters":[]}', 200),
+    );
+    final service = AcademicCalendarService(prefs, client: client);
+
+    final calendar = await service.fetchCalendarData();
+
+    expect(calendar.semesters, isEmpty);
+    // 空校历不得污染缓存：否则本地优先策略会一直展示空数据且不回退内置 asset。
+    expect(prefs.getString(cacheKey), isNull);
+  });
+
+  test('refreshCalendarData 成功时写入缓存并返回数据', () async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    final client = MockClient(
+      (_) async => http.Response(
+        validCalendar,
+        200,
+        headers: {'content-type': 'application/json; charset=utf-8'},
+      ),
+    );
+    final service = AcademicCalendarService(prefs, client: client);
+
+    final calendar = await service.refreshCalendarData();
+
+    expect(calendar, isNotNull);
+    expect(calendar!.semesters, hasLength(1));
+    expect(prefs.getString(cacheKey), validCalendar);
+  });
+
+  test('refreshCalendarData 网络失败返回 null 且缓存不变', () async {
+    SharedPreferences.setMockInitialValues({cacheKey: validCalendar});
+    final prefs = await SharedPreferences.getInstance();
+    final client = MockClient((_) async => throw Exception('network down'));
+    final service = AcademicCalendarService(prefs, client: client);
+
+    final calendar = await service.refreshCalendarData();
+
+    expect(calendar, isNull);
+    expect(prefs.getString(cacheKey), validCalendar);
+  });
+
+  test('注入的 client 不会被 service 关闭', () async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    final inner = MockClient(
+      (_) async => http.Response(
+        validCalendar,
+        200,
+        headers: {'content-type': 'application/json; charset=utf-8'},
+      ),
+    );
+    final tracking = _TrackingClient(inner);
+    final service = AcademicCalendarService(prefs, client: tracking);
+
+    final calendar = await service.refreshCalendarData();
+
+    expect(calendar, isNotNull);
+    // 注入的 client 生命周期归注入方（test）管理，service 不得 close。
+    expect(tracking.closed, isFalse);
   });
 }


### PR DESCRIPTION
### 内容

**本次改动汇总：**

1. **修复验证码下载弹窗误关页面**
   - 弹窗关闭后不再触发下载完成回调，避免误关底层页面
   - 下载失败时关闭弹窗并返回失败状态，不再无声卡住

2. **修复切页动画状态残留**
   - 认证边界变化（登录/登出）时复位切页动画，避免新页面停在半透明/偏移中间态

3. **修复电费查询房间名显示**
   - 房间名支持折行并限制宽度，避免与右侧删除/隐私按钮重叠

4. **优化互动校历加载**
   - 优先读取本地缓存/内置数据，首次打开不再等待网络，解决加载缓慢
   - 新增下拉刷新，仅刷新时走网络拉取最新校历
   - 刷新失败时保留现有数据并提示

### 测试
- 相关单元测试通过（`wfw_auth_test`、`auth_scoped_indexed_stack_test`、`academic_calendar_test` 等）
- 代码通过 `dart format` 与静态检查