### PR TITLE
ci: F-Droid 可复制构建（Reproducible Builds）适配

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -17,9 +17,6 @@ outputs:
   GIT_COMMIT_DATE:
     description: "Git commit date"
     value: ${{ steps.git_meta.outputs.GIT_COMMIT_DATE }}
-  BUILD_TIME:
-    description: "Build time"
-    value: ${{ steps.git_meta.outputs.BUILD_TIME }}
 
 runs:
   using: composite

--- a/.github/scripts/git_meta.py
+++ b/.github/scripts/git_meta.py
@@ -1,7 +1,6 @@
 """Extract git metadata for CI builds and output to GITHUB_OUTPUT."""
 
 import subprocess
-import datetime
 import os
 import shlex
 
@@ -21,13 +20,13 @@ def main():
     git_commit = run(["git", "rev-parse", "HEAD"])
     git_commit_date = run(["git", "log", "-1", "--format=%ci"])
 
-    build_time = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%S+0000")
-
+    # 注意：不要在这里加入构建时间戳等非确定性输出。
+    # Android release 需要与 F-Droid 构建服务器产出逐字节一致的 APK（可复制构建），
+    # 同一 commit 的任何两次构建必须得到完全相同的结果。
     outputs = {
         "GIT_TAG": tag,
         "GIT_COMMIT": git_commit,
         "GIT_COMMIT_DATE": git_commit_date,
-        "BUILD_TIME": build_time,
     }
 
     output_path = os.environ.get("GITHUB_OUTPUT", "")

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -54,8 +54,7 @@ jobs:
             --obfuscate --split-debug-info=build/app/outputs/symbols/universal \
             --dart-define=GIT_TAG=${{ steps.setup.outputs.GIT_TAG }} \
             --dart-define=GIT_COMMIT=${{ steps.setup.outputs.GIT_COMMIT }} \
-            --dart-define=GIT_COMMIT_DATE=${{ steps.setup.outputs.GIT_COMMIT_DATE }} \
-            --dart-define=BUILD_TIME=${{ steps.setup.outputs.BUILD_TIME }}
+            --dart-define=GIT_COMMIT_DATE=${{ steps.setup.outputs.GIT_COMMIT_DATE }}
           mkdir -p release-apks
           cp build/app/outputs/flutter-apk/app-release.apk \
             release-apks/app-universal-release.apk
@@ -66,8 +65,7 @@ jobs:
             --obfuscate --split-debug-info=build/app/outputs/symbols/split \
             --dart-define=GIT_TAG=${{ steps.setup.outputs.GIT_TAG }} \
             --dart-define=GIT_COMMIT=${{ steps.setup.outputs.GIT_COMMIT }} \
-            --dart-define=GIT_COMMIT_DATE=${{ steps.setup.outputs.GIT_COMMIT_DATE }} \
-            --dart-define=BUILD_TIME=${{ steps.setup.outputs.BUILD_TIME }}
+            --dart-define=GIT_COMMIT_DATE=${{ steps.setup.outputs.GIT_COMMIT_DATE }}
           cp build/app/outputs/flutter-apk/app-*-release.apk release-apks/
 
       - name: Upload universal and split APKs

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -64,8 +64,7 @@ jobs:
           flutter build linux --release \
             --dart-define=GIT_TAG=${{ steps.setup.outputs.GIT_TAG }} \
             --dart-define=GIT_COMMIT=${{ steps.setup.outputs.GIT_COMMIT }} \
-            --dart-define=GIT_COMMIT_DATE=${{ steps.setup.outputs.GIT_COMMIT_DATE }} \
-            --dart-define=BUILD_TIME=${{ steps.setup.outputs.BUILD_TIME }}
+            --dart-define=GIT_COMMIT_DATE=${{ steps.setup.outputs.GIT_COMMIT_DATE }}
 
       - name: Archive Linux Release
         run: tar -czvf linux-release.tar.gz -C build/linux/x64/release/bundle .

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -35,8 +35,7 @@ jobs:
           flutter build windows --release \
             --dart-define=GIT_TAG=${{ steps.setup.outputs.GIT_TAG }} \
             --dart-define=GIT_COMMIT=${{ steps.setup.outputs.GIT_COMMIT }} \
-            --dart-define=GIT_COMMIT_DATE=${{ steps.setup.outputs.GIT_COMMIT_DATE }} \
-            --dart-define=BUILD_TIME=${{ steps.setup.outputs.BUILD_TIME }}
+            --dart-define=GIT_COMMIT_DATE=${{ steps.setup.outputs.GIT_COMMIT_DATE }}
         shell: bash
 
       - name: Archive Windows Release

--- a/lib/providers/app_info_provider.dart
+++ b/lib/providers/app_info_provider.dart
@@ -4,6 +4,18 @@ import 'package:bugaoshan/models/version_info.dart';
 import 'package:bugaoshan/providers/environment_info/native.dart';
 
 class AppInfoProvider {
+  /// 已知 F-Droid 客户端的包名。
+  ///
+  /// 从这些渠道安装的包由 F-Droid 负责更新。由于 F-Droid 版采用可复制构建，
+  /// 与 GitHub Release 同签名，技术上自更新也能成功，但 F-Droid 收录政策要求
+  /// 应用不得引导用户绕过 F-Droid 渠道更新，因此需要对这类安装隐藏自更新。
+  static const _fdroidInstallerStores = {
+    'org.fdroid.fdroid', // F-Droid 官方客户端
+    'org.fdroid.basic', // F-Droid Basic
+    'com.looker.droidify', // Droid-ify
+    'com.machiav3lli.fdroid', // Neo Store
+  };
+
   PackageInfo packageInfo;
   AppInfoProvider(this.packageInfo) {
     _version = packageInfo.version;
@@ -15,14 +27,16 @@ class AppInfoProvider {
     return _version;
   }
 
+  /// 是否从 F-Droid 渠道安装（官方客户端及常见第三方客户端）。
+  bool get isFdroidInstall =>
+      _fdroidInstallerStores.contains(packageInfo.installerStore);
+
   String get gitTag =>
       const String.fromEnvironment('GIT_TAG', defaultValue: 'null');
   String get gitCommit =>
       const String.fromEnvironment('GIT_COMMIT', defaultValue: 'null');
   String get gitCommitDateRaw =>
       const String.fromEnvironment('GIT_COMMIT_DATE', defaultValue: 'null');
-  String get buildTime =>
-      const String.fromEnvironment('BUILD_TIME', defaultValue: 'null');
   String get shortCommit =>
       gitCommit.length >= 7 ? gitCommit.substring(0, 7) : gitCommit;
 
@@ -43,8 +57,7 @@ class AppInfoProvider {
       build:
           "Tag: $gitTag\n"
           "Commit: $shortCommit\n"
-          "CommitDate: $gitCommitDateRaw\n"
-          "BuildTime: $buildTime",
+          "CommitDate: $gitCommitDateRaw",
     );
   }
 }

--- a/lib/services/update_service.dart
+++ b/lib/services/update_service.dart
@@ -74,9 +74,13 @@ class UpdateService {
   UpdateService(this._prefs, this._currentVersion);
 
   bool get supportsInAppUpdate =>
-      (Platform.isLinux && !Platform.environment.containsKey('FLATPAK_ID')) ||
-      Platform.isAndroid ||
-      Platform.isWindows;
+      // F-Droid 渠道安装的包由 F-Droid 负责更新，应用内自更新对其隐藏。
+      // 用运行时安装来源判断而非构建时开关，以保持 F-Droid 可复制构建
+      // 与 CI 产物逐字节一致。
+      !getIt<AppInfoProvider>().isFdroidInstall &&
+      ((Platform.isLinux && !Platform.environment.containsKey('FLATPAK_ID')) ||
+          Platform.isAndroid ||
+          Platform.isWindows);
 
   UpdateAssetPlatform? get _assetPlatform {
     if (Platform.isAndroid) return UpdateAssetPlatform.android;

--- a/update_and_push_tag.py
+++ b/update_and_push_tag.py
@@ -46,6 +46,22 @@ def verify_pattern(version:str)->bool:
         return False
     return True
 
+def split_version(version:str):
+    """把 'x.y.z' 或 'x.y.z+N' 拆成 (x, y, z) 三个整数，忽略 +N 构建号后缀。"""
+    base = version.split("+")[0]
+    a, b, c = (int(p) for p in base.split("."))
+    return a, b, c
+
+def get_build_number(version:str)->int:
+    """versionCode 基线 = a*10000 + b*100 + c。
+
+    CI 构建时 Flutter 的 --split-per-abi 会在此基础上自动加 ABI 偏移
+    (v7a +1000 / v8a +2000 / x86_64 +4000)，F-Droid 的 UpdateCheckData
+    依赖 pubspec.yaml 中的 '+N' 提取 vercode，因此发版时必须保留该后缀。
+    """
+    a, b, c = split_version(version)
+    return a * 10000 + b * 100 + c
+
 def get_latest_tag():
     # 定义通用的subprocess参数
     subprocess_kwargs = {
@@ -69,8 +85,8 @@ def get_latest_tag():
     return prev_tag
 
 def get_version_increase(version:str):
-    a,b,c=version.split(".")
-    return f"{a}.{b}.{int(c)+1}"
+    a,b,c=split_version(version)
+    return f"{a}.{b}.{c+1}"
 
 def commit_changes(new_version:str):
     print("提交更改...")
@@ -187,7 +203,9 @@ if local_exists or remote_exists:
         print("操作已取消。")
         exit(0)
 
-print(f"即将修改pubspec.yaml中的版本号为:{new_version}，并创建tag {tag_name}，然后推送。")
+build_number = get_build_number(new_version)
+full_version = f"{new_version}+{build_number}"
+print(f"即将修改pubspec.yaml中的版本号为:{full_version}（含versionCode基线+{build_number}），并创建tag {tag_name}，然后推送。")
 print("请确认是否继续？(y/n)")
 confirm = input()
 if confirm.lower() != 'y':
@@ -197,7 +215,7 @@ if confirm.lower() != 'y':
 # modify pubspec.yaml
 with open('pubspec.yaml', 'r', encoding='utf-8') as f:
     data = yaml.safe_load(f)
-data['version'] = new_version
+data['version'] = full_version
 with open('pubspec.yaml', 'w', encoding='utf-8') as f:
     yaml.safe_dump(data, f, default_flow_style=False, allow_unicode=True, sort_keys=False)
 

--- a/update_and_push_tag.py
+++ b/update_and_push_tag.py
@@ -47,8 +47,8 @@ def verify_pattern(version:str)->bool:
     return True
 
 def split_version(version:str):
-    """把 'x.y.z' 或 'x.y.z+N' 拆成 (x, y, z) 三个整数，忽略 +N 构建号后缀。"""
-    base = version.split("+")[0]
+    """把 'x.y.z'、'x.y.z+N' 或 'x.y.z-pre+N' 拆成 (x, y, z) 三个整数。"""
+    base = version.split("+")[0].split("-")[0]
     a, b, c = (int(p) for p in base.split("."))
     return a, b, c
 


### PR DESCRIPTION
## 背景

配合 PR #193 的 F-Droid 上架，确定走**官方 F-Droid + 可复制构建**路线：F-Droid 构建服务器从源码构建未签名 APK，与 GitHub Release 的 CI 产物逐字节比对，一致则**直接发布 CI 签名的 APK**——两个渠道同签名，用户可互相覆盖安装。本 PR 是主仓库侧需要的全部适配。

## 改动

### 1. `update_and_push_tag.py`：发版保留 versionCode 基线（+N）

- 原脚本写入纯 `x.y.z`，会抹掉 +N；且读取 `2.2.0+20200` 时 `int('0+20200')` 直接崩溃
- 现在读取时剥离 `+N`/`-pre` 后缀，写入时自动计算 `N = major*10000 + minor*100 + patch`
- **为什么必须保留**：F-Droid 的 `UpdateCheckData` 靠正则从 pubspec 的 `+N` 提取 vercode，丢了自动更新就断；CI 的 `--split-per-abi` 在 N 的基础上自动加 ABI 偏移（见下）

### 2. 移除 `BUILD_TIME` dart-define

构建时间戳导致同一 commit 两次构建产物不同，是可复制构建的硬性破坏项。涉及 `git_meta.py`、三个平台构建 workflow、setup action、`app_info_provider.dart`（关于页本就有 CommitDate，信息无损失）。

### 3. F-Droid 渠道安装隐藏应用内自更新

- `AppInfoProvider.isFdroidInstall`：通过 `package_info_plus` 的 `installerStore` 识别 F-Droid 客户端（官方/Basic/Droid-ify/Neo Store）
- `UpdateService.supportsInAppUpdate` 对其返回 false
- F-Droid 收录政策要求应用不得引导用户绕过 F-Droid 更新；用**运行时**检测而非构建时开关，是为了保持单一构建产物——否则又会破坏逐字节一致

## 关键事实：versionCode 规则

已对照 Flutter 3.44 源码（`FlutterPlugin.kt`）确认：`--split-per-abi` 时 `versionCode = abiCode*1000 + base`（v7a=1, v8a=2, x86_64=4）。即 pubspec `2.3.0+20300` 时 CI 产出 universal=20300、v7a=21300、v8a=22300、x86_64=24300。PR #193 原先的 +1001/+2001/+4001 方案与之不符，已在该 PR 中一并修正。

## 与 PR #193 的协调

- 两边 `update_and_push_tag.py` 的修改已做成**相同文本**，无论谁先合并都不会冲突（#193 额外保留其 changelog 生成钩子）
- **合并顺序要求**：本 PR 与 #193 都必须在下一个 release（v2.3.0）之前合并，否则 CI 产物含 BUILD_TIME、无法通过 RB 验证
- v2.3.0 发布后：@wjj-8283 在 docker 里跑 `fdroid build --verify` 验证，通过即可向 fdroiddata 提交（recipe 已写在 #193 的 `metadata/io.github.the_brotherhood_of_scu.bugaoshan.yml`）

## 测试

- `flutter analyze` 改动文件无问题
- tag 脚本版本计算逻辑已用断言验证（含 `+N`/`-pre` 兼容）
- workflow/action YAML 语法校验通过，`git_meta.py` 本地运行输出正常