### PR TITLE
feat(iOS): 增加课表小组件样式与系统液态玻璃适配

### DIFF
--- a/ios/CourseWidget/WidgetExtension.swift
+++ b/ios/CourseWidget/WidgetExtension.swift
@@ -513,6 +513,35 @@ func shouldShowTomorrow() -> Bool {
     return sharedDefaults.bool(forKey: "widget_show_tomorrow")
 }
 
+enum WidgetColorStyle: Int {
+    case colorful
+    case monochrome
+}
+
+enum WidgetDensity: Int {
+    case standard
+    case compact
+}
+
+struct WidgetAppearance {
+    let colorStyle: WidgetColorStyle
+    let density: WidgetDensity
+}
+
+func loadWidgetAppearance() -> WidgetAppearance {
+    guard let sharedDefaults = UserDefaults(suiteName: appGroupId) else {
+        return WidgetAppearance(colorStyle: .colorful, density: .standard)
+    }
+    return WidgetAppearance(
+        colorStyle: WidgetColorStyle(
+            rawValue: sharedDefaults.integer(forKey: "widget_color_style")
+        ) ?? .colorful,
+        density: WidgetDensity(
+            rawValue: sharedDefaults.integer(forKey: "widget_density")
+        ) ?? .standard
+    )
+}
+
 func loadWidgetData() -> (courses: [Course], dateText: String, weekText: String, isTomorrow: Bool, nextTransition: Date?, isOnVacation: Bool)? {
     print("BugaoShan Widget: loadWidgetData() called")
 
@@ -701,16 +730,19 @@ struct CourseProvider: TimelineProvider {
 
 // 桌面小组件
 struct DesktopWidgetView: View {
+    @Environment(\.widgetRenderingMode) private var widgetRenderingMode
+
     var entry: CourseProvider.Entry
     var widgetFamily: WidgetFamily
+    var appearance: WidgetAppearance
 
     var body: some View {
         // iOS 17 以后系统自带了 widget margin (约16px)。
         // 如果再加一层外边距会导致内容被过度挤压。建议移除或大幅减小这里的手动 padding。
         let widgetPadding: CGFloat = widgetFamily == .systemSmall ? 0 : 2
 
-        // 适当增大最外层间距，让内容呼吸感更强
-        VStack(alignment: .leading, spacing: widgetFamily == .systemSmall ? 8 : 12) {
+        // 标准模式保留完整信息，紧凑模式缩短间距以容纳更多课程。
+        VStack(alignment: .leading, spacing: outerSpacing) {
             // 1. 动态头部
             HStack {
                 if widgetFamily == .systemLarge {
@@ -745,13 +777,19 @@ struct DesktopWidgetView: View {
                     .frame(maxWidth: .infinity, alignment: .center)
                 Spacer(minLength: 0)
             } else {
-                // 中组件限制为2节，大组件限制为6节
-                let maxCourses = (widgetFamily == .systemSmall || widgetFamily == .systemMedium) ? 2 : 6
+                let maxCourses = maximumCourseCount
                 let displayCourses = Array(displayableCourses.prefix(maxCourses))
 
-                VStack(alignment: .leading, spacing: widgetFamily == .systemSmall ? 8 : 10) {
+                VStack(alignment: .leading, spacing: courseSpacing) {
                     ForEach(displayCourses.indices, id: \.self) { index in
-                        CourseCard(course: displayCourses[index], isTomorrow: entry.isTomorrow, compact: widgetFamily == .systemSmall)
+                        CourseCard(
+                            course: displayCourses[index],
+                            isTomorrow: entry.isTomorrow,
+                            compact: usesCompactCards,
+                            showLocation: appearance.density == .standard,
+                            colorStyle: appearance.colorStyle,
+                            isFullColorAppearance: widgetRenderingMode == .fullColor
+                        )
                     }
                 }
                 // 底部剩余课程提示
@@ -766,6 +804,35 @@ struct DesktopWidgetView: View {
             Spacer(minLength: 0)
         }
         .padding(widgetPadding)
+    }
+
+    private var outerSpacing: CGFloat {
+        if widgetFamily == .systemSmall || appearance.density == .compact {
+            return 8
+        }
+        return 12
+    }
+
+    private var courseSpacing: CGFloat {
+        if widgetFamily == .systemSmall {
+            return appearance.density == .compact ? 5 : 8
+        }
+        return appearance.density == .compact ? 6 : 10
+    }
+
+    private var usesCompactCards: Bool {
+        widgetFamily == .systemSmall || appearance.density == .compact
+    }
+
+    private var maximumCourseCount: Int {
+        switch widgetFamily {
+            case .systemSmall:
+                return 2
+            case .systemMedium:
+                return appearance.density == .compact ? 3 : 2
+            default:
+                return appearance.density == .compact ? 7 : 6
+        }
     }
 
     private var emptyStateText: String {
@@ -846,7 +913,11 @@ struct CourseWidgetEntryView: View {
                 LockScreenRectangularView(entry: entry)
             default:
                 // 桌面小组件视图
-                DesktopWidgetView(entry: entry, widgetFamily: widgetFamily)
+                DesktopWidgetView(
+                    entry: entry,
+                    widgetFamily: widgetFamily,
+                    appearance: loadWidgetAppearance()
+                )
         }
     }
 }
@@ -855,6 +926,9 @@ struct CourseCard: View {
     let course: Course
     let isTomorrow: Bool
     let compact: Bool
+    let showLocation: Bool
+    let colorStyle: WidgetColorStyle
+    let isFullColorAppearance: Bool
 
     var body: some View {
         VStack(alignment: .leading, spacing: compact ? 2 : 4) {
@@ -862,15 +936,17 @@ struct CourseCard: View {
             Text(course.name)
                 .font(compact ? .footnote : .subheadline)
                 .fontWeight(course.status == .inProgress ? .bold : .medium)
-                .foregroundColor(isTomorrow ? .orange : .primary)
-                .lineLimit(2)
+                .foregroundColor(
+                    isTomorrow && usesCourseColors ? .orange : .primary
+                )
+                .lineLimit(compact ? 1 : 2)
 
             // 显示具体小时分钟，如果解析失败则回退到"第x-y节"
             let timeDisplay = course.timeText ?? formatCourseTime()
 
             if compact {
                 // Small 尺寸：分三行，地点与时间独立
-                if !course.location.isEmpty {
+                if showLocation && !course.location.isEmpty {
                     Text(course.location)
                         .font(.caption2)
                         .foregroundColor(.secondary)
@@ -878,13 +954,23 @@ struct CourseCard: View {
                 }
                 Text(timeDisplay)
                     .font(.caption2)
-                    .foregroundColor(course.status == .inProgress ? courseColor : .secondary)
+                    .foregroundColor(
+                        course.status == .inProgress
+                            ? resolvedCourseColor
+                            : .secondary
+                    )
                     .lineLimit(1)
             } else {
                 // Medium / Large 尺寸：合并为一行
-                Text("\(timeDisplay) · \(course.location)")
+                Text(showLocation && !course.location.isEmpty
+                    ? "\(timeDisplay) · \(course.location)"
+                    : timeDisplay)
                     .font(.caption)
-                    .foregroundColor(course.status == .inProgress ? courseColor : .secondary)
+                    .foregroundColor(
+                        course.status == .inProgress
+                            ? resolvedCourseColor
+                            : .secondary
+                    )
                     .lineLimit(2)
             }
         }
@@ -894,15 +980,27 @@ struct CourseCard: View {
         .padding(.leading, compact ? 9 : 12)
         .overlay(
             RoundedRectangle(cornerRadius: 2)
-                .fill(courseColor)
-                .frame(width: compact ? 3 : 4),
+                .fill(resolvedCourseColor)
+                .frame(width: compact ? 3 : 4)
+                .widgetAccentable(),
             alignment: .leading
         )
         // 由于 HStack 自动包裹高度，竖线会自动与 VStack 等高。无需额外设定高度。
-        .opacity(course.status == .completed ? 0.4 : 1.0)
+        .opacity(
+            course.status == .completed
+                ? (isFullColorAppearance ? 0.45 : 0.6)
+                : 1.0
+        )
     }
 
-    var courseColor: Color {
+    private var usesCourseColors: Bool {
+        colorStyle == .colorful && isFullColorAppearance
+    }
+
+    private var resolvedCourseColor: Color {
+        guard usesCourseColors else {
+            return .primary.opacity(0.72)
+        }
         let argb = UInt32(bitPattern: Int32(truncatingIfNeeded: course.colorValue))
         if argb == 0 || (argb >> 24) == 0 {
             return isTomorrow ? .orange : .blue
@@ -930,6 +1028,8 @@ struct CourseWidget: Widget {
     var body: some WidgetConfiguration {
         StaticConfiguration(kind: kind, provider: CourseProvider()) { entry in
             CourseWidgetEntryView(entry: entry)
+                // WidgetKit removes this background for the system Clear and
+                // Tinted appearances, applying Liquid Glass or the system tint.
                 .containerBackground(Color(.systemBackground), for: .widget)
         }
         .configurationDisplayName("课表组件")

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -64,6 +64,24 @@ import WidgetKit
                     return
                 }
                 self?.syncWidgetShowTomorrow(value: value, result: result)
+            case "syncWidgetAppearance":
+                guard
+                    let arguments = call.arguments as? [String: Any],
+                    let colorStyle = arguments["colorStyle"] as? Int,
+                    let density = arguments["density"] as? Int
+                else {
+                    result(FlutterError(
+                        code: "INVALID_ARGUMENT",
+                        message: "Color style and density are required",
+                        details: nil
+                    ))
+                    return
+                }
+                self?.syncWidgetAppearance(
+                    colorStyle: colorStyle,
+                    density: density,
+                    result: result
+                )
             default:
                 result(FlutterMethodNotImplemented)
             }
@@ -93,6 +111,29 @@ import WidgetKit
             WidgetCenter.shared.reloadAllTimelines()
         }
         
+        result(nil)
+    }
+
+    private func syncWidgetAppearance(
+        colorStyle: Int,
+        density: Int,
+        result: @escaping FlutterResult
+    ) {
+        guard let sharedDefaults = UserDefaults(suiteName: appGroupId) else {
+            result(FlutterError(
+                code: "APP_GROUP_UNAVAILABLE",
+                message: "App Group not available",
+                details: nil
+            ))
+            return
+        }
+        sharedDefaults.set(colorStyle, forKey: "widget_color_style")
+        sharedDefaults.set(density, forKey: "widget_density")
+
+        if #available(iOS 14.0, *) {
+            WidgetCenter.shared.reloadAllTimelines()
+        }
+
         result(nil)
     }
 

--- a/lib/injection/injector.dart
+++ b/lib/injection/injector.dart
@@ -321,6 +321,12 @@ void _configureAsyncDependencies() {
         await service.syncWidgetShowTomorrow(
           appConfig.widgetShowTomorrow.value,
         );
+        if (Platform.isIOS) {
+          await service.syncWidgetAppearance(
+            colorStyle: appConfig.widgetColorStyle.value,
+            density: appConfig.widgetDensity.value,
+          );
+        }
       } catch (e) {
         debugPrint('Failed to sync initial widget setting: $e');
       }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -35,6 +35,15 @@
     "@widgetShowTomorrowAfterEnd": {
         "description": "Toggle to show next day's courses in the home screen widget when today's classes are finished."
     },
+    "widgetAppearanceTitle": "Widget Appearance",
+    "widgetAppearanceDescription": "Customize every Bugaoshan course widget on this device.",
+    "widgetColorStyle": "Color",
+    "widgetColorful": "Course colors",
+    "widgetMonochrome": "Monochrome",
+    "widgetDensity": "Information density",
+    "widgetDensityStandard": "Standard",
+    "widgetDensityCompact": "Compact",
+    "widgetSystemAppearanceHint": "On iOS 26 and later, Clear and Tinted Home Screen appearances automatically use the system glass or tint treatment.",
     "onboardingSkip": "Skip",
     "onboardingNext": "Next",
     "onboardingStart": "Get Started",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -253,6 +253,60 @@ abstract class AppLocalizations {
   /// **'Show next day\'s courses after today\'s classes finish'**
   String get widgetShowTomorrowAfterEnd;
 
+  /// No description provided for @widgetAppearanceTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Widget Appearance'**
+  String get widgetAppearanceTitle;
+
+  /// No description provided for @widgetAppearanceDescription.
+  ///
+  /// In en, this message translates to:
+  /// **'Customize every Bugaoshan course widget on this device.'**
+  String get widgetAppearanceDescription;
+
+  /// No description provided for @widgetColorStyle.
+  ///
+  /// In en, this message translates to:
+  /// **'Color'**
+  String get widgetColorStyle;
+
+  /// No description provided for @widgetColorful.
+  ///
+  /// In en, this message translates to:
+  /// **'Course colors'**
+  String get widgetColorful;
+
+  /// No description provided for @widgetMonochrome.
+  ///
+  /// In en, this message translates to:
+  /// **'Monochrome'**
+  String get widgetMonochrome;
+
+  /// No description provided for @widgetDensity.
+  ///
+  /// In en, this message translates to:
+  /// **'Information density'**
+  String get widgetDensity;
+
+  /// No description provided for @widgetDensityStandard.
+  ///
+  /// In en, this message translates to:
+  /// **'Standard'**
+  String get widgetDensityStandard;
+
+  /// No description provided for @widgetDensityCompact.
+  ///
+  /// In en, this message translates to:
+  /// **'Compact'**
+  String get widgetDensityCompact;
+
+  /// No description provided for @widgetSystemAppearanceHint.
+  ///
+  /// In en, this message translates to:
+  /// **'On iOS 26 and later, Clear and Tinted Home Screen appearances automatically use the system glass or tint treatment.'**
+  String get widgetSystemAppearanceHint;
+
   /// No description provided for @onboardingSkip.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -91,6 +91,35 @@ class AppLocalizationsEn extends AppLocalizations {
       'Show next day\'s courses after today\'s classes finish';
 
   @override
+  String get widgetAppearanceTitle => 'Widget Appearance';
+
+  @override
+  String get widgetAppearanceDescription =>
+      'Customize every Bugaoshan course widget on this device.';
+
+  @override
+  String get widgetColorStyle => 'Color';
+
+  @override
+  String get widgetColorful => 'Course colors';
+
+  @override
+  String get widgetMonochrome => 'Monochrome';
+
+  @override
+  String get widgetDensity => 'Information density';
+
+  @override
+  String get widgetDensityStandard => 'Standard';
+
+  @override
+  String get widgetDensityCompact => 'Compact';
+
+  @override
+  String get widgetSystemAppearanceHint =>
+      'On iOS 26 and later, Clear and Tinted Home Screen appearances automatically use the system glass or tint treatment.';
+
+  @override
   String get onboardingSkip => 'Skip';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -85,6 +85,34 @@ class AppLocalizationsZh extends AppLocalizations {
   String get widgetShowTomorrowAfterEnd => '当天课程结束后显示第二天课程';
 
   @override
+  String get widgetAppearanceTitle => '小组件外观';
+
+  @override
+  String get widgetAppearanceDescription => '统一调整本设备上的所有不高山课表小组件。';
+
+  @override
+  String get widgetColorStyle => '配色';
+
+  @override
+  String get widgetColorful => '课程色彩';
+
+  @override
+  String get widgetMonochrome => '单色';
+
+  @override
+  String get widgetDensity => '信息密度';
+
+  @override
+  String get widgetDensityStandard => '标准';
+
+  @override
+  String get widgetDensityCompact => '紧凑';
+
+  @override
+  String get widgetSystemAppearanceHint =>
+      '在 iOS 26 及更高版本中，主屏幕的透明与着色外观会自动使用系统玻璃或着色效果。';
+
+  @override
   String get onboardingSkip => '跳过';
 
   @override

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -35,6 +35,15 @@
     "@widgetShowTomorrowAfterEnd": {
         "description": "当天课程结束时，在桌面小组件中显示第二天的课程。"
     },
+    "widgetAppearanceTitle": "小组件外观",
+    "widgetAppearanceDescription": "统一调整本设备上的所有不高山课表小组件。",
+    "widgetColorStyle": "配色",
+    "widgetColorful": "课程色彩",
+    "widgetMonochrome": "单色",
+    "widgetDensity": "信息密度",
+    "widgetDensityStandard": "标准",
+    "widgetDensityCompact": "紧凑",
+    "widgetSystemAppearanceHint": "在 iOS 26 及更高版本中，主屏幕的透明与着色外观会自动使用系统玻璃或着色效果。",
     "onboardingSkip": "跳过",
     "onboardingNext": "下一步",
     "onboardingStart": "立即体验",

--- a/lib/models/widget_appearance.dart
+++ b/lib/models/widget_appearance.dart
@@ -1,0 +1,3 @@
+enum WidgetColorStyle { colorful, monochrome }
+
+enum WidgetDensity { standard, compact }

--- a/lib/pages/settings/add_widget/add_widget_page.dart
+++ b/lib/pages/settings/add_widget/add_widget_page.dart
@@ -4,6 +4,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:bugaoshan/injection/injector.dart';
 import 'package:bugaoshan/l10n/app_localizations.dart';
+import 'package:bugaoshan/models/widget_appearance.dart';
 import 'package:bugaoshan/providers/app_config_provider.dart';
 import 'package:bugaoshan/services/widget_update_service.dart';
 import 'package:bugaoshan/widgets/common/styled_card.dart';
@@ -137,6 +138,118 @@ class _AddWidgetContentState extends State<AddWidgetContent>
     );
   }
 
+  void _syncWidgetAppearance(AppConfigProvider appConfig) {
+    unawaited(
+      getIt<WidgetUpdateService>().syncWidgetAppearance(
+        colorStyle: appConfig.widgetColorStyle.value,
+        density: appConfig.widgetDensity.value,
+      ),
+    );
+  }
+
+  Widget _buildAppearanceCard(
+    BuildContext context,
+    AppLocalizations localizations,
+    AppConfigProvider appConfig,
+  ) {
+    final textTheme = Theme.of(context).textTheme;
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return StyledCard(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              localizations.widgetAppearanceTitle,
+              style: textTheme.titleMedium?.copyWith(
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+            const SizedBox(height: 4),
+            Text(
+              localizations.widgetAppearanceDescription,
+              style: textTheme.bodySmall?.copyWith(
+                color: colorScheme.onSurfaceVariant,
+              ),
+            ),
+            const SizedBox(height: 16),
+            Text(localizations.widgetColorStyle, style: textTheme.labelLarge),
+            const SizedBox(height: 8),
+            SizedBox(
+              width: double.infinity,
+              child: SegmentedButton<WidgetColorStyle>(
+                segments: [
+                  ButtonSegment(
+                    value: WidgetColorStyle.colorful,
+                    icon: const Icon(Icons.palette_outlined),
+                    label: Text(localizations.widgetColorful),
+                  ),
+                  ButtonSegment(
+                    value: WidgetColorStyle.monochrome,
+                    icon: const Icon(Icons.tonality_outlined),
+                    label: Text(localizations.widgetMonochrome),
+                  ),
+                ],
+                selected: {appConfig.widgetColorStyle.value},
+                onSelectionChanged: (selection) {
+                  appConfig.widgetColorStyle.value = selection.single;
+                  _syncWidgetAppearance(appConfig);
+                },
+              ),
+            ),
+            const SizedBox(height: 16),
+            Text(localizations.widgetDensity, style: textTheme.labelLarge),
+            const SizedBox(height: 8),
+            SizedBox(
+              width: double.infinity,
+              child: SegmentedButton<WidgetDensity>(
+                segments: [
+                  ButtonSegment(
+                    value: WidgetDensity.standard,
+                    icon: const Icon(Icons.view_agenda_outlined),
+                    label: Text(localizations.widgetDensityStandard),
+                  ),
+                  ButtonSegment(
+                    value: WidgetDensity.compact,
+                    icon: const Icon(Icons.density_small_outlined),
+                    label: Text(localizations.widgetDensityCompact),
+                  ),
+                ],
+                selected: {appConfig.widgetDensity.value},
+                onSelectionChanged: (selection) {
+                  appConfig.widgetDensity.value = selection.single;
+                  _syncWidgetAppearance(appConfig);
+                },
+              ),
+            ),
+            const SizedBox(height: 16),
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Icon(
+                  Icons.auto_awesome_outlined,
+                  size: 18,
+                  color: colorScheme.primary,
+                ),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    localizations.widgetSystemAppearanceHint,
+                    style: textTheme.bodySmall?.copyWith(
+                      color: colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
   Future<void> _pinWidget(BuildContext context, WidgetSize size) async {
     final localizations = AppLocalizations.of(context)!;
     final service = getIt<WidgetUpdateService>();
@@ -249,7 +362,11 @@ class _AddWidgetContentState extends State<AddWidgetContent>
         _platform == TargetPlatform.iOS || _platform == TargetPlatform.macOS;
 
     return ListenableBuilder(
-      listenable: appConfig.widgetShowTomorrow,
+      listenable: Listenable.merge([
+        appConfig.widgetShowTomorrow,
+        appConfig.widgetColorStyle,
+        appConfig.widgetDensity,
+      ]),
       builder: (context, _) {
         return Column(
           crossAxisAlignment: CrossAxisAlignment.start,
@@ -298,6 +415,10 @@ class _AddWidgetContentState extends State<AddWidgetContent>
             // Consolidated single card with size choices (Android only)
             if (isAndroid) _WidgetPickerCard(onPin: _pinWidget),
             if (isAndroid) const SizedBox(height: 16),
+            if (_platform == TargetPlatform.iOS) ...[
+              _buildAppearanceCard(context, localizations, appConfig),
+              const SizedBox(height: 16),
+            ],
             _buildShowTomorrowSwitch(context, localizations),
             if (isAndroid) ...[
               const SizedBox(height: 16),

--- a/lib/providers/app_config_provider.dart
+++ b/lib/providers/app_config_provider.dart
@@ -2,6 +2,7 @@ import 'dart:ui';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart' show Colors, Curve, Curves;
+import 'package:bugaoshan/models/widget_appearance.dart';
 import 'package:bugaoshan/utils/locale_utils.dart';
 import 'package:bugaoshan/models/campus_item_config.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -23,6 +24,8 @@ const String _keyVisibleDockIds = 'visibleDockIds';
 const String _keyAcceptedEulaVersion = 'acceptedEulaVersion';
 const String _keyThemeColorMode = 'themeColorMode';
 const String _keyWidgetShowTomorrow = 'widget_show_tomorrow';
+const String _keyWidgetColorStyle = 'widget_color_style';
+const String _keyWidgetDensity = 'widget_density';
 const String _keyUsePreviewUpdateSource = 'usePreviewUpdateSource';
 const String _keyShowTeacherName = 'showTeacherName';
 const String _keyShowLocation = 'showLocation';
@@ -74,6 +77,10 @@ class AppConfigProvider {
   final ValueNotifier<ThemeColorMode> themeColorMode =
       ValueNotifier<ThemeColorMode>(ThemeColorMode.system);
   final ValueNotifier<bool> widgetShowTomorrow = ValueNotifier<bool>(false);
+  final ValueNotifier<WidgetColorStyle> widgetColorStyle =
+      ValueNotifier<WidgetColorStyle>(WidgetColorStyle.colorful);
+  final ValueNotifier<WidgetDensity> widgetDensity =
+      ValueNotifier<WidgetDensity>(WidgetDensity.standard);
   final ValueNotifier<bool> usePreviewUpdateSource = ValueNotifier<bool>(false);
   final ValueNotifier<bool> useGoogleFonts = ValueNotifier<bool>(true);
   final ValueNotifier<bool> showTeacherName = ValueNotifier<bool>(true);
@@ -133,6 +140,17 @@ class AppConfigProvider {
         : ThemeColorMode.custom;
     widgetShowTomorrow.value =
         _sharedPreferences.getBool(_keyWidgetShowTomorrow) ?? false;
+    final widgetColorStyleIndex =
+        _sharedPreferences.getInt(_keyWidgetColorStyle) ?? 0;
+    widgetColorStyle.value =
+        widgetColorStyleIndex < WidgetColorStyle.values.length
+        ? WidgetColorStyle.values[widgetColorStyleIndex]
+        : WidgetColorStyle.colorful;
+    final widgetDensityIndex =
+        _sharedPreferences.getInt(_keyWidgetDensity) ?? 0;
+    widgetDensity.value = widgetDensityIndex < WidgetDensity.values.length
+        ? WidgetDensity.values[widgetDensityIndex]
+        : WidgetDensity.standard;
     usePreviewUpdateSource.value =
         _sharedPreferences.getBool(_keyUsePreviewUpdateSource) ?? false;
     useGoogleFonts.value =
@@ -235,6 +253,15 @@ class AppConfigProvider {
         _keyWidgetShowTomorrow,
         widgetShowTomorrow.value,
       );
+    });
+    widgetColorStyle.addListener(() {
+      _sharedPreferences.setInt(
+        _keyWidgetColorStyle,
+        widgetColorStyle.value.index,
+      );
+    });
+    widgetDensity.addListener(() {
+      _sharedPreferences.setInt(_keyWidgetDensity, widgetDensity.value.index);
     });
     usePreviewUpdateSource.addListener(() {
       _sharedPreferences.setBool(

--- a/lib/services/widget_update_service.dart
+++ b/lib/services/widget_update_service.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
+import 'package:bugaoshan/models/widget_appearance.dart';
 import 'package:bugaoshan/utils/constants.dart';
 
 class WidgetUpdateService {
@@ -116,6 +117,25 @@ class WidgetUpdateService {
       }
     } catch (e, stack) {
       debugPrint('WidgetUpdate: syncWidgetShowTomorrow FAILED: $e');
+      debugPrint('WidgetUpdate: stack: $stack');
+    }
+  }
+
+  /// Syncs the visual style used by the iOS WidgetKit extension.
+  Future<void> syncWidgetAppearance({
+    required WidgetColorStyle colorStyle,
+    required WidgetDensity density,
+  }) async {
+    if (!_platformChecker() || defaultTargetPlatform != TargetPlatform.iOS) {
+      return;
+    }
+    try {
+      await _channel.invokeMethod<void>('syncWidgetAppearance', {
+        'colorStyle': colorStyle.index,
+        'density': density.index,
+      });
+    } catch (e, stack) {
+      debugPrint('WidgetUpdate: syncWidgetAppearance FAILED: $e');
       debugPrint('WidgetUpdate: stack: $stack');
     }
   }

--- a/test/add_widget_picker_test.dart
+++ b/test/add_widget_picker_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:bugaoshan/injection/injector.dart';
 import 'package:bugaoshan/l10n/app_localizations.dart';
+import 'package:bugaoshan/models/widget_appearance.dart';
 import 'package:bugaoshan/pages/settings/add_widget/add_widget_page.dart';
 import 'package:bugaoshan/services/widget_update_service.dart';
 import 'package:bugaoshan/providers/app_config_provider.dart';
@@ -10,6 +11,8 @@ import 'package:bugaoshan/providers/app_config_provider.dart';
 class FakeWidgetUpdateService implements WidgetUpdateService {
   String? lastSizeArg;
   bool? lastShowTomorrowArg;
+  WidgetColorStyle? lastColorStyle;
+  WidgetDensity? lastDensity;
 
   @override
   Future<void> updateWidgetData({bool force = false}) async {}
@@ -17,6 +20,15 @@ class FakeWidgetUpdateService implements WidgetUpdateService {
   @override
   Future<void> syncWidgetShowTomorrow(bool value) async {
     lastShowTomorrowArg = value;
+  }
+
+  @override
+  Future<void> syncWidgetAppearance({
+    required WidgetColorStyle colorStyle,
+    required WidgetDensity density,
+  }) async {
+    lastColorStyle = colorStyle;
+    lastDensity = density;
   }
 
   @override
@@ -106,5 +118,41 @@ void main() {
     await tester.tap(find.text(l10n.pinWidgetButton));
     await tester.pumpAndSettle();
     expect(fake.lastSizeArg, equals('large'));
+  });
+
+  testWidgets('iOS widget appearance settings sync selected styles', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: const Scaffold(
+          body: SingleChildScrollView(
+            child: AddWidgetContent(
+              showDescription: false,
+              debugPlatformOverride: TargetPlatform.iOS,
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final l10n = AppLocalizations.of(
+      tester.element(find.byType(AddWidgetContent)),
+    )!;
+    final fake = getIt<WidgetUpdateService>() as FakeWidgetUpdateService;
+
+    expect(find.text(l10n.widgetAppearanceTitle), findsOneWidget);
+    await tester.tap(find.text(l10n.widgetMonochrome));
+    await tester.pumpAndSettle();
+    expect(fake.lastColorStyle, WidgetColorStyle.monochrome);
+    expect(fake.lastDensity, WidgetDensity.standard);
+
+    await tester.tap(find.text(l10n.widgetDensityCompact));
+    await tester.pumpAndSettle();
+    expect(fake.lastColorStyle, WidgetColorStyle.monochrome);
+    expect(fake.lastDensity, WidgetDensity.compact);
   });
 }

--- a/test/app_config_widget_appearance_test.dart
+++ b/test/app_config_widget_appearance_test.dart
@@ -1,0 +1,28 @@
+import 'package:bugaoshan/models/widget_appearance.dart';
+import 'package:bugaoshan/providers/app_config_provider.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  test('loads and persists widget appearance preferences', () async {
+    SharedPreferences.setMockInitialValues({
+      'widget_color_style': WidgetColorStyle.monochrome.index,
+      'widget_density': WidgetDensity.compact.index,
+    });
+    final preferences = await SharedPreferences.getInstance();
+    final provider = AppConfigProvider(preferences);
+    await provider.init();
+
+    expect(provider.widgetColorStyle.value, WidgetColorStyle.monochrome);
+    expect(provider.widgetDensity.value, WidgetDensity.compact);
+
+    provider.widgetColorStyle.value = WidgetColorStyle.colorful;
+    provider.widgetDensity.value = WidgetDensity.standard;
+
+    expect(
+      preferences.getInt('widget_color_style'),
+      WidgetColorStyle.colorful.index,
+    );
+    expect(preferences.getInt('widget_density'), WidgetDensity.standard.index);
+  });
+}

--- a/test/widget_update_service_test.dart
+++ b/test/widget_update_service_test.dart
@@ -1,14 +1,17 @@
 import 'dart:async';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:fake_async/fake_async.dart';
+import 'package:bugaoshan/models/widget_appearance.dart';
 import 'package:bugaoshan/services/widget_update_service.dart';
 import 'package:bugaoshan/utils/constants.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
   tearDown(() {
+    debugDefaultTargetPlatformOverride = null;
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockMethodCallHandler(kUpdateMethodChannel, null);
   });
@@ -163,6 +166,29 @@ void main() {
 
     expect(events, ['small']);
     await sub.cancel();
+    service.dispose();
+  });
+
+  test('syncWidgetAppearance forwards both iOS style settings', () async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+    MethodCall? receivedCall;
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(kUpdateMethodChannel, (call) async {
+          receivedCall = call;
+          return null;
+        });
+
+    final service = WidgetUpdateService(platformChecker: () => true);
+    await service.syncWidgetAppearance(
+      colorStyle: WidgetColorStyle.monochrome,
+      density: WidgetDensity.compact,
+    );
+
+    expect(receivedCall?.method, 'syncWidgetAppearance');
+    expect(receivedCall?.arguments, {
+      'colorStyle': WidgetColorStyle.monochrome.index,
+      'density': WidgetDensity.compact.index,
+    });
     service.dispose();
   });
 }


### PR DESCRIPTION
## 改动

- 在 iOS“添加小组件”页面增加全局外观设置：课程色彩/单色、标准/紧凑
- 通过 App Group 同步设置，并刷新 WidgetKit timelines
- 紧凑模式减少间距、隐藏地点并在中/大组件容纳更多课程
- 根据 `widgetRenderingMode` 适配系统着色模式，保留可移除的 `containerBackground`，让 iOS 26/27 的 Clear 与 Tinted 主屏幕外观自动应用系统 Liquid Glass 或着色效果
- 补充设置持久化、MethodChannel 参数和界面交互测试

## 设计边界

- 透明度由 iOS 主屏幕的 Clear/Tinted 外观统一控制，与系统电池小组件一致；应用内不伪造玻璃材质或强制透明度
- 本次设置作用于本设备上的全部不高山课表小组件，不迁移为逐个组件的 AppIntent 配置
- 不改 Android/macOS 小组件

## 验证

- `dart format --output=none --set-exit-if-changed`（8 个相关 Dart 文件）
- `flutter test test/app_config_widget_appearance_test.dart`（1 passed）
- `flutter test test/add_widget_picker_test.dart`（2 passed）
- `flutter test test/widget_update_service_test.dart`（8 passed）
- `git diff --check`
- Xcode 26.6：`CourseWidgetExtension` simulator build（`CODE_SIGNING_ALLOWED=NO`）
- Xcode 27.0 beta 4：以 `IPHONEOS_DEPLOYMENT_TARGET=17.0` 验证同一 target 编译
