### PR TITLE
refactor: 撤销余额查询历史记录的账号隔离

### DIFF
--- a/docs/decisions/0005-remove-balance-history-account-isolation.md
+++ b/docs/decisions/0005-remove-balance-history-account-isolation.md
@@ -1,0 +1,47 @@
+# ADR-0005：撤销余额历史记录的账号隔离
+
+- 状态：已接受并实施
+- 决策日期：2026-08-12
+
+## 背景
+
+PR #198（`refactor/balance-provider-state`，merge commit `e354cec`）在把余额查询远端状态收敛到 `BalanceQueryProvider` 的同时，引入了**账号维度的数据隔离**：
+
+1. 身份状态机：Provider 增加 `setUserIdentity` / `activateForPrincipal` / `clear()` / `confirmedUserIdentity`，由 injector 在登录、切换账号和登出时驱动。
+2. 历史记录按账号隔离：房间标识 `roomKey` 增加 `balance-v2:$identity:` 前缀，同一房间在不同账号下是不同 key，各自采样、各自存历史。
+3. 绑定按账号分区存储：SharedPreferences key 变为 `balance_query_binding_<identity>` / `balance_query_current_room_<identity>`，并配套旧数据的按账号迁移逻辑。
+4. 登出清理：登出时清空 Provider 内存状态。
+
+
+## 决策
+
+**撤销余额查询的账号隔离，余额数据按房间维度全局共享：**
+
+1. `roomKey` 只由房间属性构成（`schoolCode_regCode_unitCode_roomNo`），不含账号信息；历史记录跨账号复用。
+2. 绑定与当前房间索引恢复全局持久化（`balance_query_binding` / `balance_query_current_room`），不做按账号分区和迁移。
+3. 移除身份状态机（`setUserIdentity` / `activateForPrincipal` / `clear` / `confirmedUserIdentity` 及 generation 守卫），登出不再清空余额数据。
+4. 保留 PR #198 的状态收敛架构：页面只读 Provider 快照并发出加载/刷新意图；保留多房间/多范围缓存（余额 30 分钟 TTL、趋势按范围）、并发请求合并（in-flight 复用）和"余额解析失败不写 0"的修复。
+
+## 理由
+
+1. **不是隐私数据**：宿舍电费/空调余额是房间维度的公共数据，同寝室成员看到的是同一房间、同一数值，隔离的隐私前提不成立。
+2. **避免重复获取**：账号隔离使同寝室成员各自的 `roomKey` 不同，室友查询并采样过的历史记录无法复用，造成重复请求和重复采样。
+3. **降低复杂度**：身份状态机、分区存储、数据迁移和登出清理钩子只为隔离服务；撤销后 Provider 不再感知登录账号，与成绩等隐私数据（按账号隔离）形成清晰对比。
+
+## 兼容性
+
+- 页面与 Provider 的公开 API 不变（`balanceStateFor` / `trendStateFor` / `ensureBalance` / `ensureTrend` 等），UI 层零改动。
+- 其余 Provider（成绩等隐私数据）的账号隔离不受影响。
+
+## 后果
+
+正面影响：
+
+- 同寝室账号共享历史记录与自动采样结果，避免重复获取。
+- Provider 简化：无身份状态、无迁移、无登出清理分支。
+- 登出/切换账号不会让余额查询页丢失已绑定房间。
+
+代价与约束：
+
+- 余额数据不能再按账号扩展私有化；未来若出现账号维度的余额数据，需重新设计存储 key。
+- 多账号共用同一份绑定列表：任何账号都能看到（非隐私的）房间绑定集合。

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -8,6 +8,7 @@ ADR 保存已经影响代码边界、后续开发仍需遵守的设计决策。�
 | [0002](0002-separate-subsystem-authentication.md) | 2026-06-06 | 已接受并实施 | 根认证与子系统认证拆分，显式声明依赖 |
 | [0003](0003-make-course-display-settings-global.md) | 2026-07-05 | 已接受并实施 | 课表显示偏好归属全局设置域 |
 | [0004](0004-use-distribution-wpe-on-linux.md) | 2026-07-29 | 已接受并实施 | Linux WebView 保留插件，但由分发环境提供 WPE |
+| [0005](0005-remove-balance-history-account-isolation.md) | 2026-08-12 | 已接受并实施 | 撤销余额历史记录的账号隔离，余额数据按房间共享 |
 
 ## 状态定义
 

--- a/lib/injection/injector.dart
+++ b/lib/injection/injector.dart
@@ -269,30 +269,13 @@ void _configureAsyncDependencies() {
     await getIt.isReady<DatabaseService>();
     await getIt.isReady<PayAppAuth>();
     await getIt.isReady<AppConfigProvider>();
-    await getIt.isReady<ScuAuthProvider>();
-    await getIt.isReady<ScuAuth>();
-    final prefs = getIt<SharedPreferences>();
-    final authProvider = getIt<ScuAuthProvider>();
-    final scuAuth = getIt<ScuAuth>();
-    String? currentIdentity() => BalanceQueryProvider.confirmedUserIdentity(
-      isLoggedIn: authProvider.isLoggedIn,
-      principal: scuAuth.principal,
-    );
-    final balanceProvider = BalanceQueryProvider(
-      prefs,
+    return BalanceQueryProvider(
+      getIt<SharedPreferences>(),
       getIt<PayAppApiService>(),
       getIt<DatabaseService>(),
       getIt<PayAppAuth>(),
       getIt<AppConfigProvider>(),
     );
-    await balanceProvider.setUserIdentity(currentIdentity());
-    authProvider.addListener(() {
-      final identity = currentIdentity();
-      if (identity != null) {
-        unawaited(balanceProvider.setUserIdentity(identity));
-      }
-    });
-    return balanceProvider;
   });
   getIt.registerSingletonAsync<UpdateService>(() async {
     await getIt.isReady<SharedPreferences>();
@@ -352,10 +335,6 @@ void _configureAsyncDependencies() {
   getIt.isReady<ScuAuth>().then((_) {
     getIt<ScuAuth>().addListener(() {
       final scu = getIt<ScuAuth>();
-      if (getIt.isRegistered<BalanceQueryProvider>() &&
-          scu.state != AuthState.ready) {
-        getIt<BalanceQueryProvider>().clear();
-      }
       if (scu.state == AuthState.unknown) {
         // logout 发生，清理需要登录态的 Provider 缓存
         if (getIt.isRegistered<PlanCompletionProvider>()) {

--- a/lib/providers/balance_query_provider.dart
+++ b/lib/providers/balance_query_provider.dart
@@ -133,6 +133,12 @@ class _TrendEntry {
   );
 }
 
+/// 余额查询状态管理。
+///
+/// 余额（电费/空调）是房间维度的公共数据，不属于任何单个账号：
+/// 历史记录按房间标识（roomKey）共享，绑定与当前房间全局持久化，
+/// 不按登录账号隔离。同一寝室的不同账号看到并复用同一份数据，
+/// 避免重复查询（见 `docs/decisions/0005-remove-balance-history-account-isolation.md`）。
 class BalanceQueryProvider extends ChangeNotifier {
   final SharedPreferences _prefs;
   final PayAppApiService _payappApi;
@@ -143,17 +149,12 @@ class BalanceQueryProvider extends ChangeNotifier {
 
   final _balanceEntries = <_BalanceCacheKey, _ResourceEntry<RoomInfo>>{};
   final _trendEntries = <_TrendCacheKey, _TrendEntry>{};
-  _ResourceEntry<List<CampusItem>> _campusEntry =
-      _ResourceEntry<List<CampusItem>>();
+  final _campusEntry = _ResourceEntry<List<CampusItem>>();
   final _buildingEntries = <String, _ResourceEntry<List<BuildingItem>>>{};
   final _unitEntries = <String, _ResourceEntry<List<UnitItem>>>{};
 
   bool _lastPayAppReady = false;
   bool _autoSampling = false;
-  String? _userIdentity;
-  int _identityGeneration = 0;
-  Future<void>? _identityActivation;
-  Future<void>? _legacyMigration;
 
   BalanceQueryProvider(
     this._prefs,
@@ -163,76 +164,10 @@ class BalanceQueryProvider extends ChangeNotifier {
     this._appConfig, {
     DateTime Function()? now,
   }) : _now = now ?? DateTime.now {
+    _loadBindingInfo();
     _payAppAuth.addListener(_onPayAppAuthChanged);
     _lastPayAppReady = _payAppAuth.isReady;
   }
-
-  static String? _normalizeIdentity(String? value) {
-    final normalized = value?.trim();
-    return normalized == null || normalized.isEmpty ? null : normalized;
-  }
-
-  /// 仅接受与当前 token 绑定的 SCU principal 作为余额数据身份。
-  static String? confirmedUserIdentity({
-    required bool isLoggedIn,
-    required String? principal,
-  }) => isLoggedIn ? _normalizeIdentity(principal) : null;
-
-  /// 当前激活的 SCU principal。为 null 时不暴露、也不恢复任何余额数据。
-  String? get userIdentity => _userIdentity;
-
-  /// 切换已确认的 SCU 身份；身份未知时清空所有内存余额资源。
-  ///
-  /// 调用方可以不 await 本方法，但在页面展示绑定前应保证当前身份已激活。
-  Future<void> setUserIdentity(String? userIdentity) =>
-      activateForPrincipal(userIdentity);
-
-  /// [setUserIdentity] 的语义化别名，供认证协调层使用。
-  Future<void> activateForPrincipal(String? principal) {
-    final normalized = _normalizeIdentity(principal);
-    if (normalized == null) {
-      clear();
-      return Future.value();
-    }
-    if (normalized == _userIdentity && _identityActivation != null) {
-      return _identityActivation!;
-    }
-
-    final generation = ++_identityGeneration;
-    _userIdentity = normalized;
-    _resetInMemoryState();
-    notifyListeners();
-
-    final activation = _restoreBindingsFor(normalized, generation);
-    _identityActivation = activation;
-    return activation;
-  }
-
-  /// 使当前账号的所有内存数据和飞行请求失效。
-  ///
-  /// 已发出的网络或数据库操作仍会自然完成，但不会再写回 Provider 或历史记录。
-  void clear() {
-    _identityGeneration++;
-    _userIdentity = null;
-    _identityActivation = null;
-    _resetInMemoryState();
-    notifyListeners();
-  }
-
-  void _resetInMemoryState() {
-    _bindings = [];
-    _currentIndex = 0;
-    _isSwitching = false;
-    _autoSampling = false;
-    _balanceEntries.clear();
-    _trendEntries.clear();
-    _campusEntry = _ResourceEntry<List<CampusItem>>();
-    _buildingEntries.clear();
-    _unitEntries.clear();
-  }
-
-  bool _isCurrentGeneration(int generation) =>
-      generation == _identityGeneration;
 
   /// PayAppAuth 状态变化:isReady 由 false→true 时(登录成功或 SSO 重连),
   /// 若用户开启了"登录后自动采样"开关,且当前房间今日尚无记录,则静默采样一次。
@@ -249,7 +184,6 @@ class BalanceQueryProvider extends ChangeNotifier {
     if (!_appConfig.autoSampleBalanceOnLogin.value) return;
     final binding = currentBinding;
     if (binding == null) return;
-    final generation = _identityGeneration;
 
     _autoSampling = true;
     try {
@@ -261,13 +195,11 @@ class BalanceQueryProvider extends ChangeNotifier {
         balanceType: kBalanceTypeElectric,
         since: startOfTodayUtc,
       );
-      if (!_isCurrentGeneration(generation)) return;
       final acRecords = await _db.getBalanceRecords(
         roomKey: roomKey,
         balanceType: kBalanceTypeAc,
         since: startOfTodayUtc,
       );
-      if (!_isCurrentGeneration(generation)) return;
 
       if (electricRecords.isEmpty) {
         try {
@@ -286,9 +218,7 @@ class BalanceQueryProvider extends ChangeNotifier {
     } catch (e) {
       debugPrint('Auto-sample balance failed: $e');
     } finally {
-      if (_isCurrentGeneration(generation)) {
-        _autoSampling = false;
-      }
+      _autoSampling = false;
     }
   }
 
@@ -344,119 +274,41 @@ class BalanceQueryProvider extends ChangeNotifier {
       )
       .state;
 
-  Future<void> _restoreBindingsFor(String identity, int generation) async {
-    await _migrateLegacyBindings();
-    if (!_isCurrentGeneration(generation) || _userIdentity != identity) return;
-
-    final json = _prefs.getString(_bindingInfoKeyFor(identity));
-    var bindings = <RoomBinding>[];
+  void _loadBindingInfo() {
+    final json = _prefs.getString(_keyBindingInfo);
     if (json != null) {
       try {
         final List<dynamic> list = jsonDecode(json);
-        bindings = list
+        _bindings = list
             .map((e) => RoomBinding.fromJson(e as Map<String, dynamic>))
             .toList();
       } catch (e) {
         debugPrint('Failed to load balance binding info: $e');
       }
     }
-    if (!_isCurrentGeneration(generation) || _userIdentity != identity) return;
-
-    var currentIndex = _prefs.getInt(_currentRoomIndexKeyFor(identity)) ?? 0;
-    if (currentIndex < 0 || currentIndex >= bindings.length) {
-      currentIndex = bindings.isEmpty ? 0 : bindings.length - 1;
+    _currentIndex = _prefs.getInt(_keyCurrentRoomIndex) ?? 0;
+    if (_currentIndex < 0 || _currentIndex >= _bindings.length) {
+      _currentIndex = _bindings.isEmpty ? 0 : _bindings.length - 1;
     }
-    _bindings = bindings;
-    _currentIndex = currentIndex;
     notifyListeners();
   }
 
-  /// 将旧版全局绑定迁移为每个 SCU principal 独立的存储区。
-  ///
-  /// 老记录的 [RoomBinding.cusNo] 是唯一可用的归属信息；无法归属的记录不迁移，
-  /// 以避免在任意账号下展示它们。
-  Future<void> _migrateLegacyBindings() {
-    final pending = _legacyMigration;
-    if (pending != null) return pending;
-
-    final migration = _performLegacyBindingMigration();
-    _legacyMigration = migration;
-    return migration;
-  }
-
-  Future<void> _performLegacyBindingMigration() async {
-    final json = _prefs.getString(_keyBindingInfo);
-    if (json == null) return;
-
-    try {
-      final List<dynamic> list = jsonDecode(json);
-      final bindings = list
-          .map((e) => RoomBinding.fromJson(e as Map<String, dynamic>))
-          .toList();
-      final legacyIndex = _prefs.getInt(_keyCurrentRoomIndex) ?? 0;
-      final grouped = <String, List<RoomBinding>>{};
-      final selectedIndices = <String, int>{};
-
-      for (var index = 0; index < bindings.length; index++) {
-        final binding = bindings[index];
-        final identity = _normalizeIdentity(binding.cusNo);
-        if (identity == null) continue;
-        final group = grouped.putIfAbsent(identity, () => <RoomBinding>[]);
-        if (index == legacyIndex) selectedIndices[identity] = group.length;
-        group.add(binding);
-      }
-
-      for (final entry in grouped.entries) {
-        final identity = entry.key;
-        if (_prefs.containsKey(_bindingInfoKeyFor(identity))) continue;
-        await _prefs.setString(
-          _bindingInfoKeyFor(identity),
-          jsonEncode(entry.value.map((binding) => binding.toJson()).toList()),
-        );
-        final selectedIndex = selectedIndices[identity] ?? 0;
-        await _prefs.setInt(_currentRoomIndexKeyFor(identity), selectedIndex);
-      }
-
-      await _prefs.remove(_keyBindingInfo);
-      await _prefs.remove(_keyCurrentRoomIndex);
-    } catch (e) {
-      debugPrint('Failed to migrate legacy balance bindings: $e');
-    }
-  }
-
-  Future<void> _saveBindingInfo({
-    required String identity,
-    required List<RoomBinding> bindings,
-    required int currentIndex,
-  }) async {
-    final json = jsonEncode(bindings.map((e) => e.toJson()).toList());
-    await _prefs.setString(_bindingInfoKeyFor(identity), json);
-    await _prefs.setInt(_currentRoomIndexKeyFor(identity), currentIndex);
+  Future<void> _saveBindingInfo() async {
+    final json = jsonEncode(_bindings.map((e) => e.toJson()).toList());
+    await _prefs.setString(_keyBindingInfo, json);
+    await _prefs.setInt(_keyCurrentRoomIndex, _currentIndex);
   }
 
   Future<void> addBinding(RoomBinding binding) async {
-    final identity = _userIdentity;
-    if (identity == null) throw StateError('未确认当前登录账号');
-    final generation = _identityGeneration;
     _bindings.add(binding);
     _currentIndex = _bindings.length - 1;
-    final bindings = List<RoomBinding>.from(_bindings);
-    final currentIndex = _currentIndex;
+    await _saveBindingInfo();
     notifyListeners();
-    await _saveBindingInfo(
-      identity: identity,
-      bindings: bindings,
-      currentIndex: currentIndex,
-    );
-    if (!_isCurrentGeneration(generation) || _userIdentity != identity) return;
     ensureCurrentBalances();
   }
 
   Future<void> removeBinding(int index) async {
     if (index < 0 || index >= _bindings.length) return;
-    final identity = _userIdentity;
-    if (identity == null) return;
-    final generation = _identityGeneration;
     final removed = _bindings[index];
     final roomKey = _roomKeyFor(removed);
     _bindings.removeAt(index);
@@ -466,34 +318,21 @@ class BalanceQueryProvider extends ChangeNotifier {
       _currentIndex = _bindings.isEmpty ? 0 : _bindings.length - 1;
     }
     _evictBalanceEntriesFor(removed);
-    final bindings = List<RoomBinding>.from(_bindings);
-    final currentIndex = _currentIndex;
+    await _saveBindingInfo();
     notifyListeners();
-    await _saveBindingInfo(
-      identity: identity,
-      bindings: bindings,
-      currentIndex: currentIndex,
-    );
-    if (!_isCurrentGeneration(generation) || _userIdentity != identity) return;
     // 同步删除该房间的历史记录,避免残留。
     try {
       await _db.deleteBalanceRecordsByRoom(roomKey);
     } catch (e) {
       debugPrint('Failed to clean balance history for removed room: $e');
     }
-    if (!_isCurrentGeneration(generation) || _userIdentity != identity) return;
     ensureCurrentBalances();
   }
 
   Future<void> switchBinding(int index) async {
     if (index < 0 || index >= _bindings.length) return;
-    final identity = _userIdentity;
-    if (identity == null) return;
-    final generation = _identityGeneration;
     _currentIndex = index;
-    final currentIndex = _currentIndex;
-    await _prefs.setInt(_currentRoomIndexKeyFor(identity), currentIndex);
-    if (!_isCurrentGeneration(generation) || _userIdentity != identity) return;
+    await _prefs.setInt(_keyCurrentRoomIndex, _currentIndex);
     _isSwitching = true;
     notifyListeners();
 
@@ -509,17 +348,14 @@ class BalanceQueryProvider extends ChangeNotifier {
         roomNo: binding.roomNo,
       );
     } finally {
-      if (_isCurrentGeneration(generation) && _userIdentity == identity) {
-        _isSwitching = false;
-        notifyListeners();
-        ensureCurrentBalances();
-      }
+      _isSwitching = false;
+      notifyListeners();
+      ensureCurrentBalances();
     }
   }
 
   /// 返回当前房间+类型的内存缓存；不存在或满 30 分钟时重新请求。
   Future<RoomInfo> ensureBalance(int balanceType) async {
-    _requireActiveIdentity();
     final binding = currentBinding;
     if (binding == null) throw BalanceQueryException('未绑定房间');
     return _loadBalanceFor(binding, balanceType);
@@ -527,7 +363,6 @@ class BalanceQueryProvider extends ChangeNotifier {
 
   /// 清空当前值并强制向服务端请求最新余额。
   Future<RoomInfo> refreshBalance(int balanceType) async {
-    _requireActiveIdentity();
     final binding = currentBinding;
     if (binding == null) throw BalanceQueryException('未绑定房间');
     return _loadBalanceFor(binding, balanceType, force: true);
@@ -553,11 +388,6 @@ class BalanceQueryProvider extends ChangeNotifier {
     int balanceType, {
     bool force = false,
   }) {
-    final identity = _userIdentity;
-    if (identity == null) {
-      throw StateError('未确认当前登录账号');
-    }
-    final generation = _identityGeneration;
     final roomKey = _roomKeyFor(binding);
     final entry = _balanceEntries.putIfAbsent(
       _BalanceCacheKey(roomKey, balanceType),
@@ -574,17 +404,8 @@ class BalanceQueryProvider extends ChangeNotifier {
       clearValueOnLoad: true,
       force: force,
       onLoaded: (info) async {
-        if (!_isCurrentGeneration(generation) || _userIdentity != identity) {
-          return;
-        }
         if (_bindings.any((item) => _roomKeyFor(item) == roomKey)) {
-          await _recordHistory(
-            info,
-            balanceType: balanceType,
-            identity: identity,
-            generation: generation,
-            roomKey: roomKey,
-          );
+          await _recordHistory(info, binding, balanceType);
         }
       },
     );
@@ -597,7 +418,6 @@ class BalanceQueryProvider extends ChangeNotifier {
   Future<RoomInfo> queryAcInfo() => refreshBalance(kBalanceTypeAc);
 
   Future<List<CampusItem>> getCampusList() {
-    _requireActiveIdentity();
     return _loadResource(
       _campusEntry,
       _payappApi.getCampus,
@@ -606,7 +426,6 @@ class BalanceQueryProvider extends ChangeNotifier {
   }
 
   Future<List<BuildingItem>> getArchitectureList(String schoolCode) {
-    _requireActiveIdentity();
     final entry = _buildingEntries.putIfAbsent(
       schoolCode,
       _ResourceEntry<List<BuildingItem>>.new,
@@ -619,7 +438,6 @@ class BalanceQueryProvider extends ChangeNotifier {
   }
 
   Future<List<UnitItem>> getUnitList(String schoolCode, String regCode) {
-    _requireActiveIdentity();
     final entry = _unitEntries.putIfAbsent(
       _unitKey(schoolCode, regCode),
       _ResourceEntry<List<UnitItem>>.new,
@@ -640,7 +458,6 @@ class BalanceQueryProvider extends ChangeNotifier {
     String unitCode,
     String roomNo,
   ) {
-    _requireActiveIdentity();
     return _payappApi.verificationRoom(
       cusNo: cusNo,
       type: type,
@@ -668,7 +485,6 @@ class BalanceQueryProvider extends ChangeNotifier {
     final inFlight = entry.inFlight;
     if (inFlight != null) return inFlight;
 
-    final generation = _identityGeneration;
     entry.isLoading = true;
     entry.error = null;
     if (clearValueOnLoad) {
@@ -680,25 +496,17 @@ class BalanceQueryProvider extends ChangeNotifier {
     Future<T> execute() async {
       try {
         final loaded = await loader();
-        if (_isCurrentGeneration(generation)) {
-          if (onLoaded != null) await onLoaded(loaded);
-          if (_isCurrentGeneration(generation)) {
-            entry.value = loaded;
-            entry.updatedAt = _now();
-          }
-        }
+        if (onLoaded != null) await onLoaded(loaded);
+        entry.value = loaded;
+        entry.updatedAt = _now();
         return loaded;
       } catch (e) {
-        if (_isCurrentGeneration(generation)) {
-          entry.error = e;
-        }
+        entry.error = e;
         rethrow;
       } finally {
-        if (_isCurrentGeneration(generation)) {
-          entry.isLoading = false;
-          entry.inFlight = null;
-          notifyListeners();
-        }
+        entry.isLoading = false;
+        entry.inFlight = null;
+        notifyListeners();
       }
     }
 
@@ -726,14 +534,12 @@ class BalanceQueryProvider extends ChangeNotifier {
     bool force = false,
   }) async {
     final binding = currentBinding;
-    final identity = _userIdentity;
-    if (binding == null || identity == null) return;
+    if (binding == null) return;
     final roomKey = _roomKeyFor(binding);
     final entry = _trendEntryFor(binding, balanceType, since, until);
     if (!force && entry.records != null) return;
     final pending = entry.inFlight;
     if (pending != null) return pending;
-    final generation = _identityGeneration;
 
     entry.isLoading = true;
     entry.error = null;
@@ -752,21 +558,15 @@ class BalanceQueryProvider extends ChangeNotifier {
           since: from,
           until: until,
         );
-        if (_isCurrentGeneration(generation) && _userIdentity == identity) {
-          entry.records = List.unmodifiable(records);
-          entry.trend = BalanceTrendCalculator.calculate(entry.records!);
-        }
+        entry.records = List.unmodifiable(records);
+        entry.trend = BalanceTrendCalculator.calculate(entry.records!);
       } catch (e) {
-        if (_isCurrentGeneration(generation) && _userIdentity == identity) {
-          entry.error = e;
-        }
+        entry.error = e;
         rethrow;
       } finally {
-        if (_isCurrentGeneration(generation) && _userIdentity == identity) {
-          entry.isLoading = false;
-          entry.inFlight = null;
-          notifyListeners();
-        }
+        entry.isLoading = false;
+        entry.inFlight = null;
+        notifyListeners();
       }
     }
 
@@ -822,41 +622,23 @@ class BalanceQueryProvider extends ChangeNotifier {
         _now().difference(updatedAt) < cacheDuration;
   }
 
+  /// 房间标识：仅由房间属性构成，不包含账号信息。
+  ///
+  /// 余额是房间维度的公共数据，同一房间在不同账号下共享历史记录。
   String _roomKeyFor(RoomBinding binding) {
-    final identity = _userIdentity;
-    if (identity == null) {
-      throw StateError('未确认当前登录账号');
-    }
-    return 'balance-v2:$identity:'
-        '${binding.schoolCode}_${binding.regCode}_${binding.unitCode}_${binding.roomNo}';
+    return '${binding.schoolCode}_${binding.regCode}_${binding.unitCode}_${binding.roomNo}';
   }
 
   String _unitKey(String schoolCode, String regCode) =>
       '${schoolCode}_$regCode';
 
-  void _requireActiveIdentity() {
-    if (_userIdentity == null) {
-      throw StateError('未确认当前登录账号');
-    }
-  }
-
-  String _bindingInfoKeyFor(String identity) => '${_keyBindingInfo}_$identity';
-
-  String _currentRoomIndexKeyFor(String identity) =>
-      '${_keyCurrentRoomIndex}_$identity';
-
   /// 仅在成功请求后记录一条历史快照。失败不影响主流程。
   Future<void> _recordHistory(
-    RoomInfo info, {
-    required int balanceType,
-    required String identity,
-    required int generation,
-    required String roomKey,
-  }) async {
+    RoomInfo info,
+    RoomBinding binding,
+    int balanceType,
+  ) async {
     try {
-      if (!_isCurrentGeneration(generation) || _userIdentity != identity) {
-        return;
-      }
       final now = _now().toUtc();
       final balance = double.tryParse(info.balance);
       if (balance == null) {
@@ -864,27 +646,19 @@ class BalanceQueryProvider extends ChangeNotifier {
         return;
       }
       final record = BalanceRecord(
-        roomKey: roomKey,
+        roomKey: _roomKeyFor(binding),
         balanceType: balanceType,
         timestamp: now,
         balance: balance,
         price: double.tryParse(info.price) ?? 0,
       );
-      if (!_isCurrentGeneration(generation) || _userIdentity != identity) {
-        return;
-      }
       await _db.insertBalanceRecord(record);
-      if (!_isCurrentGeneration(generation) || _userIdentity != identity) {
-        return;
-      }
       await _db.deleteBalanceRecordsBefore(
         now.subtract(_balanceHistoryRetention),
       );
-      if (!_isCurrentGeneration(generation) || _userIdentity != identity) {
-        return;
-      }
       _trendEntries.removeWhere(
-        (key, _) => key.roomKey == roomKey && key.balanceType == balanceType,
+        (key, _) =>
+            key.roomKey == record.roomKey && key.balanceType == balanceType,
       );
     } catch (e) {
       debugPrint('Failed to record balance history: $e');

--- a/test/balance_query_provider_test.dart
+++ b/test/balance_query_provider_test.dart
@@ -183,93 +183,6 @@ void main() {
     expect(trend.records, hasLength(1));
   });
 
-  test('旧版全局绑定会按 principal 迁移并仅恢复当前账号的数据', () async {
-    final bindings = [
-      _binding('A', cusNo: 'student-a'),
-      _binding('B', cusNo: 'student-b'),
-    ];
-    final harness = await _createProvider(
-      bindings: bindings,
-      currentIndex: 1,
-      initialUserId: 'student-b',
-    );
-    addTearDown(harness.dispose);
-
-    expect(harness.provider.bindings.single.roomNo, 'B');
-    expect(harness.provider.currentIndex, 0);
-    expect(harness.prefs.containsKey('balance_query_binding'), isFalse);
-    expect(
-      harness.prefs.getString('balance_query_binding_student-a'),
-      isNotNull,
-    );
-    expect(
-      harness.prefs.getString('balance_query_binding_student-b'),
-      isNotNull,
-    );
-
-    await harness.provider.setUserIdentity('student-a');
-    expect(harness.provider.bindings.single.roomNo, 'A');
-  });
-
-  test('切换账号会隔离余额、趋势和选项缓存', () async {
-    final fakeApi = _FakePayAppApiService();
-    final harness = await _createProvider(
-      fakeApi: fakeApi,
-      bindings: [
-        _binding('A', cusNo: 'student-a'),
-        _binding('B', cusNo: 'student-b'),
-      ],
-      initialUserId: 'student-a',
-    );
-    addTearDown(harness.dispose);
-
-    await harness.provider.ensureBalance(kBalanceTypeElectric);
-    await harness.provider.getCampusList();
-    await harness.provider.ensureTrend(balanceType: kBalanceTypeElectric);
-    expect(
-      harness.provider.trendStateFor(balanceType: kBalanceTypeElectric).records,
-      isNotEmpty,
-    );
-
-    await harness.provider.setUserIdentity('student-b');
-    expect(harness.provider.currentBinding?.roomNo, 'B');
-    expect(harness.provider.electricInfo, isNull);
-    expect(harness.provider.campusState.value, isNull);
-    expect(
-      harness.provider.trendStateFor(balanceType: kBalanceTypeElectric).records,
-      isEmpty,
-    );
-
-    await harness.provider.ensureBalance(kBalanceTypeElectric);
-    expect(fakeApi.queryCalls, 2);
-
-    await harness.provider.setUserIdentity('student-a');
-    expect(harness.provider.currentBinding?.roomNo, 'A');
-    expect(harness.provider.electricInfo, isNull);
-    await harness.provider.ensureTrend(balanceType: kBalanceTypeElectric);
-    expect(
-      harness.provider.trendStateFor(balanceType: kBalanceTypeElectric).records,
-      hasLength(1),
-    );
-  });
-
-  test('账号切换会阻止旧余额请求写入缓存或历史记录', () async {
-    final pending = Completer<RoomInfo>();
-    final fakeApi = _FakePayAppApiService()..pendingQuery = pending;
-    final harness = await _createProvider(fakeApi: fakeApi);
-    addTearDown(harness.dispose);
-
-    final request = harness.provider.ensureBalance(kBalanceTypeElectric);
-    await harness.provider.setUserIdentity('student-b');
-    pending.complete(_roomInfo(balance: '42'));
-    expect((await request).balance, '42');
-
-    expect(harness.provider.bindings, isEmpty);
-    expect(harness.provider.electricInfo, isNull);
-    final rows = await harness.db.query('balance_records');
-    expect(rows, isEmpty);
-  });
-
   testWidgets('余额列表在首帧后才发起首次加载', (tester) async {
     final fakeApi = _FakePayAppApiService();
     // _createProvider 内部有真实的异步 I/O（SharedPreferences、sqflite），
@@ -306,7 +219,6 @@ Future<_ProviderHarness> _createProvider({
   _FakePayAppApiService? fakeApi,
   List<RoomBinding>? bindings,
   int currentIndex = 0,
-  String? initialUserId,
   DateTime Function()? now,
 }) async {
   final getIt = GetIt.instance;
@@ -337,7 +249,6 @@ Future<_ProviderHarness> _createProvider({
     appConfig,
     now: now,
   );
-  await provider.setUserIdentity(initialUserId ?? storedBindings.first.cusNo);
   return _ProviderHarness(provider, prefs, db, getIt);
 }
 


### PR DESCRIPTION
## Summary

- 撤销 PR #198 为余额查询引入的**账号维度隔离**：历史记录、绑定和缓存不再按 SCU 账号分区，恢复跨账号共享。
- 移除身份状态机（`setUserIdentity` / `activateForPrincipal` / `clear` / `confirmedUserIdentity`）、`roomKey` 的身份前缀、绑定按账号分区存储及其迁移逻辑、登出清理分支。
- 保留 PR #198 的价值部分：状态收敛到 Provider、多房间/多范围缓存（余额 30 分钟 TTL、趋势按范围）、并发请求合并（in-flight 复用）与"余额解析失败不写 0"的修复；页面文件零改动。
- 新增 ADR-0005（`docs/decisions/0005-remove-balance-history-account-isolation.md`）记录该决策。

## Why

余额（电费/空调）是**房间维度的公共数据，不是隐私数据**：

1. 同寝室成员看到的是同一房间、同一数值，账号隔离的隐私前提不成立。
2. 隔离导致室友账号各自的 `roomKey` 不同，查询并采样过的历史无法复用，造成重复获取。
3. 身份状态机、分区存储、数据迁移和登出清理只为隔离服务，增加复杂度。

## Impact

- 同寝室账号共享历史记录与自动采样结果，避免重复请求。
- 登出/切换账号不再清空余额数据；绑定列表全局共享。
- 其余 Provider（成绩等隐私数据）的账号隔离不受影响。

## Validation

- `flutter analyze`（No issues found）
- `flutter test`（256 passed, 1 skipped）

## 备注

- 之前版本未上线，无需数据迁移。
- ADR-0005 的「实施提交」字段待 PR 合并后补充。