### PR TITLE
fix(macos): 修复分发版数据库目录导致的启动失败

### DIFF
--- a/lib/services/database_service.dart
+++ b/lib/services/database_service.dart
@@ -39,8 +39,9 @@ class DatabaseService {
     debugPrint('BugaoShan Database: Initializing database...');
 
     Directory dir;
-    // iOS/macOS 使用 App Group 共享目录，让 Widget Extension 也能访问数据库
-    if (!kIsWeb && (Platform.isIOS || Platform.isMacOS)) {
+    // iOS 使用 App Group 共享目录，让 Widget Extension 也能访问数据库。
+    // macOS 没有 Widget Extension，继续使用应用自己的 Support 目录。
+    if (!kIsWeb && Platform.isIOS) {
       const appGroupId = 'group.io.github.thebrotherhoodofscu.bugaoshan';
       try {
         final appGroupDir = await FlutterAppGroupDirectory.getAppGroupDirectory(
@@ -67,8 +68,8 @@ class DatabaseService {
     final dbPath = p.join(dir.path, 'bugaoshan.db');
     debugPrint('BugaoShan Database: Database path: $dbPath');
 
-    // 如果在 iOS/macOS 上，检查是否需要从旧位置迁移数据库
-    if (!kIsWeb && (Platform.isIOS || Platform.isMacOS)) {
+    // iOS 检查是否需要从旧位置迁移数据库到 App Group。
+    if (!kIsWeb && Platform.isIOS) {
       try {
         final oldDir = await getApplicationSupportDirectory();
         final oldDbPath = p.join(oldDir.path, 'bugaoshan.db');


### PR DESCRIPTION
## 修改内容

- 仅在 iOS 上使用 App Group 共享数据库目录。
- macOS 恢复使用应用自身的 Application Support 目录。

## 原因

iOS 小组件需要通过 App Group 与主应用共享课表数据库，但 macOS 没有对应的 Widget Extension 和 App Group entitlement。此前 macOS 仍尝试在 App Group 容器中创建数据库，沙盒会拒绝写入并导致 SQLite code 14，应用启动停在白屏。

## 影响

- 修复 Developer ID 分发版 macOS 应用无法启动的问题。
- 保留 iOS 主应用与 CourseWidget 的数据库共享行为。

## 验证

- `flutter test`
- `flutter analyze`
- macOS Profile 构建并实际启动，数据库路径切换到 Application Support，SQLite code 14 消失。
