### PR TITLE
fix(登录): 透传登录失败具体原因并移除死文案

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -555,7 +555,6 @@
     "captchaLoadFailed": "Failed to load captcha",
     "networkError": "Network error",
     "calendarRefreshSuccess": "Calendar updated",
-    "loginFailed": "Login failed",
     "invalidCaptcha": "Invalid captcha, please try again",
     "loginFailedWillLock": "Login failed, {count} more attempt(s) will lock your account",
     "@loginFailedWillLock": {

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -2857,12 +2857,6 @@ abstract class AppLocalizations {
   /// **'Calendar updated'**
   String get calendarRefreshSuccess;
 
-  /// No description provided for @loginFailed.
-  ///
-  /// In en, this message translates to:
-  /// **'Login failed'**
-  String get loginFailed;
-
   /// No description provided for @invalidCaptcha.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1478,9 +1478,6 @@ class AppLocalizationsEn extends AppLocalizations {
   String get calendarRefreshSuccess => 'Calendar updated';
 
   @override
-  String get loginFailed => 'Login failed';
-
-  @override
   String get invalidCaptcha => 'Invalid captcha, please try again';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -1432,9 +1432,6 @@ class AppLocalizationsZh extends AppLocalizations {
   String get calendarRefreshSuccess => '校历已更新';
 
   @override
-  String get loginFailed => '登录失败';
-
-  @override
   String get invalidCaptcha => '验证码错误，请重试';
 
   @override

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -535,7 +535,6 @@
     "captchaLoadFailed": "验证码加载失败",
     "networkError": "网络错误",
     "calendarRefreshSuccess": "校历已更新",
-    "loginFailed": "登录失败",
     "invalidCaptcha": "验证码错误，请重试",
     "loginFailedWillLock": "登录失败，再输错 {count} 次将锁定账户",
     "@loginFailedWillLock": {

--- a/lib/pages/auth/scu_login_page.dart
+++ b/lib/pages/auth/scu_login_page.dart
@@ -186,10 +186,12 @@ class _ScuLoginPageState extends State<ScuLoginPage> {
         if (attempted != null && total != null && total > attempted) {
           return l10n.loginFailedWillLock(total - attempted);
         }
-        return l10n.loginFailed;
+        // 格式不符：不吞掉原因，直接显示原始错误消息
+        return e.message;
       default:
         debugPrint('Unlocalized login error message: ${e.message}');
-        return l10n.loginFailed;
+        // 未识别的错误不套用国际化，直接透传后端返回的具体原因（如「密码错误」）
+        return e.message;
     }
   }
 

--- a/lib/services/auth/scu_auth.dart
+++ b/lib/services/auth/scu_auth.dart
@@ -21,6 +21,32 @@ import 'package:bugaoshan/utils/storage_keys.dart';
 const kZhjwBase = 'http://zhjw.scu.edu.cn';
 const _sessionDurationSeconds = 3600;
 
+/// 从 rest_token 失败响应体中提取具体错误信息；无法解析或没有错误字段时返回 null。
+/// 兼容业务格式（success/message/msg）与 OAuth 格式（error/error_description）。
+///
+/// [visibleForTesting]：纯解析函数，供单元测试覆盖各类响应格式。
+@visibleForTesting
+String? extractTokenErrorMessage(String body) {
+  try {
+    final decoded = jsonDecode(body);
+    if (decoded is Map<String, dynamic>) {
+      for (final key in const [
+        'message',
+        'msg',
+        'error_description',
+        'description',
+        'error',
+      ]) {
+        final value = decoded[key];
+        if (value is String && value.isNotEmpty) return value;
+      }
+    }
+  } catch (_) {
+    // 非 JSON 响应（网关错误页等），回退到 HTTP 状态码
+  }
+  return null;
+}
+
 /// SCU 统一身份认证（第3层）
 ///
 /// 合并原 ScuAuthService + ScuAuthSession，职责：
@@ -238,6 +264,16 @@ class ScuAuth extends ChangeNotifier {
         .timeout(kHttpTimeout);
 
     if (tokenResp.statusCode < 200 || tokenResp.statusCode >= 300) {
+      // 密码错误等服务端以非 2xx（如 400）返回，且 body 里带有具体原因；
+      // 先尝试提取，避免只显示笼统的 HTTP 状态码。
+      final detail = extractTokenErrorMessage(tokenResp.body);
+      if (detail != null) {
+        _log.w(
+          'ScuAuth',
+          'login: rest_token HTTP ${tokenResp.statusCode}: $detail',
+        );
+        throw ScuLoginException(detail);
+      }
       _log.w('ScuAuth', 'login: rest_token HTTP ${tokenResp.statusCode}');
       throw ScuLoginException('登录请求失败(HTTP ${tokenResp.statusCode})');
     }

--- a/test/scu_auth_test.dart
+++ b/test/scu_auth_test.dart
@@ -95,6 +95,56 @@ void main() {
     expect(auth.autoLoginCalls, 1);
     expect(sessionSaveCalls, 3);
   });
+
+  group('extractTokenErrorMessage', () {
+    test('extracts message from business format', () {
+      expect(
+        extractTokenErrorMessage('{"success":false,"message":"密码错误"}'),
+        '密码错误',
+      );
+    });
+
+    test('extracts msg field', () {
+      expect(extractTokenErrorMessage('{"msg":"账号或密码错误"}'), '账号或密码错误');
+    });
+
+    test('prefers message over OAuth error code', () {
+      expect(
+        extractTokenErrorMessage('{"message":"密码错误","error":"invalid_grant"}'),
+        '密码错误',
+      );
+    });
+
+    test('extracts OAuth error_description', () {
+      expect(
+        extractTokenErrorMessage(
+          '{"error":"invalid_grant","error_description":"用户名或密码错误"}',
+        ),
+        '用户名或密码错误',
+      );
+    });
+
+    test('falls back to OAuth error code', () {
+      expect(
+        extractTokenErrorMessage('{"error":"invalid_grant"}'),
+        'invalid_grant',
+      );
+    });
+
+    test('returns null for non-JSON body', () {
+      expect(extractTokenErrorMessage('<html>gateway error</html>'), isNull);
+    });
+
+    test('returns null for empty or missing error fields', () {
+      expect(extractTokenErrorMessage('{}'), isNull);
+      expect(extractTokenErrorMessage('{"success":false}'), isNull);
+      expect(extractTokenErrorMessage('{"message":""}'), isNull);
+    });
+
+    test('returns null for non-map JSON', () {
+      expect(extractTokenErrorMessage('[1,2,3]'), isNull);
+    });
+  });
 }
 
 class _TestScuAuth extends ScuAuth {


### PR DESCRIPTION
### 背景

登录失败（如密码错误）时，登录页只显示笼统的"登录失败"，看不到后端返回的具体原因（"密码错误""再输错 N 次将锁定"），用户与开发者都难以定位问题。

### 根因（两层原因叠加，由两次改动引入）

**① UI 层吞掉具体原因 —— `43da650`（2026-04-24，添加登录失败本地化）**

此前登录失败直接显示后端 message（`_errorMsg = e.message`）；该提交改为经 `_localizeLoginError` 本地化映射，但映射表**只覆盖两种**错误：

| 后端 message | 显示 |
|---|---|
| `invalid_captcha` | "验证码错误" |
| `login_failed_will_lock_*` | "再输错 N 次将锁定账户" |
| **其余所有（含"密码错误"）** | **"登录失败"（default 吞掉）** |

具体 message 只打了 `debugPrint`，没有透传给用户。

**② HTTP 非 2xx 不解析 body —— `c4a1770`（2026-07-26，登录链路修复）**

该提交新增 `rest_token` 的 HTTP 状态码检查：非 2xx 直接抛 `"登录请求失败(HTTP ${statusCode})"`。SCU 密码错误时 `rest_token` 返回 **HTTP 400**，body 里其实带具体原因（如 `login_failed_will_lock_1_5`），但状态码检查把"解析 body 提取 message"的分支挡在了前面 → 用户看到"400"而非具体原因。

### 修复

1. **scu_login_page.dart**：`_localizeLoginError` 的 `default` 与锁定格式不符分支改为**直接透传后端原始错误消息**（`invalid_captcha` / `login_failed_will_lock` 仍保留国际化文案，其余显示 `e.message`）。
2. **scu_auth.dart**：`rest_token` HTTP 非 2xx 时**先解析 body 提取具体错误**（新增 `extractTokenErrorMessage` 顶层 `@visibleForTesting` 纯函数，兼容 `message` / `msg` / `error_description` / `error` 等格式），提取不到才回退 HTTP 状态码。
3. 移除已无引用的 `loginFailed` 死文案（ARB 与生成文件同步）。
4. 新增 `extractTokenErrorMessage` 8 个单元测试。

### 验证

- 修复前：密码错误 → "登录失败"
- 修复后：密码错误 → "登录失败，再输错 N 次将锁定账户"
- `flutter test test/scu_auth_test.dart`：11 个测试全部通过