### PR TITLE
小组件同步放假状态并更新部分文档

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ This file provides guidance to AI coding agents (e.g. Claude Code, Kimi Code) wh
 
 The name comes from a landmark on SCU's Jiang'an campus — "Bugaoshan" is a play on words meaning "not a tall mountain" and "The Brotherhood of SCU" sounds similar.
 
-> **⚠️ Flutter 版本要求**: 本项目需要 **Flutter >= 3.44**（Dart SDK >= 3.10.4）才能正常编译。CI uses Flutter **3.44.6** stable. 详情见 `CONTRIBUTING.md` 与 `.github/actions/setup/action.yml`.
+> **⚠️ Flutter 版本要求**: 本项目需要 **Flutter >= 3.44**（Dart SDK >= 3.10.4）才能正常编译。CI uses Flutter **3.44** stable. 详情见 `CONTRIBUTING.md` 与 `.github/actions/setup/action.yml`.
 
 ## Build & Run
 
@@ -138,7 +138,7 @@ Follow [Conventional Commits](https://www.conventionalcommits.org/): `feat:`, `f
 │       ├── 0003-make-course-display-settings-global.md
 │       └── 0004-use-distribution-wpe-on-linux.md
 └── .github/
-    ├── actions/setup/          # composite action: install Flutter 3.44.6, gen-l10n, git metadata
+    ├── actions/setup/          # composite action: install Flutter 3.44, gen-l10n, git metadata
     ├── scripts/                # Python release automation
     │   ├── git_meta.py             # export GIT_TAG / GIT_COMMIT / GIT_COMMIT_DATE / BUILD_TIME
     │   ├── release_tags.py         # resolve version + prev tag
@@ -162,7 +162,7 @@ Follow [Conventional Commits](https://www.conventionalcommits.org/): `feat:`, `f
 Two patterns coexist by design:
 
 - **ChangeNotifier** — providers with coarse-grained state changes (auth state, load states, error states). UI consumes via `ListenableBuilder(listenable: providerInstance)`. Examples: `ScuAuthProvider`, `GradesProvider`, `TrainProgramProvider`, `WfwAuth`, `ScuAuth`.
-- **多个 ValueNotifier 字段** — providers with many independent config/setting fields where widgets should only rebuild when specific fields change. UI consumes via `ListenableBuilder(listenable: Listenable.merge([field1, field2]))` or `ValueListenableBuilder`. Examples: `AppConfigProvider` (~14 fields: locale, themeColor, themeColorMode, colorOpacity, useGoogleFonts, …), `CourseProvider` (5 fields).
+- **多个 ValueNotifier 字段** — providers with many independent config/setting fields where widgets should only rebuild when specific fields change. UI consumes via `ListenableBuilder(listenable: Listenable.merge([field1, field2]))` or `ValueListenableBuilder`. Examples: `AppConfigProvider` (~25 fields: locale, themeColor, themeColorMode, colorOpacity, useGoogleFonts, …), `CourseProvider` (4 fields).
 - **手动 `addListener`** — only for imperative side-effects (animations, SnackBars, triggering data loads), never for pure rebuild triggers.
 
 **Directory convention:** All DI-registered providers live in `lib/providers/`. Page-specific non-DI utility classes may live in page directories (e.g. `lib/services/ccyl/ccyl_service.dart`).
@@ -211,7 +211,9 @@ The CCYL service is special: its token expires via an explicit business error co
 - **`UpdateService`** — GitHub release check / download / install for desktop (Windows + Linux). Coordinates with `assets/scripts/update.bat` / `update.sh`.
 - **`UpdateChecker`** (`lib/services/update_checker.dart`) — fetches latest version info from GitHub `/releases/latest` API.
 - **`UpdateAssetSelector`** (`lib/services/update_asset_selector.dart`) — selects correct APK/asset based on device platform and CPU architecture.
-- **`WidgetUpdateService`** — Android home-screen widget data sync via MethodChannel `bugaoshan/update`. Has its own debounce + in-flight coalescing logic (covered by `test/widget_update_service_test.dart`).
+- **`WidgetUpdateService`** — Android + iOS/macOS home-screen widget data sync via MethodChannel `bugaoshan/update` (Android) and App Group (iOS/macOS, `syncWidgetShowTomorrow`). Has its own debounce + in-flight coalescing logic (covered by `test/widget_update_service_test.dart`).
+- **`DownloadNotificationService`** (`lib/services/download_notification_service.dart`) — Android 下载进度通知栏（进度条 + 取消按钮，MethodChannel `bugaoshan/update` + EventChannel `bugaoshan/download_cancel`，仅 Android，其他平台静默 no-op）；由 `UpdateProvider` 使用。
+- **`AcademicCalendarService`** (`lib/services/api/academic_calendar_service.dart`) — academic calendar data with mirror fetch + SharedPreferences cache.
 - **`DynamicIconService`** (`lib/services/dynamic_icon_service.dart`) — runtime app icon switching via MethodChannel `bugaoshan/dynamic_icon` (Android native).
 - **`BackgroundCacheService`** — precaches the user's background image post-frame.
 - **`ExitService`** — unified exit (windowManager.destroy on desktop, exit(0) on mobile).
@@ -239,11 +241,11 @@ Dev page (`lib/pages/dev/auth_log/`) gains:
 
 Three notice sources, each in its own subdirectory under `lib/pages/campus/notice/` (see `docs/architecture/notice-webview.md`):
 
-- **`jwc/`** — `jwc.scu.edu.cn` 教务处, beautified by `assets/js/jwc_notice_beautify.js`.
+- **`jwc/`** — `jwc.scu.edu.cn` 教务处, beautified by `assets/js/jwc_notice_beautify.js`. Sets `useWebViewDownload: true` for cookie-based downloads.
 - **`xgb/`** — `xgb.scu.edu.cn` 党委学工部, beautified by `party_notice_beautify.js`.
 - **`tuanwei/`** — `tuanwei.scu.edu.cn` 团委 (青春川大), beautified by `tuanwei_notice_beautify.js`. Sets `useWebViewDownload: true` for cookie-based downloads.
 
-All three wrap a shared `WebViewNoticePage` (`webview_notice_page.dart`) which loads the URL in an `InAppWebView`, injects the corresponding beautify JS on `onLoadStop`, double-`requestAnimationFrame` for `dom_ready.js`, extracts attachments via the `AttachmentsChannel` JS handler, and shows a draggable `NoticeAttachmentFab` when attachments are present.
+All three wrap a shared `WebViewNoticePage` (`lib/widgets/webview/webview_notice_page.dart`) which loads the URL in an `InAppWebView`, injects the corresponding beautify JS on `onLoadStop`, double-`requestAnimationFrame` for `dom_ready.js`, extracts attachments via the `AttachmentsChannel` JS handler, and shows a draggable `NoticeAttachmentFab` when attachments are present.
 
 Shared downloads module lives in `lib/pages/campus/downloads/`:
 - `NoticeAttachmentFab` / `attachment_fab.dart` — draggable FAB.
@@ -260,9 +262,10 @@ Shared downloads module lives in `lib/pages/campus/downloads/`:
 | `UserInfoProvider` | 监听 `WfwAuth`，登录后自动 fetch 用户信息（realname/number）和标签（图书借阅 / 校园卡 / 网费），登出 clear. |
 | `GradesProvider` | Holds `ZhjwApiService`; fetches scheme & passing scores (session-expired retry handled by the API service layer). Caches grades to SharedPreferences. |
 | `CourseProvider` | 课表 CRUD via `DatabaseService`. |
-| `AppConfigProvider` | ~18 `ValueNotifier` fields: locale, themeColor, themeColorMode, colorOpacity, useGoogleFonts, course card font, card animation duration, grid visibility, row height, background image, dock items, EULA version, wizard completed, … |
+| `AppConfigProvider` | ~25 `ValueNotifier` fields: locale, themeColor, themeColorMode, colorOpacity, useGoogleFonts, course card font/row height, grid visibility, background image, dock items, EULA version, wizard completed, widget show-tomorrow, preview update source, privacy toggles (showTeacherName/showLocation/showWeekend…), … |
 | `SetThemeColorProvider` | 从背景图提取主题色（pixel sampling + `compute()` isolate），支持系统强调色预览. |
 | `AppInfoProvider` | App version + CI build metadata (git tag / commit / build time). |
+| `UpdateProvider` | 更新检查/下载状态管理（包裹 `UpdateService`）：isChecking / isDownloading / lastCheckResult / stableResult / previewResult + `UpdateProgressState`；供 about/home 页与 Dev 页使用。 |
 | `BalanceQueryProvider` | 电费 / 空调余额状态管理，支持多房间绑定切换. |
 | `CcylProvider` | 第二课堂登录状态管理。委托 `CcylAuth` 持久化 OAuth token (`FlutterSecureStorage`)，通过 `service` getter 暴露 `CcylApiService`. |
 | `TrainProgramProvider` | 培养方案查询；管理学院/年级/方案列表 + 详情加载状态. |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 修复课程表左侧时间标签可能换行的问题
 - 修复电费查询、体测页面预热失败后无限加载的问题
 - 修复预览版更新检查可能匹配到错误版本的问题
+- 修复假期自动获取当前周数时报错的问题
 - 修复导出空课表时失败的问题
 - 修复了一些小问题
 - 修复低版本安卓、苹果系统上保存图片到相册相关权限的问题
@@ -290,5 +291,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 发布工作流重构
 - 训练计划列表底部增加间距
 - 非移动平台隐藏刷新按钮
-
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - iOS 端桌面小组件，支持在桌面显示课表
 - 新增 macOS 平台支持（课表可导出到系统日历）
 - 增加开发团队的介绍页面
+- 课表页新增放假页面，假期中显示放假信息，并支持切换到下学期查看
 
 ### Changed
 - 统一UI卡片样式：使用带有轻微阴影的圆角卡片
@@ -31,6 +32,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 适配成绩页面支持存在多个培养方案的情况
 - 优化卡片的UI设计
 - 校历优先加载本地缓存，减少网络等待，并支持下拉刷新
+- 互动校历默认显示当前/下学期
+- 导入课表时自动根据校历计算学期周数
 
 ### Removed
 - 移除功能：当软件状态恢复时，例如从后台打开，最小化之后打开：课表跳转到当前周

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 将验证码识别从LiteRT切换为内置实现减小包体积、提高跨平台兼容性
 - 适配成绩页面支持存在多个培养方案的情况
 - 优化卡片的UI设计
+- 校历优先加载本地缓存，减少网络等待，并支持下拉刷新
 
 ### Removed
 - 移除功能：当软件状态恢复时，例如从后台打开，最小化之后打开：课表跳转到当前周
@@ -41,6 +42,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 修复导出空课表时失败的问题
 - 修复了一些小问题
 - 修复低版本安卓、苹果系统上保存图片到相册相关权限的问题
+- 修复校历刷新时资源泄漏、加载异常数据可能污染本地缓存的问题
+- 修复部分按钮、房间名等长文本显示溢出或重叠的问题
 
 ## [2.2.0] - 2026-07-13
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Flutter](https://img.shields.io/badge/Flutter-3.44-02569B?logo=flutter&logoColor=white)](https://flutter.dev)
 [![Dart](https://img.shields.io/badge/Dart-3.10-0175C2?logo=dart&logoColor=white)](https://dart.dev)
 [![License](https://img.shields.io/badge/License-AGPL3.0-green.svg)](LICENSE)
-[![Platform](https://img.shields.io/badge/Platform-Linux%20%7C%20Android%20%7C%20Windows-blue)](https://flutter.dev)
+[![Platform](https://img.shields.io/badge/Platform-Linux%20%7C%20Android%20%7C%20Windows%20%7C%20macOS-blue)](https://flutter.dev)
 
 > 川大学生专属校园助手
 
@@ -55,6 +55,8 @@
 ## 📥 下载
 
 **前往 [Release 页面](https://github.com/The-Brotherhood-of-SCU/Bugaoshan/releases/latest) 下载最新版本**
+
+> 📱 **iOS 与鸿蒙版本正在邀测中**，欢迎加入官方QQ群（1102483776）参与测试
 
 ---
 

--- a/android/app/src/main/kotlin/io/github/the_brotherhood_of_scu/bugaoshan/CourseGlanceWidget.kt
+++ b/android/app/src/main/kotlin/io/github/the_brotherhood_of_scu/bugaoshan/CourseGlanceWidget.kt
@@ -467,12 +467,28 @@ object WidgetDataLoader {
     /** 计算学期结束日(最后一周的周日),基于学期开始日与总周数。 */
     private fun computeSemesterEndDate(semesterStartDate: String, totalWeeks: Int): Calendar? {
         if (semesterStartDate.isEmpty() || totalWeeks <= 0) return null
-        val parts = semesterStartDate.split("-")
-        if (parts.size != 3) return null
+        val start = parseCalendarDate(semesterStartDate) ?: return null
         return Calendar.getInstance().apply {
-            set(parts[0].toInt(), parts[1].toInt() - 1, parts[2].toInt(), 0, 0, 0)
-            set(Calendar.MILLISECOND, 0)
+            timeInMillis = start.timeInMillis
             add(Calendar.DAY_OF_MONTH, totalWeeks * 7 - 1)
+        }
+    }
+
+    /**
+     * 安全解析 `yyyy-MM-dd` 日期字符串为当日零点日历。
+     * 格式非法(如含非数字)时返回 null,避免抛异常导致整个小组件加载失败。
+     */
+    private fun parseCalendarDate(dateStr: String): Calendar? {
+        val parts = dateStr.split("-")
+        if (parts.size != 3) return null
+        return try {
+            Calendar.getInstance().apply {
+                set(parts[0].toInt(), parts[1].toInt() - 1, parts[2].toInt(), 0, 0, 0)
+                set(Calendar.MILLISECOND, 0)
+            }
+        } catch (e: NumberFormatException) {
+            Log.w(TAG, "Invalid date string: $dateStr", e)
+            null
         }
     }
 
@@ -518,12 +534,7 @@ object WidgetDataLoader {
                     Log.w(TAG, "Invalid schedule config for id=$id", e)
                     continue
                 }
-                val parts = start.split("-")
-                if (parts.size != 3) continue
-                val startCal = Calendar.getInstance().apply {
-                    set(parts[0].toInt(), parts[1].toInt() - 1, parts[2].toInt(), 0, 0, 0)
-                    set(Calendar.MILLISECOND, 0)
-                }
+                val startCal = parseCalendarDate(start) ?: continue
                 if (startCal.after(currentEnd) && (next == null || startCal.before(next))) {
                     next = startCal
                 }

--- a/android/app/src/main/kotlin/io/github/the_brotherhood_of_scu/bugaoshan/CourseGlanceWidget.kt
+++ b/android/app/src/main/kotlin/io/github/the_brotherhood_of_scu/bugaoshan/CourseGlanceWidget.kt
@@ -152,13 +152,20 @@ object WidgetDataLoader {
             val semesterStartDate = config.optString("semesterStartDate", "")
             val totalWeeks = config.optInt("totalWeeks", 20)
             val timeSlots = config.optJSONArray("timeSlots")
+            val semesterEndDate = computeSemesterEndDate(semesterStartDate, totalWeeks)
+            val onVacation = semesterEndDate != null && isOnVacation(
+                db, currentScheduleId, semesterEndDate,
+            )
             val currentWeek = computeCurrentWeek(semesterStartDate, totalWeeks)
             val cal = Calendar.getInstance()
             val dayOfWeek = (cal.get(Calendar.DAY_OF_WEEK) + 5) % 7 + 1
-            var courses =
+            var courses = if (onVacation) {
+                JSONArray()
+            } else {
                 loadCoursesForSelectedSchedule(currentScheduleId) { scheduleId ->
                     queryCourses(db, scheduleId, dayOfWeek, currentWeek)
                 }
+            }
             val now = Calendar.getInstance()
             val currentHour = now.get(Calendar.HOUR_OF_DAY)
             val currentMinute = now.get(Calendar.MINUTE)
@@ -167,7 +174,7 @@ object WidgetDataLoader {
             var showingTomorrow = false
             var tomorrowCal: Calendar? = null
             var weekForTomorrow = currentWeek
-            if (courses.length() == 0) {
+            if (courses.length() == 0 && !onVacation) {
                 try {
                     val prefs = context.getSharedPreferences("FlutterSharedPreferences", Context.MODE_PRIVATE)
                     val rawKey = "widget_show_tomorrow"
@@ -210,9 +217,14 @@ object WidgetDataLoader {
                 dateText = "$month/$day $dayName $tomorrowLabel"
             }
             val weekNumber = if (showingTomorrow) weekForTomorrow else currentWeek
-            val weekText = context.getString(R.string.widget_week_format, weekNumber)
-            // 展示明天课程时今天已无变化点,边界闹钟交由午夜闹钟接力
-            val nextTransitionMillis = if (!showingTomorrow) {
+            val weekText = if (onVacation) {
+                context.getString(R.string.widget_vacation)
+            } else {
+                context.getString(R.string.widget_week_format, weekNumber)
+            }
+            // 展示明天课程时今天已无变化点,边界闹钟交由午夜闹钟接力;
+            // 放假中同样没有课程边界变化点。
+            val nextTransitionMillis = if (!showingTomorrow && !onVacation) {
                 computeNextTransitionMillis(courses, timeSlots, currentTimeMinutes)
             } else {
                 null
@@ -222,7 +234,11 @@ object WidgetDataLoader {
                 dateText = dateText,
                 weekText = weekText,
                 headerTitle = context.getString(R.string.widget_header_title),
-                emptyText = context.getString(R.string.widget_empty_today),
+                emptyText = if (onVacation) {
+                    context.getString(R.string.widget_vacation_hint)
+                } else {
+                    context.getString(R.string.widget_empty_today)
+                },
                 isTomorrow = showingTomorrow,
                 nextTransitionMillis = nextTransitionMillis,
             )
@@ -446,6 +462,74 @@ object WidgetDataLoader {
         val week = days / 7 + 1
         val maxWeek = if (totalWeeks >= 1) totalWeeks else week
         return week.coerceIn(1, maxWeek)
+    }
+
+    /** 计算学期结束日(最后一周的周日),基于学期开始日与总周数。 */
+    private fun computeSemesterEndDate(semesterStartDate: String, totalWeeks: Int): Calendar? {
+        if (semesterStartDate.isEmpty() || totalWeeks <= 0) return null
+        val parts = semesterStartDate.split("-")
+        if (parts.size != 3) return null
+        return Calendar.getInstance().apply {
+            set(parts[0].toInt(), parts[1].toInt() - 1, parts[2].toInt(), 0, 0, 0)
+            set(Calendar.MILLISECOND, 0)
+            add(Calendar.DAY_OF_MONTH, totalWeeks * 7 - 1)
+        }
+    }
+
+    /**
+     * 判断当前是否处于「学期之间」的假期:当前学期已结束且下学期尚未开始。
+     * 与 App 端 CoursePageController._computeShowVacationPage 保持一致。
+     */
+    private fun isOnVacation(
+        db: SQLiteDatabase,
+        currentScheduleId: String,
+        semesterEndDate: Calendar,
+    ): Boolean {
+        val today = Calendar.getInstance().apply {
+            set(Calendar.HOUR_OF_DAY, 0)
+            set(Calendar.MINUTE, 0)
+            set(Calendar.SECOND, 0)
+            set(Calendar.MILLISECOND, 0)
+        }
+        // 学期未结束 → 不放假
+        if (!today.after(semesterEndDate)) return false
+        // 找下学期(当前学期结束后最早开始的课表)
+        val next = findNextSemesterStart(db, currentScheduleId, semesterEndDate)
+            ?: return false
+        // 今天在下学期开始前 → 放假中
+        return today.before(next)
+    }
+
+    /** 在全部课表中查找在当前学期结束后最早开始的课表,返回其学期开始日。 */
+    private fun findNextSemesterStart(
+        db: SQLiteDatabase,
+        currentScheduleId: String,
+        currentEnd: Calendar,
+    ): Calendar? {
+        var next: Calendar? = null
+        db.rawQuery("SELECT id, config_json FROM schedules", null).use { cursor ->
+            while (cursor.moveToNext()) {
+                val id = cursor.getString(0)
+                if (id == currentScheduleId) continue
+                val configJson = cursor.getString(1) ?: continue
+                val start = try {
+                    JSONObject(configJson).optString("semesterStartDate", "")
+                } catch (e: Exception) {
+                    Log.w(TAG, "Invalid schedule config for id=$id", e)
+                    continue
+                }
+                val parts = start.split("-")
+                if (parts.size != 3) continue
+                val startCal = Calendar.getInstance().apply {
+                    set(parts[0].toInt(), parts[1].toInt() - 1, parts[2].toInt(), 0, 0, 0)
+                    set(Calendar.MILLISECOND, 0)
+                }
+                if (startCal.after(currentEnd) && (next == null || startCal.before(next))) {
+                    next = startCal
+                }
+            }
+        }
+        return next
     }
 
     private fun formatTime(timeSlots: JSONArray?, section: Int, isEnd: Boolean = false): String {

--- a/android/app/src/main/res/values-zh-rCN/strings.xml
+++ b/android/app/src/main/res/values-zh-rCN/strings.xml
@@ -2,6 +2,8 @@
 <resources>
     <string name="tomorrow">明天</string>
     <string name="widget_week_format">第%1$d周</string>
+    <string name="widget_vacation">放假中</string>
+    <string name="widget_vacation_hint">享受假期～</string>
     <string name="widget_empty_today">今天没有课程</string>
     <string name="widget_sync_hint">打开 App 同步课表</string>
     <string name="widget_section_single">第%1$d节</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -6,6 +6,8 @@
     <string name="widget_name_large">Schedule (Large)</string>
     <string name="tomorrow">Tomorrow</string>
     <string name="widget_week_format">Week %1$d</string>
+    <string name="widget_vacation">On vacation</string>
+    <string name="widget_vacation_hint">Enjoy your vacation</string>
     <string name="widget_empty_today">No classes today</string>
     <string name="widget_sync_hint">Open the app to sync your schedule</string>
     <string name="widget_section_single">Section %1$d</string>

--- a/ios/CourseWidget/WidgetExtension.swift
+++ b/ios/CourseWidget/WidgetExtension.swift
@@ -238,6 +238,79 @@ func computeWeekForDate(semesterStartDate: Date, totalWeeks: Int, date: Date) ->
     return max(1, min(week, totalWeeks))
 }
 
+/// 计算学期结束日(最后一周的周日),基于学期开始日与总周数。
+/// totalWeeks 非法时返回 nil,与 Android 端保持一致。
+func computeSemesterEndDate(semesterStartDate: Date, totalWeeks: Int) -> Date? {
+    guard totalWeeks > 0 else { return nil }
+    let calendar = Calendar.current
+    let startOfSemester = calendar.startOfDay(for: semesterStartDate)
+    return calendar.date(byAdding: .day, value: totalWeeks * 7 - 1, to: startOfSemester)
+}
+
+/// 在全部课表中查找在当前学期结束后最早开始的课表,返回其学期开始日。
+func findNextSemesterStart(_ db: OpaquePointer, currentScheduleId: String, currentEnd: Date) -> Date? {
+    var stmt: OpaquePointer?
+    let query = "SELECT id, config_json FROM schedules"
+    guard sqlite3_prepare_v2(db, query, -1, &stmt, nil) == SQLITE_OK else {
+        print("BugaoShan Widget: Failed to prepare query for all schedules")
+        return nil
+    }
+    defer { sqlite3_finalize(stmt) }
+
+    let dateFormatter = DateFormatter()
+    dateFormatter.dateFormat = "yyyy-MM-dd"
+    dateFormatter.locale = Locale(identifier: "en_US_POSIX")
+    dateFormatter.timeZone = TimeZone.current
+
+    var next: Date? = nil
+    while sqlite3_step(stmt) == SQLITE_ROW {
+        guard let idCString = sqlite3_column_text(stmt, 0),
+              let jsonCString = sqlite3_column_text(stmt, 1)
+        else { continue }
+
+        let id = String(cString: idCString)
+        if id == currentScheduleId { continue }
+
+        guard let jsonData = String(cString: jsonCString).data(using: .utf8),
+              let json = try? JSONSerialization.jsonObject(with: jsonData, options: []) as? [String: Any],
+              let startStr = json["semesterStartDate"] as? String,
+              let startDate = dateFormatter.date(from: startStr)
+        else { continue }
+
+        let startOfDay = Calendar.current.startOfDay(for: startDate)
+        if startOfDay > currentEnd {
+            if let currentNext = next {
+                if startOfDay < currentNext {
+                    next = startOfDay
+                }
+            } else {
+                next = startOfDay
+            }
+        }
+    }
+    return next
+}
+
+/// 判断当前是否处于「学期之间」的假期:当前学期已结束且下学期尚未开始。
+/// 与 App 端 CoursePageController._computeShowVacationPage 保持一致。
+func isOnVacation(_ db: OpaquePointer, currentScheduleId: String, semesterStartDate: Date, totalWeeks: Int) -> Bool {
+    let calendar = Calendar.current
+    let today = calendar.startOfDay(for: Date())
+    // 学期结束日非法(如 totalWeeks <= 0)→ 不放假
+    guard let semesterEnd = computeSemesterEndDate(semesterStartDate: semesterStartDate, totalWeeks: totalWeeks) else {
+        return false
+    }
+
+    // 学期未结束 → 不放假
+    if today <= semesterEnd { return false }
+    // 找下学期(当前学期结束后最早开始的课表)
+    guard let next = findNextSemesterStart(db, currentScheduleId: currentScheduleId, currentEnd: semesterEnd) else {
+        return false
+    }
+    // 今天在下学期开始前 → 放假中
+    return today < next
+}
+
 func isCourseActive(currentWeek: Int, startWeek: Int, endWeek: Int, weekType: Int) -> Bool {
     print("BugaoShan Widget: isCourseActive - currentWeek: \(currentWeek), startWeek: \(startWeek), endWeek: \(endWeek), weekType: \(weekType)")
 
@@ -440,7 +513,7 @@ func shouldShowTomorrow() -> Bool {
     return sharedDefaults.bool(forKey: "widget_show_tomorrow")
 }
 
-func loadWidgetData() -> (courses: [Course], dateText: String, weekText: String, isTomorrow: Bool, nextTransition: Date?)? {
+func loadWidgetData() -> (courses: [Course], dateText: String, weekText: String, isTomorrow: Bool, nextTransition: Date?, isOnVacation: Bool)? {
     print("BugaoShan Widget: loadWidgetData() called")
 
     guard let dbPath = getDatabasePath() else {
@@ -491,9 +564,10 @@ func loadWidgetData() -> (courses: [Course], dateText: String, weekText: String,
     let now = Date()
     let dayOfWeek = (calendar.component(.weekday, from: now) + 5) % 7 + 1 // Convert to Monday=1 to Sunday=7
     let currentWeek = computeCurrentWeek(semesterStartDate: config.semesterStartDate, totalWeeks: config.totalWeeks)
-    print("BugaoShan Widget: Today - dayOfWeek: \(dayOfWeek), currentWeek: \(currentWeek)")
+    let onVacation = isOnVacation(safeDB, currentScheduleId: currentScheduleId, semesterStartDate: config.semesterStartDate, totalWeeks: config.totalWeeks)
+    print("BugaoShan Widget: Today - dayOfWeek: \(dayOfWeek), currentWeek: \(currentWeek), onVacation: \(onVacation)")
 
-    var courses = queryCourses(safeDB, scheduleId: actualScheduleId, dayOfWeek: dayOfWeek, currentWeek: currentWeek)
+    var courses = onVacation ? [] : queryCourses(safeDB, scheduleId: actualScheduleId, dayOfWeek: dayOfWeek, currentWeek: currentWeek)
     print("BugaoShan Widget: Loaded \(courses.count) courses for today")
 
     let nowComponents = calendar.dateComponents([.hour, .minute], from: now)
@@ -506,7 +580,7 @@ func loadWidgetData() -> (courses: [Course], dateText: String, weekText: String,
     // ✨ 如果今天没有课，或者今天的课“全都上完了”，才尝试显示明天
     let hasUnfinishedCourses = courses.contains { $0.status != .completed }
 
-    if !hasUnfinishedCourses && shouldShowTomorrow() {
+    if !onVacation && !hasUnfinishedCourses && shouldShowTomorrow() {
         print("BugaoShan Widget: No active courses for today, checking tomorrow")
         if let tomorrow = calendar.date(byAdding: .day, value: 1, to: now) {
             let tomorrowDayOfWeek = (calendar.component(.weekday, from: tomorrow) + 5) % 7 + 1
@@ -538,11 +612,11 @@ func loadWidgetData() -> (courses: [Course], dateText: String, weekText: String,
     if isTomorrow {
         dateText += " 明天"
     }
-    let weekText = "第\(weekNum)周"
+    let weekText = onVacation ? "放假中" : "第\(weekNum)周"
 
-    let nextTransition = isTomorrow ? nil : computeNextTransitionMillis(courses, timeSlots: config.timeSlots, currentTimeMinutes: currentTimeMinutes)
+    let nextTransition = (isTomorrow || onVacation) ? nil : computeNextTransitionMillis(courses, timeSlots: config.timeSlots, currentTimeMinutes: currentTimeMinutes)
 
-    return (courses, dateText, weekText, isTomorrow, nextTransition)
+    return (courses, dateText, weekText, isTomorrow, nextTransition, onVacation)
 }
 
 struct CourseWidgetEntry: TimelineEntry {
@@ -551,6 +625,7 @@ struct CourseWidgetEntry: TimelineEntry {
     let dateText: String
     let weekText: String
     let isTomorrow: Bool
+    let isOnVacation: Bool
 }
 
 struct CourseProvider: TimelineProvider {
@@ -563,7 +638,8 @@ struct CourseProvider: TimelineProvider {
             ],
             dateText: "1/1 周一",
             weekText: "第1周",
-            isTomorrow: false
+            isTomorrow: false,
+            isOnVacation: false
         )
     }
 
@@ -574,7 +650,8 @@ struct CourseProvider: TimelineProvider {
                 courses: data.courses,
                 dateText: data.dateText,
                 weekText: data.weekText,
-                isTomorrow: data.isTomorrow
+                isTomorrow: data.isTomorrow,
+                isOnVacation: data.isOnVacation
             )
             completion(entry)
         } else {
@@ -591,7 +668,8 @@ struct CourseProvider: TimelineProvider {
                 courses: data.courses,
                 dateText: data.dateText,
                 weekText: data.weekText,
-                isTomorrow: data.isTomorrow
+                isTomorrow: data.isTomorrow,
+                isOnVacation: data.isOnVacation
             )
 
             var nextUpdate = Calendar.current.date(byAdding: .minute, value: 15, to: now)
@@ -660,8 +738,16 @@ struct DesktopWidgetView: View {
 
             if displayableCourses.isEmpty {
                 Spacer(minLength: 0)
-                // 区分是真没课，还是课上完了
-                Text(entry.courses.isEmpty ? (entry.isTomorrow ? "明天没课" : "今天没课") : "今天的课都上完啦")
+                // 区分是真没课，还是课上完了；放假中显示放假提示
+                let emptyText: String
+                if entry.isOnVacation {
+                    emptyText = "享受假期～"
+                } else if entry.courses.isEmpty {
+                    emptyText = entry.isTomorrow ? "明天没课" : "今天没课"
+                } else {
+                    emptyText = "今天的课都上完啦"
+                }
+                Text(emptyText)
                     .font(.callout)
                     .foregroundColor(.secondary)
                     .frame(maxWidth: .infinity, alignment: .center)
@@ -720,15 +806,15 @@ struct LockScreenRectangularView: View {
                     // 锁屏下使用 .secondary 会自动渲染为半透明，形成层级感
                     .foregroundColor(.secondary)
             } else {
-                // 没课的状态
+                // 没课的状态；放假中显示放假提示
                 HStack {
                     Image(systemName: "sparkles")
-                    Text(entry.isTomorrow ? "明天没课" : "今天课上完啦")
+                    Text(entry.isOnVacation ? "放假中" : (entry.isTomorrow ? "明天没课" : "今天课上完啦"))
                         .font(.headline)
                 }
                 .widgetAccentable()
 
-                Text("好好休息吧")
+                Text(entry.isOnVacation ? "享受假期～" : "好好休息吧")
                     .font(.caption)
                     .foregroundColor(.secondary)
             }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -265,6 +265,7 @@
     "setCurrentWeekHint": "Automatically calculates the semester start date based on the current week",
     "autoFetchCurrentWeek": "Auto Fetch Current Week",
     "autoFetchCurrentWeekHint": "Fetch current teaching week from academic system",
+    "autoFetchCurrentWeekOnVacation": "No teaching week is available during vacation. Schedule unchanged.",
     "fetchingCurrentWeek": "Fetching...",
     "loginRequired": "Please complete SCU Unified Identity login in the Profile page first",
     "goToLogin": "Go to Login",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1177,6 +1177,12 @@ abstract class AppLocalizations {
   /// **'Fetch current teaching week from academic system'**
   String get autoFetchCurrentWeekHint;
 
+  /// No description provided for @autoFetchCurrentWeekOnVacation.
+  ///
+  /// In en, this message translates to:
+  /// **'No teaching week is available during vacation. Schedule unchanged.'**
+  String get autoFetchCurrentWeekOnVacation;
+
   /// No description provided for @fetchingCurrentWeek.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -590,6 +590,10 @@ class AppLocalizationsEn extends AppLocalizations {
       'Fetch current teaching week from academic system';
 
   @override
+  String get autoFetchCurrentWeekOnVacation =>
+      'No teaching week is available during vacation. Schedule unchanged.';
+
+  @override
   String get fetchingCurrentWeek => 'Fetching...';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -572,6 +572,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get autoFetchCurrentWeekHint => '从教务系统获取当前教学周';
 
   @override
+  String get autoFetchCurrentWeekOnVacation => '假期中暂无教学周，未修改课表';
+
+  @override
   String get fetchingCurrentWeek => '正在获取...';
 
   @override

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -244,6 +244,7 @@
     "setCurrentWeekHint": "将根据当前周数自动推算学期开始日期",
     "autoFetchCurrentWeek": "自动获取当前周数",
     "autoFetchCurrentWeekHint": "从教务系统获取当前教学周",
+    "autoFetchCurrentWeekOnVacation": "假期中暂无教学周，未修改课表",
     "fetchingCurrentWeek": "正在获取...",
     "loginRequired": "请先在「我的」页面完成统一身份认证登录",
     "goToLogin": "前往登录",

--- a/lib/pages/campus/downloads/notice_downloaded_page.dart
+++ b/lib/pages/campus/downloads/notice_downloaded_page.dart
@@ -298,8 +298,39 @@ class _NoticeDownloadedPageState extends State<NoticeDownloadedPage>
       ),
     );
     if (confirmed != true) return;
+    await _deletePaths(_selected.toList());
+  }
+
+  /// Prompts the user and deletes a single downloaded file.
+  Future<void> _deleteFile(_FileInfo info) async {
+    final l10n = AppLocalizations.of(context)!;
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: Text(l10n.confirmDelete),
+        content: Text(l10n.confirmDeleteFile),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, false),
+            child: Text(l10n.cancel),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            child: Text(l10n.delete),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true) return;
+    await _deletePaths([info.file.path]);
+  }
+
+  /// Shared deletion routine: removes files, cleans up stale [DownloadManager]
+  /// tasks and empty subdirectories, then refreshes the list.
+  Future<void> _deletePaths(List<String> paths) async {
+    final l10n = AppLocalizations.of(context)!;
     final manager = getIt<DownloadManager>();
-    for (final path in _selected) {
+    for (final path in paths) {
       final file = File(path);
       if (await file.exists()) await file.delete();
       // Remove stale task from DownloadManager so the attachment sheet
@@ -539,6 +570,8 @@ class _NoticeDownloadedPageState extends State<NoticeDownloadedPage>
                   _openFile(file);
                 } else if (value == 'share') {
                   _shareFile(file);
+                } else if (value == 'delete') {
+                  _deleteFile(info);
                 }
               },
               itemBuilder: (ctx) => [
@@ -555,6 +588,14 @@ class _NoticeDownloadedPageState extends State<NoticeDownloadedPage>
                   child: ListTile(
                     leading: const Icon(Icons.share),
                     title: Text(l10n.share),
+                    contentPadding: EdgeInsets.zero,
+                  ),
+                ),
+                PopupMenuItem(
+                  value: 'delete',
+                  child: ListTile(
+                    leading: const Icon(Icons.delete_outline),
+                    title: Text(l10n.delete),
                     contentPadding: EdgeInsets.zero,
                   ),
                 ),

--- a/lib/pages/course/course_schedule_setting.dart
+++ b/lib/pages/course/course_schedule_setting.dart
@@ -61,6 +61,13 @@ class _CourseScheduleSettingState extends State<CourseScheduleSetting> {
     try {
       final week = await getIt<ZhjwApiService>().fetchCurrentWeek();
       if (!mounted) return;
+      if (week == null) {
+        final l10n = AppLocalizations.of(context)!;
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(l10n.autoFetchCurrentWeekOnVacation)),
+        );
+        return;
+      }
       final now = DateTime.now();
       final today = DateTime(now.year, now.month, now.day);
       final currentSunday = today.toSunday();

--- a/lib/services/api/zhjw_api_service.dart
+++ b/lib/services/api/zhjw_api_service.dart
@@ -50,8 +50,11 @@ class ZhjwApiService {
   //  课表
   // ═══════════════════════════════════════════════════════════════════
 
-  /// 从教务系统首页获取当前教学周数
-  Future<int> fetchCurrentWeek() {
+  /// 从教务系统首页获取当前教学周数。
+  ///
+  /// 假期首页没有“第 N 周”字段，而是显示“当前处于假期时间”，此时返回
+  /// `null`，由调用方给出明确的假期提示，而不是把正常假期当成系统异常。
+  Future<int?> fetchCurrentWeek() {
     return _request((client) async {
       final resp = await client.get(
         Uri.parse('$kZhjwBase/'),
@@ -64,10 +67,9 @@ class ZhjwApiService {
       final body = resp.body.trim();
       _checkSessionExpiry(body, resp.statusCode);
       final match = RegExp(r'第(\d+)周').firstMatch(body);
-      if (match == null) {
-        throw const ServiceException('无法获取当前周数，请检查教务系统状态');
-      }
-      return int.parse(match.group(1)!);
+      if (match != null) return int.parse(match.group(1)!);
+      if (body.contains('当前处于假期时间')) return null;
+      throw const ServiceException('无法获取当前周数，请检查教务系统状态');
     });
   }
 

--- a/test/zhjw_api_service_test.dart
+++ b/test/zhjw_api_service_test.dart
@@ -1,0 +1,90 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:bugaoshan/injection/injector.dart';
+import 'package:bugaoshan/services/api/zhjw_api_service.dart';
+import 'package:bugaoshan/services/auth/cookie_client.dart';
+import 'package:bugaoshan/services/auth/scu_auth.dart';
+import 'package:bugaoshan/services/auth/scu_exceptions.dart';
+import 'package:bugaoshan/services/auth/zhjw_auth.dart';
+import 'package:bugaoshan/utils/auth_logger.dart';
+
+void main() {
+  late SharedPreferences prefs;
+  late AuthLogger logger;
+
+  setUp(() async {
+    await getIt.reset();
+    logger = AuthLogger();
+    getIt.registerSingleton<AuthLogger>(logger);
+    SharedPreferences.setMockInitialValues({});
+    prefs = await SharedPreferences.getInstance();
+  });
+
+  tearDown(() async {
+    await getIt.reset();
+  });
+
+  test('fetchCurrentWeek parses teaching week from home page', () async {
+    final helper = _buildApi('<html>第12周</html>', prefs, logger);
+    addTearDown(helper.auth.dispose);
+    expect(await helper.api.fetchCurrentWeek(), 12);
+  });
+
+  test('fetchCurrentWeek returns null on vacation home page', () async {
+    final helper = _buildApi('<html>当前处于假期时间</html>', prefs, logger);
+    addTearDown(helper.auth.dispose);
+    expect(await helper.api.fetchCurrentWeek(), isNull);
+  });
+
+  test(
+    'fetchCurrentWeek throws when week is unavailable outside vacation',
+    () async {
+      final helper = _buildApi('<html>教务系统</html>', prefs, logger);
+      addTearDown(helper.auth.dispose);
+      await expectLater(
+        helper.api.fetchCurrentWeek(),
+        throwsA(isA<ServiceException>()),
+      );
+    },
+  );
+}
+
+({ZhjwApiService api, ZhjwAuth auth}) _buildApi(
+  String homeBody,
+  SharedPreferences prefs,
+  AuthLogger logger,
+) {
+  var requests = 0;
+  final client = CookieClient(
+    inner: MockClient((request) async {
+      requests++;
+      if (requests == 1) return http.Response('ok', 200, request: request);
+      return http.Response.bytes(
+        utf8.encode(homeBody),
+        200,
+        headers: const {'content-type': 'text/html; charset=utf-8'},
+        request: request,
+      );
+    }),
+  );
+  final scuAuth = _TestScuAuth(prefs, logger: logger, client: client);
+  final auth = ZhjwAuth(scuAuth, logger: logger);
+  return (api: ZhjwApiService(auth), auth: auth);
+}
+
+class _TestScuAuth extends ScuAuth {
+  final CookieClient client;
+
+  _TestScuAuth(super.prefs, {required super.logger, required this.client});
+
+  @override
+  Future<CookieClient> getClient() async => client;
+
+  @override
+  String? get accessToken => 'test-token';
+}


### PR DESCRIPTION
### 描述

**问题**：学期之间放假时，app 内课表页显示"放假中"，但桌面小组件仍显示"第 X 周"并加载课程，状态不同步。

**修复**：
- Android / iOS 小组件均复刻 app 端放假判断逻辑（学期已结束且下学期未开始 → 放假中），放假时显示"放假中"+ 空态提示，不加载课程、不调度课程边界闹钟
- 新增 `parseCalendarDate` 安全解析，非法学期日期不再导致整个小组件加载失败

**其他**：
- 附件管理页文件右侧菜单新增"删除"功能
- 补充 CHANGELOG 与 README（部分功能条目、iOS/鸿蒙邀测说明、平台 badge）