### PR TITLE
fix: 修复 Xcode 26 小组件编译并补充 macOS 下载项

### DIFF
--- a/.github/scripts/release_body.py
+++ b/.github/scripts/release_body.py
@@ -12,7 +12,6 @@ def main():
 - Android: [arm64-Apk]({repo}/releases/download/v{version}/bugaoshan_{version}_arm64-v8a.apk)
 - Windows: [x64 Zip]({repo}/releases/download/v{version}/bugaoshan_{version}_windows_x64.zip)
 - Linux: [x64 Tar.gz]({repo}/releases/download/v{version}/bugaoshan_{version}_linux_x64.tar.gz)
-- macOS (Apple Silicon): [DMG]({repo}/releases/download/v{version}/bugaoshan_{version}_macos_arm64.dmg)
 - IOS: 未发布正式版，可安装testflight后点击链接进行邀测: https://testflight.apple.com/join/Vyenb6gC
 
 > 💡 **Note**: 当前项目优先保障 Android 端的稳定与体验。 Windows,Linux 版本可能存在部分兼容性或体验问题。

--- a/.github/scripts/release_body.py
+++ b/.github/scripts/release_body.py
@@ -12,6 +12,7 @@ def main():
 - Android: [arm64-Apk]({repo}/releases/download/v{version}/bugaoshan_{version}_arm64-v8a.apk)
 - Windows: [x64 Zip]({repo}/releases/download/v{version}/bugaoshan_{version}_windows_x64.zip)
 - Linux: [x64 Tar.gz]({repo}/releases/download/v{version}/bugaoshan_{version}_linux_x64.tar.gz)
+- macOS (Apple Silicon): [DMG]({repo}/releases/download/v{version}/bugaoshan_{version}_macos_arm64.dmg)
 - IOS: 未发布正式版，可安装testflight后点击链接进行邀测: https://testflight.apple.com/join/Vyenb6gC
 
 > 💡 **Note**: 当前项目优先保障 Android 端的稳定与体验。 Windows,Linux 版本可能存在部分兼容性或体验问题。

--- a/ios/CourseWidget/WidgetExtension.swift
+++ b/ios/CourseWidget/WidgetExtension.swift
@@ -739,15 +739,7 @@ struct DesktopWidgetView: View {
             if displayableCourses.isEmpty {
                 Spacer(minLength: 0)
                 // 区分是真没课，还是课上完了；放假中显示放假提示
-                let emptyText: String
-                if entry.isOnVacation {
-                    emptyText = "享受假期～"
-                } else if entry.courses.isEmpty {
-                    emptyText = entry.isTomorrow ? "明天没课" : "今天没课"
-                } else {
-                    emptyText = "今天的课都上完啦"
-                }
-                Text(emptyText)
+                Text(emptyStateText)
                     .font(.callout)
                     .foregroundColor(.secondary)
                     .frame(maxWidth: .infinity, alignment: .center)
@@ -774,6 +766,16 @@ struct DesktopWidgetView: View {
             Spacer(minLength: 0)
         }
         .padding(widgetPadding)
+    }
+
+    private var emptyStateText: String {
+        if entry.isOnVacation {
+            return "享受假期～"
+        }
+        if entry.courses.isEmpty {
+            return entry.isTomorrow ? "明天没课" : "今天没课"
+        }
+        return "今天的课都上完啦"
     }
 }
 


### PR DESCRIPTION
## 改动

- 将桌面小组件空状态文案计算移出 SwiftUI `ViewBuilder`，保持现有显示逻辑不变。
- 在 Release 下载公告中增加 macOS（Apple Silicon）DMG 链接。

## 原因

Xcode 26.6 编译 `CourseWidget` 时，`ViewBuilder` 内的局部 `String` 变量触发 `Type '()' cannot conform to 'View'`，导致 iOS archive 无法生成。改为计算属性后消除该兼容性问题。

## 验证

- `flutter build ipa --release --no-codesign`（v2.3.0，build 1351.1）成功生成 archive。
- Release 公告脚本已验证生成正确的 macOS DMG 链接。
