### PR TITLE
feat: 接入 Sentry 错误收集与用户反馈

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -54,7 +54,8 @@ jobs:
             --obfuscate --split-debug-info=build/app/outputs/symbols/universal \
             --dart-define=GIT_TAG=${{ steps.setup.outputs.GIT_TAG }} \
             --dart-define=GIT_COMMIT=${{ steps.setup.outputs.GIT_COMMIT }} \
-            --dart-define=GIT_COMMIT_DATE=${{ steps.setup.outputs.GIT_COMMIT_DATE }}
+            --dart-define=GIT_COMMIT_DATE=${{ steps.setup.outputs.GIT_COMMIT_DATE }} \
+            --dart-define=SENTRY_DSN="${{ secrets.SENTRY_DSN }}"
           mkdir -p release-apks
           cp build/app/outputs/flutter-apk/app-release.apk \
             release-apks/app-universal-release.apk
@@ -65,7 +66,8 @@ jobs:
             --obfuscate --split-debug-info=build/app/outputs/symbols/split \
             --dart-define=GIT_TAG=${{ steps.setup.outputs.GIT_TAG }} \
             --dart-define=GIT_COMMIT=${{ steps.setup.outputs.GIT_COMMIT }} \
-            --dart-define=GIT_COMMIT_DATE=${{ steps.setup.outputs.GIT_COMMIT_DATE }}
+            --dart-define=GIT_COMMIT_DATE=${{ steps.setup.outputs.GIT_COMMIT_DATE }} \
+            --dart-define=SENTRY_DSN="${{ secrets.SENTRY_DSN }}"
           cp build/app/outputs/flutter-apk/app-*-release.apk release-apks/
 
       - name: Upload universal and split APKs

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -64,7 +64,8 @@ jobs:
           flutter build linux --release \
             --dart-define=GIT_TAG=${{ steps.setup.outputs.GIT_TAG }} \
             --dart-define=GIT_COMMIT=${{ steps.setup.outputs.GIT_COMMIT }} \
-            --dart-define=GIT_COMMIT_DATE=${{ steps.setup.outputs.GIT_COMMIT_DATE }}
+            --dart-define=GIT_COMMIT_DATE=${{ steps.setup.outputs.GIT_COMMIT_DATE }} \
+            --dart-define=SENTRY_DSN="${{ secrets.SENTRY_DSN }}"
 
       - name: Archive Linux Release
         run: tar -czvf linux-release.tar.gz -C build/linux/x64/release/bundle .

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -35,7 +35,8 @@ jobs:
           flutter build windows --release \
             --dart-define=GIT_TAG=${{ steps.setup.outputs.GIT_TAG }} \
             --dart-define=GIT_COMMIT=${{ steps.setup.outputs.GIT_COMMIT }} \
-            --dart-define=GIT_COMMIT_DATE=${{ steps.setup.outputs.GIT_COMMIT_DATE }}
+            --dart-define=GIT_COMMIT_DATE=${{ steps.setup.outputs.GIT_COMMIT_DATE }} \
+            --dart-define=SENTRY_DSN="${{ secrets.SENTRY_DSN }}"
         shell: bash
 
       - name: Archive Windows Release

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,9 @@ migrate_working_dir/
 /build/
 /coverage/
 
+# Sentry Native runtime data (local crash sessions; never commit)
+.sentry-native/
+
 # Symbolication related
 app.*.symbols
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,6 +116,7 @@ Follow [Conventional Commits](https://www.conventionalcommits.org/): `feat:`, `f
 │   │   ├── campus_page/
 │   │   ├── course/             # Course schedule pages
 │   │   ├── dev/                # Developer tools & auth log viewer
+│   │   ├── feedback/           # Shared error feedback page (Sentry)
 │   │   ├── profile/
 │   │   ├── settings/
 │   │   └── wizard/             # First-launch wizard
@@ -130,7 +131,8 @@ Follow [Conventional Commits](https://www.conventionalcommits.org/): `feat:`, `f
 │   ├── architecture/           # current implementation architecture
 │   │   ├── authentication.md
 │   │   ├── linux-distribution.md
-│   │   └── notice-webview.md
+│   │   ├── notice-webview.md
+│   │   └── sentry-feedback.md
 │   └── decisions/              # Architecture Decision Records (ADRs)
 │       ├── README.md
 │       ├── 0001-use-webview-and-js-injection-for-notices.md
@@ -216,6 +218,7 @@ The CCYL service is special: its token expires via an explicit business error co
 - **`AcademicCalendarService`** (`lib/services/api/academic_calendar_service.dart`) — academic calendar data with mirror fetch + SharedPreferences cache.
 - **`DynamicIconService`** (`lib/services/dynamic_icon_service.dart`) — runtime app icon switching via MethodChannel `bugaoshan/dynamic_icon` (Android native).
 - **`BackgroundCacheService`** — precaches the user's background image post-frame.
+- **`SentryService`** (`lib/services/sentry/`) — Sentry 初始化（`SENTRY_DSN` dart-define 注入）、异常上报、用户反馈提交（截图 + 日志附件）。`ErrorFeedbackCoordinator` 包装 `FlutterError.onError` / `PlatformDispatcher.onError`，异常时自动弹出共享反馈页并做 15 秒防抖；反馈页同时支持「我的」页面手动打开。
 - **`ExitService`** — unified exit (windowManager.destroy on desktop, exit(0) on mobile).
 - **`WindowStateService`** — desktop window position/size persistence.
 
@@ -225,7 +228,7 @@ All auth-layer modules (`ScuAuth`, `CookieClient`, `AuthCoordinator`, `ZhjwAuth`
 
 - Ring buffer caps at 1000 entries (oldest evicted).
 - Each entry has timestamp + `AuthLogLevel` (`debug` / `info` / `warn` / `error`) + `tag` (e.g. `ScuAuth`, `CookieClient`, `ZhjwAuth`) + redacted message.
-- `AuthLogRedactor.apply()` strips `"access_token":"…"`, `"password":"…"`, `Bearer <token>` and truncates `?code=` values before storage, so logs are safe to share via the Dev page "Save" button.
+- `AuthLogRedactor.apply()` strips `"access_token":"…"`, `"password":"…"`, `Bearer <token>` and truncates `code=` / `access_token=` / `sp_code=` / `state=` query values before storage, so logs are safe to share via the Dev page "Save" button.
 - `tag` is a stable class/module identifier (for example `ScuAuth`, `CookieClient`, or `PAYAPP`) so the Viewer's dropdown groups events by source.
 - `debug` lines are only echoed to console in `kDebugMode`; production builds stay silent.
 - `AuthLogger` is a `ChangeNotifier` — Dev page's `AuthLogTile` and `AuthLogViewerPage` use `ListenableBuilder` for live updates.
@@ -310,6 +313,7 @@ CI builds inject git metadata via `--dart-define` flags: `GIT_TAG`, `GIT_COMMIT`
   - `widget_update_service_test.dart` — debounce / in-flight coalescing / dispose semantics using `fake_async` and a mocked `bugaoshan/update` MethodChannel.
   - `add_widget_picker_test.dart` — widget test with `SharedPreferences.setMockInitialValues` and a `FakeWidgetUpdateService`; resets `getIt` between tests.
   - `test_page_test.dart` — integration-ish page test.
+  - `sentry_service_test.dart` — Sentry 未配置 DSN 时提交反馈抛出 `SentryNotConfiguredException`.
 - Integration driver: `test_driver/main.dart` (`flutter drive`).
 
 Always run `dart format` (the repo's pre-commit hook enforces this on staged `.dart` files — see `.githooks/pre-commit`). When adding new tests, use `SharedPreferences.setMockInitialValues({})` + `getIt.reset()` to keep them hermetic.

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,4 +1,4 @@
-﻿# This file configures the analyzer, which statically analyzes Dart code to
+# This file configures the analyzer, which statically analyzes Dart code to
 # check for errors, warnings, and lints.
 #
 # The issues identified by the analyzer are surfaced in the UI of Dart-enabled
@@ -7,6 +7,15 @@
 
 # The following line activates a set of recommended lints for Flutter apps,
 # packages, and plugins designed to encourage good coding practices.
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 include: package:flutter_lints/flutter.yaml
 
 linter:

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@
 | [认证架构](architecture/authentication.md) | SCU 根认证、子系统认证、重试、会话隔离和 DI | 当前实现 |
 | [通知 WebView 架构](architecture/notice-webview.md) | 三类通知来源、JS bridge、附件下载和平台边界 | 当前实现 |
 | [Linux 分发架构](architecture/linux-distribution.md) | GitHub tar.gz、WPE 边界、Flatpak、AUR 和 Debian 状态 | 当前实现 |
+| [Sentry 错误收集与问题反馈](architecture/sentry-feedback.md) | DSN 注入、错误链路、反馈表单、附件与 CI 配置 | 当前实现 |
 
 ## 设计决策
 

--- a/docs/architecture/sentry-feedback.md
+++ b/docs/architecture/sentry-feedback.md
@@ -1,0 +1,65 @@
+# Sentry 错误收集与问题反馈
+
+本页描述基于 `sentry_flutter` 的错误采集、自动反馈弹窗与用户主动反馈链路。
+
+## 配置
+
+- DSN 通过编译参数注入，不写入代码：`--dart-define=SENTRY_DSN=https://xxx@oXXX.ingest.sentry.io/XXX`
+- 未注入 `SENTRY_DSN` 时 SDK 不初始化，错误采集与自动弹窗均为禁用状态（手动打开反馈页会提示未配置）。
+- CI 从 GitHub Secret `SENTRY_DSN` 注入；本地调试使用上面的 `flutter run` 参数。
+
+## 组件
+
+| 文件 | 职责 |
+|---|---|
+| `lib/services/sentry/sentry_service.dart` | `SentryFlutter.init`、异常上报、通过 `Sentry.captureFeedback` 提交用户反馈（截图 + 日志附件） |
+| `lib/services/sentry/error_feedback_coordinator.dart` | 包装 `FlutterError.onError` 与 `PlatformDispatcher.instance.onError`，自动弹反馈页并做 15 秒防抖 |
+| `lib/pages/feedback/feedback_page.dart` | 反馈表单：问题描述、联系方式、截图（`image_picker`）、日志附件（`file_picker`，`.log`/`.txt`）与内置认证日志开关 |
+| `lib/pages/dev/feedback_test_tile.dart` | 开发者页面测试入口：手动打开反馈页 / 触发测试异常 |
+
+DI 注册位于 `lib/injection/injector.dart`：
+
+- `SentryService`（lazy singleton，依赖 `AuthLogger`）
+- `ErrorFeedbackCoordinator`（lazy singleton，依赖 `SentryService`）
+
+## 启动时序
+
+`lib/main.dart`：
+
+1. `WidgetsFlutterBinding.ensureInitialized()` + 桌面平台初始化；
+2. `configureDependencies()`；
+3. `SentryService.initialize()` → `ErrorFeedbackCoordinator.attach()`；
+4. `ensureBasicDependencies()`（其异步异常也会进入上报链路）；
+5. `runApp(MyApp())`。
+
+启动失败时 `main` 的 catch 会直接调用 `SentryService.captureException` 后展示启动失败页（此时 UI 尚未构建，无法弹反馈表单）。
+
+## 错误 → 反馈链路
+
+- Flutter 框架异常：Sentry 自带的 `FlutterErrorIntegration` 已捕获，协调器保留原处理器并只负责弹窗，避免重复上报。
+- Zone/异步未捕获异常：协调器先 `Sentry.captureException`，再弹窗。
+- 异常发生在首帧构建前时，协调器轮询等待 `navigatorKey.currentContext` 可用后再通过 `popupOrNavigate` 弹出（手机全屏、平板/桌面为对话框）。
+- 同一时间只弹一个反馈页，15 秒内连续异常不重复打扰用户。
+
+## 反馈提交
+
+提交时通过 `Sentry.captureFeedback` 创建 User Feedback 事件：
+
+- 问题描述进入 `SentryFeedback.message`，联系方式若为邮箱格式进入 `contactEmail`；
+- 关联最近一次由本服务捕获的异常 `associatedEventId`；
+- 截图通过 `SentryAttachment.fromScreenshotData`、日志通过 `SentryAttachment.fromUint8List` 挂到 scope；
+- 自动附带 `AuthLogger` 导出的应用日志，文件名格式 `yyyyMMdd-HHmmss-<版本>.log`（已脱敏）；
+- 用户可额外选择 `.log` / `.txt` 文件作为附件。
+
+## 隐私
+
+- Sentry 选项关闭 `sendDefaultPii`；
+- 只有用户主动填写联系方式才会上传该字段；
+- `AuthLogger` 内容在写入缓冲前已经过 `AuthLogRedactor` 脱敏；
+- 反馈页明示内容将发送至 Sentry，提醒用户勿包含密码、令牌等敏感信息。
+
+## CI
+
+`build-android.yml` / `build-windows.yml` / `build-linux.yml` 在 `flutter build` 时追加
+`--dart-define=SENTRY_DSN="${{ secrets.SENTRY_DSN }}"`。`release.yml` 已 `secrets: inherit`，
+无需额外传递；仓库需在 GitHub Actions Secrets 中配置 `SENTRY_DSN`。

--- a/lib/injection/injector.dart
+++ b/lib/injection/injector.dart
@@ -37,6 +37,8 @@ import 'package:bugaoshan/services/auth/service_auth.dart';
 import 'package:bugaoshan/services/auth/wfw_auth.dart';
 import 'package:bugaoshan/services/download_notification_service.dart';
 import 'package:bugaoshan/services/auth/zhjw_auth.dart';
+import 'package:bugaoshan/services/sentry/error_feedback_coordinator.dart';
+import 'package:bugaoshan/services/sentry/sentry_service.dart';
 import 'package:bugaoshan/services/background_cache_service.dart';
 import 'package:bugaoshan/services/database_service.dart';
 import 'package:bugaoshan/services/download_manager.dart';
@@ -61,6 +63,23 @@ void configureDependencies() {
   getIt.registerSingleton<ExitService>(ExitService());
   getIt.registerSingleton<DownloadManager>(DownloadManager());
   getIt.registerLazySingleton<AuthLogger>(() => AuthLogger());
+  getIt.registerLazySingleton<SentryService>(
+    () => SentryService(
+      getIt<AuthLogger>(),
+      versionProvider: () {
+        try {
+          return getIt.isRegistered<AppInfoProvider>()
+              ? getIt<AppInfoProvider>().currentVersion
+              : 'unknown';
+        } catch (_) {
+          return 'unknown';
+        }
+      },
+    ),
+  );
+  getIt.registerLazySingleton<ErrorFeedbackCoordinator>(
+    () => ErrorFeedbackCoordinator(getIt<SentryService>()),
+  );
   _configureAsyncDependencies();
 }
 

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -122,6 +122,54 @@
     "materialPicker": "Material",
     "advancedPicker": "Advanced",
     "about": "About",
+    "feedback": "Error Feedback",
+    "feedbackCrashTitle": "The app ran into a problem",
+    "feedbackCrashDesc": "Please describe what you were doing and what happened. The description helps us locate and fix the issue quickly.",
+    "feedbackManualDesc": "Tell us about any problem or suggestion. Logs and screenshots make it much easier to locate the issue.",
+    "feedbackDescription": "What happened?",
+    "feedbackDescriptionHint": "Describe the problem, how to reproduce it, and what you expected to happen...",
+    "feedbackDescriptionRequired": "Please describe the problem first",
+    "feedbackContact": "Contact (optional)",
+    "feedbackContactHint": "Email / QQ etc., so we can reach you if needed",
+    "feedbackScreenshot": "Screenshot",
+    "feedbackScreenshotHint": "Attach a screenshot related to the problem (optional)",
+    "feedbackAddScreenshot": "Add Screenshot",
+    "feedbackScreenshotPickFailed": "Failed to pick screenshot: {error}",
+    "@feedbackScreenshotPickFailed": {
+        "placeholders": {
+            "error": {
+                "type": "String"
+            }
+        }
+    },
+    "feedbackLogs": "Logs",
+    "feedbackLogHint": "Attach .log / .txt files to help diagnose (optional)",
+    "feedbackIncludeAppLog": "Include app runtime log",
+    "feedbackIncludeAppLogHint": "Attach recent in-app auth and operation logs automatically",
+    "feedbackAddLogFile": "Add Log File",
+    "feedbackLogPickFailed": "Failed to pick log file: {error}",
+    "@feedbackLogPickFailed": {
+        "placeholders": {
+            "error": {
+                "type": "String"
+            }
+        }
+    },
+    "feedbackPrivacyHint": "Your feedback, logs and screenshots will be sent to Sentry. Please do not include passwords, tokens or other private information.",
+    "feedbackSubmit": "Submit Feedback",
+    "feedbackSubmitting": "Submitting...",
+    "feedbackSubmitSuccess": "Feedback submitted. Thank you!",
+    "feedbackSubmitFailed": "Failed to submit feedback: {error}",
+    "@feedbackSubmitFailed": {
+        "placeholders": {
+            "error": {
+                "type": "String"
+            }
+        }
+    },
+    "feedbackSentryNotConfigured": "Error reporting service is not configured. Please set SENTRY_DSN and rebuild.",
+    "feedbackTestOpen": "Open Feedback Page",
+    "feedbackTestCrash": "Trigger Test Crash",
     "developmentTeam": "Dev Team",
     "projectInfo": "Project Info",
     "appName": "App Name",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -643,6 +643,168 @@ abstract class AppLocalizations {
   /// **'About'**
   String get about;
 
+  /// No description provided for @feedback.
+  ///
+  /// In en, this message translates to:
+  /// **'Error Feedback'**
+  String get feedback;
+
+  /// No description provided for @feedbackCrashTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'The app ran into a problem'**
+  String get feedbackCrashTitle;
+
+  /// No description provided for @feedbackCrashDesc.
+  ///
+  /// In en, this message translates to:
+  /// **'Please describe what you were doing and what happened. The description helps us locate and fix the issue quickly.'**
+  String get feedbackCrashDesc;
+
+  /// No description provided for @feedbackManualDesc.
+  ///
+  /// In en, this message translates to:
+  /// **'Tell us about any problem or suggestion. Logs and screenshots make it much easier to locate the issue.'**
+  String get feedbackManualDesc;
+
+  /// No description provided for @feedbackDescription.
+  ///
+  /// In en, this message translates to:
+  /// **'What happened?'**
+  String get feedbackDescription;
+
+  /// No description provided for @feedbackDescriptionHint.
+  ///
+  /// In en, this message translates to:
+  /// **'Describe the problem, how to reproduce it, and what you expected to happen...'**
+  String get feedbackDescriptionHint;
+
+  /// No description provided for @feedbackDescriptionRequired.
+  ///
+  /// In en, this message translates to:
+  /// **'Please describe the problem first'**
+  String get feedbackDescriptionRequired;
+
+  /// No description provided for @feedbackContact.
+  ///
+  /// In en, this message translates to:
+  /// **'Contact (optional)'**
+  String get feedbackContact;
+
+  /// No description provided for @feedbackContactHint.
+  ///
+  /// In en, this message translates to:
+  /// **'Email / QQ etc., so we can reach you if needed'**
+  String get feedbackContactHint;
+
+  /// No description provided for @feedbackScreenshot.
+  ///
+  /// In en, this message translates to:
+  /// **'Screenshot'**
+  String get feedbackScreenshot;
+
+  /// No description provided for @feedbackScreenshotHint.
+  ///
+  /// In en, this message translates to:
+  /// **'Attach a screenshot related to the problem (optional)'**
+  String get feedbackScreenshotHint;
+
+  /// No description provided for @feedbackAddScreenshot.
+  ///
+  /// In en, this message translates to:
+  /// **'Add Screenshot'**
+  String get feedbackAddScreenshot;
+
+  /// No description provided for @feedbackScreenshotPickFailed.
+  ///
+  /// In en, this message translates to:
+  /// **'Failed to pick screenshot: {error}'**
+  String feedbackScreenshotPickFailed(String error);
+
+  /// No description provided for @feedbackLogs.
+  ///
+  /// In en, this message translates to:
+  /// **'Logs'**
+  String get feedbackLogs;
+
+  /// No description provided for @feedbackLogHint.
+  ///
+  /// In en, this message translates to:
+  /// **'Attach .log / .txt files to help diagnose (optional)'**
+  String get feedbackLogHint;
+
+  /// No description provided for @feedbackIncludeAppLog.
+  ///
+  /// In en, this message translates to:
+  /// **'Include app runtime log'**
+  String get feedbackIncludeAppLog;
+
+  /// No description provided for @feedbackIncludeAppLogHint.
+  ///
+  /// In en, this message translates to:
+  /// **'Attach recent in-app auth and operation logs automatically'**
+  String get feedbackIncludeAppLogHint;
+
+  /// No description provided for @feedbackAddLogFile.
+  ///
+  /// In en, this message translates to:
+  /// **'Add Log File'**
+  String get feedbackAddLogFile;
+
+  /// No description provided for @feedbackLogPickFailed.
+  ///
+  /// In en, this message translates to:
+  /// **'Failed to pick log file: {error}'**
+  String feedbackLogPickFailed(String error);
+
+  /// No description provided for @feedbackPrivacyHint.
+  ///
+  /// In en, this message translates to:
+  /// **'Your feedback, logs and screenshots will be sent to Sentry. Please do not include passwords, tokens or other private information.'**
+  String get feedbackPrivacyHint;
+
+  /// No description provided for @feedbackSubmit.
+  ///
+  /// In en, this message translates to:
+  /// **'Submit Feedback'**
+  String get feedbackSubmit;
+
+  /// No description provided for @feedbackSubmitting.
+  ///
+  /// In en, this message translates to:
+  /// **'Submitting...'**
+  String get feedbackSubmitting;
+
+  /// No description provided for @feedbackSubmitSuccess.
+  ///
+  /// In en, this message translates to:
+  /// **'Feedback submitted. Thank you!'**
+  String get feedbackSubmitSuccess;
+
+  /// No description provided for @feedbackSubmitFailed.
+  ///
+  /// In en, this message translates to:
+  /// **'Failed to submit feedback: {error}'**
+  String feedbackSubmitFailed(String error);
+
+  /// No description provided for @feedbackSentryNotConfigured.
+  ///
+  /// In en, this message translates to:
+  /// **'Error reporting service is not configured. Please set SENTRY_DSN and rebuild.'**
+  String get feedbackSentryNotConfigured;
+
+  /// No description provided for @feedbackTestOpen.
+  ///
+  /// In en, this message translates to:
+  /// **'Open Feedback Page'**
+  String get feedbackTestOpen;
+
+  /// No description provided for @feedbackTestCrash.
+  ///
+  /// In en, this message translates to:
+  /// **'Trigger Test Crash'**
+  String get feedbackTestCrash;
+
   /// No description provided for @developmentTeam.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -303,6 +303,102 @@ class AppLocalizationsEn extends AppLocalizations {
   String get about => 'About';
 
   @override
+  String get feedback => 'Error Feedback';
+
+  @override
+  String get feedbackCrashTitle => 'The app ran into a problem';
+
+  @override
+  String get feedbackCrashDesc =>
+      'Please describe what you were doing and what happened. The description helps us locate and fix the issue quickly.';
+
+  @override
+  String get feedbackManualDesc =>
+      'Tell us about any problem or suggestion. Logs and screenshots make it much easier to locate the issue.';
+
+  @override
+  String get feedbackDescription => 'What happened?';
+
+  @override
+  String get feedbackDescriptionHint =>
+      'Describe the problem, how to reproduce it, and what you expected to happen...';
+
+  @override
+  String get feedbackDescriptionRequired => 'Please describe the problem first';
+
+  @override
+  String get feedbackContact => 'Contact (optional)';
+
+  @override
+  String get feedbackContactHint =>
+      'Email / QQ etc., so we can reach you if needed';
+
+  @override
+  String get feedbackScreenshot => 'Screenshot';
+
+  @override
+  String get feedbackScreenshotHint =>
+      'Attach a screenshot related to the problem (optional)';
+
+  @override
+  String get feedbackAddScreenshot => 'Add Screenshot';
+
+  @override
+  String feedbackScreenshotPickFailed(String error) {
+    return 'Failed to pick screenshot: $error';
+  }
+
+  @override
+  String get feedbackLogs => 'Logs';
+
+  @override
+  String get feedbackLogHint =>
+      'Attach .log / .txt files to help diagnose (optional)';
+
+  @override
+  String get feedbackIncludeAppLog => 'Include app runtime log';
+
+  @override
+  String get feedbackIncludeAppLogHint =>
+      'Attach recent in-app auth and operation logs automatically';
+
+  @override
+  String get feedbackAddLogFile => 'Add Log File';
+
+  @override
+  String feedbackLogPickFailed(String error) {
+    return 'Failed to pick log file: $error';
+  }
+
+  @override
+  String get feedbackPrivacyHint =>
+      'Your feedback, logs and screenshots will be sent to Sentry. Please do not include passwords, tokens or other private information.';
+
+  @override
+  String get feedbackSubmit => 'Submit Feedback';
+
+  @override
+  String get feedbackSubmitting => 'Submitting...';
+
+  @override
+  String get feedbackSubmitSuccess => 'Feedback submitted. Thank you!';
+
+  @override
+  String feedbackSubmitFailed(String error) {
+    return 'Failed to submit feedback: $error';
+  }
+
+  @override
+  String get feedbackSentryNotConfigured =>
+      'Error reporting service is not configured. Please set SENTRY_DSN and rebuild.';
+
+  @override
+  String get feedbackTestOpen => 'Open Feedback Page';
+
+  @override
+  String get feedbackTestCrash => 'Trigger Test Crash';
+
+  @override
   String get developmentTeam => 'Dev Team';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -291,6 +291,93 @@ class AppLocalizationsZh extends AppLocalizations {
   String get about => '关于';
 
   @override
+  String get feedback => '问题反馈';
+
+  @override
+  String get feedbackCrashTitle => '应用似乎遇到了问题';
+
+  @override
+  String get feedbackCrashDesc => '请描述你刚才进行的操作和遇到的问题，这能帮助开发者尽快定位并修复。';
+
+  @override
+  String get feedbackManualDesc => '欢迎告诉我们遇到的问题或改进建议。附上日志和截图可以让我们更快定位问题。';
+
+  @override
+  String get feedbackDescription => '问题描述';
+
+  @override
+  String get feedbackDescriptionHint => '请详细描述问题现象、复现步骤，以及你期望的结果...';
+
+  @override
+  String get feedbackDescriptionRequired => '请先填写问题描述';
+
+  @override
+  String get feedbackContact => '联系方式（选填）';
+
+  @override
+  String get feedbackContactHint => '邮箱 / QQ 等，方便我们联系你';
+
+  @override
+  String get feedbackScreenshot => '截图';
+
+  @override
+  String get feedbackScreenshotHint => '可附上与问题相关的截图（选填）';
+
+  @override
+  String get feedbackAddScreenshot => '添加截图';
+
+  @override
+  String feedbackScreenshotPickFailed(String error) {
+    return '选择截图失败：$error';
+  }
+
+  @override
+  String get feedbackLogs => '日志';
+
+  @override
+  String get feedbackLogHint => '可添加 .log / .txt 日志文件帮助排查（选填）';
+
+  @override
+  String get feedbackIncludeAppLog => '附带应用运行日志';
+
+  @override
+  String get feedbackIncludeAppLogHint => '自动附带应用内的认证、操作等运行日志';
+
+  @override
+  String get feedbackAddLogFile => '添加日志文件';
+
+  @override
+  String feedbackLogPickFailed(String error) {
+    return '选择日志文件失败：$error';
+  }
+
+  @override
+  String get feedbackPrivacyHint => '反馈内容、日志与截图将发送至 Sentry。请勿包含密码、令牌等敏感信息。';
+
+  @override
+  String get feedbackSubmit => '提交反馈';
+
+  @override
+  String get feedbackSubmitting => '正在提交...';
+
+  @override
+  String get feedbackSubmitSuccess => '反馈已提交，感谢你的帮助！';
+
+  @override
+  String feedbackSubmitFailed(String error) {
+    return '提交反馈失败：$error';
+  }
+
+  @override
+  String get feedbackSentryNotConfigured => '错误收集服务尚未配置，请设置 SENTRY_DSN 后重新构建';
+
+  @override
+  String get feedbackTestOpen => '打开问题反馈页';
+
+  @override
+  String get feedbackTestCrash => '触发测试异常';
+
+  @override
   String get developmentTeam => '开发团队';
 
   @override

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -121,6 +121,54 @@
     "materialPicker": "材质",
     "advancedPicker": "高级",
     "about": "关于",
+    "feedback": "问题反馈",
+    "feedbackCrashTitle": "应用似乎遇到了问题",
+    "feedbackCrashDesc": "请描述你刚才进行的操作和遇到的问题，这能帮助开发者尽快定位并修复。",
+    "feedbackManualDesc": "欢迎告诉我们遇到的问题或改进建议。附上日志和截图可以让我们更快定位问题。",
+    "feedbackDescription": "问题描述",
+    "feedbackDescriptionHint": "请详细描述问题现象、复现步骤，以及你期望的结果...",
+    "feedbackDescriptionRequired": "请先填写问题描述",
+    "feedbackContact": "联系方式（选填）",
+    "feedbackContactHint": "邮箱 / QQ 等，方便我们联系你",
+    "feedbackScreenshot": "截图",
+    "feedbackScreenshotHint": "可附上与问题相关的截图（选填）",
+    "feedbackAddScreenshot": "添加截图",
+    "feedbackScreenshotPickFailed": "选择截图失败：{error}",
+    "@feedbackScreenshotPickFailed": {
+        "placeholders": {
+            "error": {
+                "type": "String"
+            }
+        }
+    },
+    "feedbackLogs": "日志",
+    "feedbackLogHint": "可添加 .log / .txt 日志文件帮助排查（选填）",
+    "feedbackIncludeAppLog": "附带应用运行日志",
+    "feedbackIncludeAppLogHint": "自动附带应用内的认证、操作等运行日志",
+    "feedbackAddLogFile": "添加日志文件",
+    "feedbackLogPickFailed": "选择日志文件失败：{error}",
+    "@feedbackLogPickFailed": {
+        "placeholders": {
+            "error": {
+                "type": "String"
+            }
+        }
+    },
+    "feedbackPrivacyHint": "反馈内容、日志与截图将发送至 Sentry。请勿包含密码、令牌等敏感信息。",
+    "feedbackSubmit": "提交反馈",
+    "feedbackSubmitting": "正在提交...",
+    "feedbackSubmitSuccess": "反馈已提交，感谢你的帮助！",
+    "feedbackSubmitFailed": "提交反馈失败：{error}",
+    "@feedbackSubmitFailed": {
+        "placeholders": {
+            "error": {
+                "type": "String"
+            }
+        }
+    },
+    "feedbackSentryNotConfigured": "错误收集服务尚未配置，请设置 SENTRY_DSN 后重新构建",
+    "feedbackTestOpen": "打开问题反馈页",
+    "feedbackTestCrash": "触发测试异常",
     "developmentTeam": "开发团队",
     "projectInfo": "项目信息",
     "appName": "应用名称",

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,4 @@
-﻿import 'dart:async';
+import 'dart:async';
 import 'dart:io';
 import 'dart:ui';
 
@@ -8,6 +8,8 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 import 'package:bugaoshan/app.dart';
 import 'package:bugaoshan/injection/injector.dart';
+import 'package:bugaoshan/services/sentry/error_feedback_coordinator.dart';
+import 'package:bugaoshan/services/sentry/sentry_service.dart';
 import 'package:bugaoshan/services/window_state_service.dart';
 import 'package:system_theme/system_theme.dart';
 import 'package:bugaoshan/services/update_service.dart';
@@ -18,6 +20,15 @@ Future<void> main() async {
     runApp(MyApp());
   } catch (error, stackTrace) {
     debugPrint('Startup error: $error\n$stackTrace');
+    if (getIt.isRegistered<SentryService>()) {
+      unawaited(
+        getIt<SentryService>().captureException(
+          error,
+          stackTrace,
+          source: 'startup',
+        ),
+      );
+    }
     runApp(_StartupErrorApp(errorMessage: stackTrace.toString()));
   }
 }
@@ -32,6 +43,15 @@ Future<void> _initializeApp() async {
     }
   }
   configureDependencies();
+
+  // Sentry 初始化必须在 runApp 之前完成，并尽早接管全局错误处理，
+  // 这样依赖初始化阶段的异步异常也能被采集。
+  final sentry = getIt<SentryService>();
+  await sentry.initialize();
+  if (sentry.isEnabled) {
+    getIt<ErrorFeedbackCoordinator>().attach();
+  }
+
   await ensureBasicDependencies();
 
   // 清理下载的安装包（首次打开或更新后）。

--- a/lib/pages/dev/dev_page.dart
+++ b/lib/pages/dev/dev_page.dart
@@ -6,6 +6,7 @@ import 'package:bugaoshan/l10n/app_localizations.dart';
 import 'package:bugaoshan/pages/dev/auth_log/auth_log_tile.dart';
 import 'package:bugaoshan/pages/dev/changelog/changelog_tile.dart';
 import 'package:bugaoshan/pages/dev/environment_info_tile.dart';
+import 'package:bugaoshan/pages/dev/feedback_test_tile.dart';
 import 'package:bugaoshan/pages/dev/update_card.dart';
 import 'package:bugaoshan/pages/dev/wizard_reset_tile.dart';
 import 'package:bugaoshan/providers/app_config_provider.dart';
@@ -136,6 +137,8 @@ class _DevPageState extends State<DevPage> {
           const WizardResetTile(),
           const Divider(),
           const AuthLogTile(),
+          const Divider(),
+          const FeedbackTestTile(),
           const Divider(),
           const UiTile(),
           const Divider(),

--- a/lib/pages/dev/feedback_test_tile.dart
+++ b/lib/pages/dev/feedback_test_tile.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+
+import 'package:bugaoshan/injection/injector.dart';
+import 'package:bugaoshan/l10n/app_localizations.dart';
+import 'package:bugaoshan/services/sentry/error_feedback_coordinator.dart';
+
+/// TestPage 入口：问题反馈调试。
+/// 可直接打开反馈页，或抛出一个未捕获异常验证自动弹窗链路。
+class FeedbackTestTile extends StatelessWidget {
+  const FeedbackTestTile({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final localizations = AppLocalizations.of(context)!;
+    final coordinator = getIt<ErrorFeedbackCoordinator>();
+
+    return Column(
+      children: [
+        ListTile(
+          leading: const Icon(Icons.feedback_outlined),
+          title: Text(localizations.feedbackTestOpen),
+          subtitle: Text(localizations.feedback),
+          onTap: () => coordinator.openFeedbackPage(context: context),
+        ),
+        ListTile(
+          leading: const Icon(Icons.bug_report_outlined),
+          title: Text(localizations.feedbackTestCrash),
+          onTap: () {
+            // 触发 FlutterError.onError → Sentry 上报 → 自动弹出反馈页。
+            throw StateError('Bugaoshan feedback test exception');
+          },
+        ),
+      ],
+    );
+  }
+}

--- a/lib/pages/feedback/feedback_page.dart
+++ b/lib/pages/feedback/feedback_page.dart
@@ -1,0 +1,390 @@
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:image_picker/image_picker.dart';
+
+import 'package:bugaoshan/l10n/app_localizations.dart';
+import 'package:bugaoshan/services/sentry/sentry_service.dart';
+import 'package:bugaoshan/widgets/route/router_utils.dart';
+
+/// 问题反馈页。自动错误弹窗与用户手动打开共用此页。
+class FeedbackPage extends StatefulWidget {
+  const FeedbackPage({
+    super.key,
+    required this.sentryService,
+    this.trigger = FeedbackTrigger.manual,
+    this.initialErrorSummary,
+  });
+
+  final SentryService sentryService;
+  final FeedbackTrigger trigger;
+  final String? initialErrorSummary;
+
+  @override
+  State<FeedbackPage> createState() => _FeedbackPageState();
+}
+
+class _FeedbackPageState extends State<FeedbackPage> {
+  final _formKey = GlobalKey<FormState>();
+  final _descriptionController = TextEditingController();
+  final _contactController = TextEditingController();
+
+  final List<FeedbackLogAttachment> _logFiles = [];
+  Uint8List? _screenshotBytes;
+  String? _screenshotName;
+  bool _includeAppLog = true;
+  bool _submitting = false;
+
+  @override
+  void dispose() {
+    _descriptionController.dispose();
+    _contactController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _pickScreenshot() async {
+    try {
+      final picked = await ImagePicker().pickImage(
+        source: ImageSource.gallery,
+        imageQuality: 90,
+        maxWidth: 1920,
+        maxHeight: 1920,
+      );
+      if (picked == null || !mounted) return;
+      final bytes = await picked.readAsBytes();
+      if (!mounted) return;
+      setState(() {
+        _screenshotBytes = bytes;
+        _screenshotName = picked.name;
+      });
+    } catch (err) {
+      if (!mounted) return;
+      _showMessage(_l10n.feedbackScreenshotPickFailed(err.toString()));
+    }
+  }
+
+  void _removeScreenshot() {
+    setState(() {
+      _screenshotBytes = null;
+      _screenshotName = null;
+    });
+  }
+
+  Future<void> _pickLogFiles() async {
+    try {
+      final result = await FilePicker.pickFiles(
+        type: FileType.custom,
+        allowedExtensions: const ['log', 'txt'],
+      );
+      if (result == null || !mounted) return;
+
+      final pickedFiles = <FeedbackLogAttachment>[];
+      for (final platformFile in result.files) {
+        try {
+          final bytes = await platformFile.readAsBytes();
+          if (bytes.isEmpty) continue;
+          pickedFiles.add(
+            FeedbackLogAttachment(fileName: platformFile.name, bytes: bytes),
+          );
+        } catch (_) {
+          // 单个文件读取失败时跳过，继续处理其余文件。
+        }
+      }
+      if (pickedFiles.isEmpty || !mounted) return;
+      setState(() => _logFiles.addAll(pickedFiles));
+    } catch (err) {
+      if (!mounted) return;
+      _showMessage(_l10n.feedbackLogPickFailed(err.toString()));
+    }
+  }
+
+  void _removeLogFile(FeedbackLogAttachment file) {
+    setState(() => _logFiles.remove(file));
+  }
+
+  Future<void> _submit() async {
+    if (!(_formKey.currentState?.validate() ?? false)) return;
+    FocusScope.of(context).unfocus();
+    setState(() => _submitting = true);
+
+    try {
+      await widget.sentryService.submitFeedback(
+        FeedbackSubmission(
+          description: _descriptionController.text.trim(),
+          contact: _contactController.text.trim().isEmpty
+              ? null
+              : _contactController.text.trim(),
+          trigger: widget.trigger,
+          errorSummary: widget.initialErrorSummary,
+          screenshotBytes: _screenshotBytes,
+          logFiles: List.unmodifiable(_logFiles),
+          includeAppLog: _includeAppLog,
+        ),
+      );
+      if (!mounted) return;
+      final rootContext = logicRootContext;
+      Navigator.of(context, rootNavigator: true).pop();
+      if (rootContext.mounted) {
+        ScaffoldMessenger.of(
+          rootContext,
+        ).showSnackBar(SnackBar(content: Text(_l10n.feedbackSubmitSuccess)));
+      }
+    } on SentryNotConfiguredException {
+      _showMessage(_l10n.feedbackSentryNotConfigured);
+    } catch (err) {
+      _showMessage(_l10n.feedbackSubmitFailed(err.toString()));
+    } finally {
+      if (mounted) setState(() => _submitting = false);
+    }
+  }
+
+  void _showMessage(String message) {
+    if (!mounted) return;
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(SnackBar(content: Text(message)));
+  }
+
+  AppLocalizations get _l10n => AppLocalizations.of(context)!;
+
+  @override
+  Widget build(BuildContext context) {
+    final localizations = _l10n;
+    final theme = Theme.of(context);
+
+    return Scaffold(
+      appBar: AppBar(title: Text(localizations.feedback)),
+      body: Form(
+        key: _formKey,
+        child: ListView(
+          padding: const EdgeInsets.fromLTRB(16, 8, 16, 24),
+          children: [
+            if (widget.trigger == FeedbackTrigger.crash)
+              Card(
+                color: theme.colorScheme.errorContainer,
+                child: Padding(
+                  padding: const EdgeInsets.all(16),
+                  child: Row(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Icon(
+                        Icons.error_outline_rounded,
+                        color: theme.colorScheme.onErrorContainer,
+                      ),
+                      const SizedBox(width: 12),
+                      Expanded(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(
+                              localizations.feedbackCrashTitle,
+                              style: theme.textTheme.titleMedium?.copyWith(
+                                color: theme.colorScheme.onErrorContainer,
+                                fontWeight: FontWeight.w600,
+                              ),
+                            ),
+                            const SizedBox(height: 4),
+                            Text(
+                              localizations.feedbackCrashDesc,
+                              style: theme.textTheme.bodyMedium?.copyWith(
+                                color: theme.colorScheme.onErrorContainer,
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              )
+            else
+              Text(
+                localizations.feedbackManualDesc,
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+            const SizedBox(height: 16),
+            TextFormField(
+              controller: _descriptionController,
+              minLines: 4,
+              maxLines: 8,
+              textInputAction: TextInputAction.newline,
+              decoration: InputDecoration(
+                labelText: localizations.feedbackDescription,
+                hintText: localizations.feedbackDescriptionHint,
+                alignLabelWithHint: true,
+                border: const OutlineInputBorder(),
+              ),
+              validator: (value) => (value == null || value.trim().isEmpty)
+                  ? localizations.feedbackDescriptionRequired
+                  : null,
+            ),
+            const SizedBox(height: 16),
+            TextFormField(
+              controller: _contactController,
+              textInputAction: TextInputAction.done,
+              decoration: InputDecoration(
+                labelText: localizations.feedbackContact,
+                hintText: localizations.feedbackContactHint,
+                border: const OutlineInputBorder(),
+              ),
+            ),
+            const SizedBox(height: 16),
+            _sectionCard(
+              theme: theme,
+              title: localizations.feedbackScreenshot,
+              subtitle: localizations.feedbackScreenshotHint,
+              child: _screenshotBytes == null
+                  ? Align(
+                      alignment: Alignment.centerLeft,
+                      child: OutlinedButton.icon(
+                        onPressed: _submitting ? null : _pickScreenshot,
+                        icon: const Icon(Icons.add_photo_alternate_outlined),
+                        label: Text(localizations.feedbackAddScreenshot),
+                      ),
+                    )
+                  : Column(
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
+                      children: [
+                        ClipRRect(
+                          borderRadius: BorderRadius.circular(12),
+                          child: ConstrainedBox(
+                            constraints: const BoxConstraints(maxHeight: 240),
+                            child: Image.memory(
+                              _screenshotBytes!,
+                              fit: BoxFit.contain,
+                            ),
+                          ),
+                        ),
+                        const SizedBox(height: 8),
+                        Row(
+                          children: [
+                            Expanded(
+                              child: Text(
+                                _screenshotName ?? '',
+                                maxLines: 1,
+                                overflow: TextOverflow.ellipsis,
+                                style: theme.textTheme.bodySmall,
+                              ),
+                            ),
+                            TextButton.icon(
+                              onPressed: _submitting ? null : _removeScreenshot,
+                              icon: const Icon(Icons.delete_outline, size: 18),
+                              label: Text(localizations.delete),
+                            ),
+                          ],
+                        ),
+                      ],
+                    ),
+            ),
+            const SizedBox(height: 12),
+            _sectionCard(
+              theme: theme,
+              title: localizations.feedbackLogs,
+              subtitle: localizations.feedbackLogHint,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  SwitchListTile(
+                    contentPadding: EdgeInsets.zero,
+                    title: Text(localizations.feedbackIncludeAppLog),
+                    subtitle: Text(
+                      localizations.feedbackIncludeAppLogHint,
+                      style: theme.textTheme.bodySmall,
+                    ),
+                    value: _includeAppLog,
+                    onChanged: _submitting
+                        ? null
+                        : (value) => setState(() => _includeAppLog = value),
+                  ),
+                  for (final file in _logFiles)
+                    ListTile(
+                      contentPadding: EdgeInsets.zero,
+                      dense: true,
+                      leading: const Icon(Icons.description_outlined),
+                      title: Text(
+                        file.fileName,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                      trailing: IconButton(
+                        icon: const Icon(Icons.close),
+                        onPressed: _submitting
+                            ? null
+                            : () => _removeLogFile(file),
+                      ),
+                    ),
+                  Align(
+                    alignment: Alignment.centerLeft,
+                    child: OutlinedButton.icon(
+                      onPressed: _submitting ? null : _pickLogFiles,
+                      icon: const Icon(Icons.note_add_outlined),
+                      label: Text(localizations.feedbackAddLogFile),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              localizations.feedbackPrivacyHint,
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+            const SizedBox(height: 16),
+            FilledButton.icon(
+              onPressed: _submitting ? null : _submit,
+              icon: _submitting
+                  ? const SizedBox(
+                      width: 16,
+                      height: 16,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : const Icon(Icons.send_rounded),
+              label: Text(
+                _submitting
+                    ? localizations.feedbackSubmitting
+                    : localizations.feedbackSubmit,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _sectionCard({
+    required ThemeData theme,
+    required String title,
+    required String subtitle,
+    required Widget child,
+  }) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              title,
+              style: theme.textTheme.titleMedium?.copyWith(
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+            const SizedBox(height: 2),
+            Text(
+              subtitle,
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+            const SizedBox(height: 12),
+            child,
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/pages/profile/profile_menu_card.dart
+++ b/lib/pages/profile/profile_menu_card.dart
@@ -7,6 +7,7 @@ import 'package:bugaoshan/pages/course/schedule_management_page.dart';
 import 'package:bugaoshan/pages/settings/software_setting_page.dart';
 import 'package:bugaoshan/providers/app_config_provider.dart';
 import 'package:bugaoshan/providers/course_provider.dart';
+import 'package:bugaoshan/services/sentry/error_feedback_coordinator.dart';
 import 'package:bugaoshan/widgets/common/info_card.dart';
 import 'package:bugaoshan/widgets/common/styled_tile.dart';
 import 'package:bugaoshan/widgets/route/router_utils.dart';
@@ -59,6 +60,13 @@ class ProfileMenuCard extends StatelessWidget {
               onTap: () => popupOrNavigate(context, AboutPage()),
             );
           },
+        ),
+        IconTile(
+          icon: Icons.feedback_outlined,
+          label: localizations.feedback,
+          onTap: () => getIt<ErrorFeedbackCoordinator>().openFeedbackPage(
+            context: context,
+          ),
         ),
       ],
     );

--- a/lib/services/sentry/error_feedback_coordinator.dart
+++ b/lib/services/sentry/error_feedback_coordinator.dart
@@ -1,0 +1,126 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+import 'package:bugaoshan/pages/feedback/feedback_page.dart';
+import 'package:bugaoshan/services/sentry/sentry_service.dart';
+import 'package:bugaoshan/widgets/route/router_utils.dart';
+
+/// 全局异常 → Sentry → 反馈弹窗的协调器。
+///
+/// [attach] 会在 Sentry 初始化后包一层全局错误处理器：
+/// - Flutter 框架异常由 Sentry 自带的 FlutterErrorIntegration 上报，这里只负责弹窗；
+/// - Zone/异步未捕获异常由本协调器调用 SentryService 上报后再弹窗。
+class ErrorFeedbackCoordinator {
+  ErrorFeedbackCoordinator(this._sentry);
+
+  final SentryService _sentry;
+
+  static const Duration _cooldown = Duration(seconds: 15);
+
+  bool _pageShowing = false;
+  DateTime? _lastShownAt;
+
+  void attach() {
+    final previousFlutterErrorHandler = FlutterError.onError;
+    FlutterError.onError = (details) {
+      previousFlutterErrorHandler?.call(details);
+      _handleFlutterError(details);
+    };
+
+    final previousPlatformErrorHandler = PlatformDispatcher.instance.onError;
+    PlatformDispatcher.instance.onError = (error, stack) {
+      final handled = previousPlatformErrorHandler?.call(error, stack) ?? true;
+      unawaited(_handlePlatformError(error, stack));
+      return handled;
+    };
+  }
+
+  void _handleFlutterError(FlutterErrorDetails details) {
+    // Sentry 的 FlutterErrorIntegration 已经完成上报，避免重复 capture。
+    _showFeedbackPage(
+      trigger: FeedbackTrigger.crash,
+      errorSummary: details.exceptionAsString(),
+    );
+  }
+
+  Future<void> _handlePlatformError(Object error, StackTrace? stack) async {
+    await _sentry.captureException(error, stack, source: 'platform');
+    _showFeedbackPage(
+      trigger: FeedbackTrigger.crash,
+      errorSummary: error.toString(),
+    );
+  }
+
+  /// 用户主动打开反馈页（“我的”页面入口）。
+  Future<void> openFeedbackPage({BuildContext? context}) async {
+    if (_pageShowing) return;
+    final rootContext = context ?? navigatorKey.currentContext;
+    if (rootContext == null) return;
+
+    _pageShowing = true;
+    try {
+      await popupOrNavigate(
+        rootContext,
+        FeedbackPage(sentryService: _sentry, trigger: FeedbackTrigger.manual),
+      );
+    } catch (err) {
+      if (kDebugMode) {
+        debugPrint('ErrorFeedbackCoordinator: open feedback page failed: $err');
+      }
+    } finally {
+      _pageShowing = false;
+    }
+  }
+
+  void _showFeedbackPage({
+    required FeedbackTrigger trigger,
+    required String errorSummary,
+  }) {
+    if (!_sentry.isEnabled || _pageShowing) return;
+    final now = DateTime.now();
+    if (_lastShownAt != null && now.difference(_lastShownAt!) < _cooldown) {
+      return;
+    }
+    _lastShownAt = now;
+    _pageShowing = true;
+
+    unawaited(_openWhenNavigatorReady(trigger, errorSummary));
+  }
+
+  Future<void> _openWhenNavigatorReady(
+    FeedbackTrigger trigger,
+    String errorSummary,
+  ) async {
+    // 异常可能发生在首帧构建前，此时 navigatorKey 还没有 context，
+    // 轮询等待 MaterialApp 挂载后再弹。
+    BuildContext? rootContext;
+    for (var attempt = 0; attempt < 20; attempt++) {
+      rootContext = navigatorKey.currentContext;
+      if (rootContext != null) break;
+      await Future<void>.delayed(const Duration(milliseconds: 250));
+    }
+    if (rootContext == null || !rootContext.mounted) {
+      _pageShowing = false;
+      return;
+    }
+
+    try {
+      await popupOrNavigate(
+        rootContext,
+        FeedbackPage(
+          sentryService: _sentry,
+          trigger: trigger,
+          initialErrorSummary: errorSummary,
+        ),
+      );
+    } catch (err) {
+      if (kDebugMode) {
+        debugPrint('ErrorFeedbackCoordinator: auto feedback page failed: $err');
+      }
+    } finally {
+      _pageShowing = false;
+    }
+  }
+}

--- a/lib/services/sentry/sentry_service.dart
+++ b/lib/services/sentry/sentry_service.dart
@@ -1,0 +1,205 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
+
+import 'package:bugaoshan/utils/auth_logger.dart';
+
+/// Sentry DSN，通过编译参数注入：
+/// `flutter run --dart-define=SENTRY_DSN=https://xxx@oXXX.ingest.sentry.io/XXX`
+/// 未配置时 Sentry 采集为禁用状态（本地开发不需要额外配置）。
+const String kSentryDsn = String.fromEnvironment('SENTRY_DSN');
+
+/// CI 注入的 Git tag，用作 Sentry release；本地构建为空。
+const String _sentryRelease = String.fromEnvironment('GIT_TAG');
+
+/// 反馈触发方式。
+enum FeedbackTrigger { crash, manual }
+
+/// 用户额外选择的日志附件。
+class FeedbackLogAttachment {
+  const FeedbackLogAttachment({required this.fileName, required this.bytes});
+
+  final String fileName;
+  final Uint8List bytes;
+}
+
+/// 一次用户反馈的完整内容。
+class FeedbackSubmission {
+  const FeedbackSubmission({
+    required this.description,
+    required this.trigger,
+    this.contact,
+    this.errorSummary,
+    this.screenshotBytes,
+    this.logFiles = const [],
+    this.includeAppLog = true,
+  });
+
+  final String description;
+  final String? contact;
+  final FeedbackTrigger trigger;
+
+  /// 自动弹出时附带的异常摘要（不含完整堆栈，堆栈已随异常事件上报）。
+  final String? errorSummary;
+
+  /// 用户选择的截图（PNG/JPEG 字节）。
+  final Uint8List? screenshotBytes;
+
+  /// 用户额外选择的日志文件。
+  final List<FeedbackLogAttachment> logFiles;
+
+  /// 是否自动附带应用内置的认证运行日志。
+  final bool includeAppLog;
+}
+
+/// Sentry 未配置（缺少 SENTRY_DSN）时提交反馈抛出。
+class SentryNotConfiguredException implements Exception {
+  const SentryNotConfiguredException();
+
+  @override
+  String toString() =>
+      'Sentry DSN is not configured. Add --dart-define=SENTRY_DSN=...';
+}
+
+/// Sentry 初始化、异常上报与用户反馈提交的封装。
+///
+/// - [initialize] 必须在 `WidgetsFlutterBinding.ensureInitialized()` 之后调用；
+/// - 自动异常弹窗由 [ErrorFeedbackCoordinator] 负责，本服务不依赖 UI。
+class SentryService {
+  SentryService(this._authLogger, {String Function()? versionProvider})
+    : _versionProvider =
+          versionProvider ??
+          (() => _sentryRelease.isNotEmpty ? _sentryRelease : 'unknown');
+
+  final AuthLogger _authLogger;
+  final String Function() _versionProvider;
+
+  bool _initialized = false;
+  SentryId? _lastErrorEventId;
+
+  bool get initialized => _initialized;
+
+  /// 是否真正启用了 Sentry（已初始化且配置了 DSN）。
+  bool get isEnabled => _initialized && kSentryDsn.isNotEmpty;
+
+  Future<void> initialize() async {
+    if (_initialized) return;
+    if (kSentryDsn.isEmpty) {
+      if (kDebugMode) {
+        debugPrint('SentryService: SENTRY_DSN 未配置，Sentry 已禁用');
+      }
+      return;
+    }
+    await SentryFlutter.init((options) {
+      options
+        ..dsn = kSentryDsn
+        ..tracesSampleRate = 1.0
+        ..attachStacktrace = true
+        ..sendDefaultPii = false
+        ..environment = kReleaseMode ? 'production' : 'development';
+      if (_sentryRelease.isNotEmpty) {
+        options.release = _sentryRelease;
+      }
+    });
+    _initialized = true;
+  }
+
+  /// 上报异常，返回事件 id；未启用 Sentry 时返回 null。
+  Future<SentryId?> captureException(
+    Object exception,
+    StackTrace? stackTrace, {
+    String source = 'unknown',
+  }) async {
+    if (!isEnabled) return null;
+    try {
+      final eventId = await Sentry.captureException(
+        exception,
+        stackTrace: stackTrace,
+        withScope: (scope) {
+          scope.setTag('error.source', source);
+        },
+      );
+      _lastErrorEventId = eventId;
+      return eventId;
+    } catch (err) {
+      // 上报失败不能反过来影响应用运行。
+      if (kDebugMode) {
+        debugPrint('SentryService: captureException failed: $err');
+      }
+      return null;
+    }
+  }
+
+  /// 以 Sentry User Feedback 事件提交用户反馈，并通过 scope 附带截图与日志。
+  Future<void> submitFeedback(FeedbackSubmission submission) async {
+    if (!isEnabled) {
+      throw const SentryNotConfiguredException();
+    }
+
+    final contact = submission.contact;
+    final feedback = SentryFeedback(
+      message: submission.description,
+      contactEmail: (contact != null && contact.contains('@')) ? contact : null,
+    );
+    if (_lastErrorEventId != null) {
+      feedback.associatedEventId = _lastErrorEventId;
+    }
+
+    await Sentry.captureFeedback(
+      feedback,
+      withScope: (scope) {
+        scope
+          ..fingerprint = ['bugaoshan-user-feedback']
+          ..setTag('feedback.kind', submission.trigger.name)
+          ..setTag(
+            'feedback.has_screenshot',
+            (submission.screenshotBytes?.isNotEmpty ?? false).toString(),
+          )
+          ..setContexts('feedback', {
+            'description': submission.description,
+            'contact': contact ?? '',
+            'error_summary': submission.errorSummary ?? '',
+            'log_file_count': submission.logFiles.length,
+          });
+
+        if (submission.screenshotBytes?.isNotEmpty ?? false) {
+          scope.addAttachment(
+            SentryAttachment.fromScreenshotData(submission.screenshotBytes!),
+          );
+        }
+
+        if (submission.includeAppLog) {
+          final authLogText = _authLogger.exportToText(includeDate: true);
+          scope.addAttachment(
+            SentryAttachment.fromUint8List(
+              Uint8List.fromList(utf8.encode(authLogText)),
+              _buildAppLogFileName(),
+              contentType: 'text/plain; charset=utf-8',
+            ),
+          );
+        }
+
+        for (final logFile in submission.logFiles) {
+          scope.addAttachment(
+            SentryAttachment.fromUint8List(
+              logFile.bytes,
+              logFile.fileName,
+              contentType: 'text/plain; charset=utf-8',
+            ),
+          );
+        }
+      },
+    );
+  }
+
+  /// 应用日志附件文件名：`yyyyMMdd-HHmmss-<版本>.log`。
+  String _buildAppLogFileName() {
+    final now = DateTime.now();
+    String two(int value) => value.toString().padLeft(2, '0');
+    final timestamp =
+        '${now.year}${two(now.month)}${two(now.day)}-'
+        '${two(now.hour)}${two(now.minute)}${two(now.second)}';
+    return '$timestamp-${_versionProvider()}.log';
+  }
+}

--- a/lib/utils/auth_logger.dart
+++ b/lib/utils/auth_logger.dart
@@ -51,7 +51,7 @@ class AuthLogEntry {
   }
 }
 
-/// 隐私脱敏：把 access_token / password / Bearer 等敏感字段遮蔽，
+/// 隐私脱敏：把 access_token / password / Bearer / sp_code 等敏感字段遮蔽，
 /// 防止日志被分享到 issue 或支持工单时泄露凭据。
 class AuthLogRedactor {
   static final RegExp _accessTokenJson = RegExp(
@@ -66,8 +66,8 @@ class AuthLogRedactor {
     r'(Bearer\s+)[A-Za-z0-9._\-]+',
     caseSensitive: false,
   );
-  static final RegExp _oauthCode = RegExp(
-    r'([?&](?:code|access_token)=)([^&\s"]+)',
+  static final RegExp _sensitiveQueryParam = RegExp(
+    r'([?&](?:code|access_token|sp_code|state)=)([^&\s"]+)',
     caseSensitive: false,
   );
   static final RegExp _principalLabel = RegExp(
@@ -91,7 +91,7 @@ class AuthLogRedactor {
       (m) => '${m[1]}"<redacted>"',
     );
     result = result.replaceAllMapped(_bearerHeader, (m) => '${m[1]}<redacted>');
-    result = result.replaceAllMapped(_oauthCode, (m) {
+    result = result.replaceAllMapped(_sensitiveQueryParam, (m) {
       final prefix = m[1] ?? '';
       final value = m[2] ?? '';
       if (value.length <= 4) return '$prefix<redacted>';

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -10,6 +10,7 @@
 #include <flutter_inappwebview_linux/flutter_inappwebview_linux_plugin.h>
 #include <flutter_secure_storage_linux/flutter_secure_storage_linux_plugin.h>
 #include <screen_retriever_linux/screen_retriever_linux_plugin.h>
+#include <sentry_flutter/sentry_flutter_plugin.h>
 #include <system_theme/system_theme_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
 #include <window_manager/window_manager_plugin.h>
@@ -27,6 +28,9 @@ void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) screen_retriever_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "ScreenRetrieverLinuxPlugin");
   screen_retriever_linux_plugin_register_with_registrar(screen_retriever_linux_registrar);
+  g_autoptr(FlPluginRegistrar) sentry_flutter_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "SentryFlutterPlugin");
+  sentry_flutter_plugin_register_with_registrar(sentry_flutter_registrar);
   g_autoptr(FlPluginRegistrar) system_theme_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "SystemThemePlugin");
   system_theme_plugin_register_with_registrar(system_theme_registrar);

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -7,6 +7,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
   flutter_inappwebview_linux
   flutter_secure_storage_linux
   screen_retriever_linux
+  sentry_flutter
   system_theme
   url_launcher_linux
   window_manager

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -14,6 +14,7 @@ import flutter_secure_storage_darwin
 import gal
 import package_info_plus
 import screen_retriever_macos
+import sentry_flutter
 import share_plus
 import shared_preferences_foundation
 import sqflite_darwin
@@ -31,6 +32,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   GalPlugin.register(with: registry.registrar(forPlugin: "GalPlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
   ScreenRetrieverMacosPlugin.register(with: registry.registrar(forPlugin: "ScreenRetrieverMacosPlugin"))
+  SentryFlutterPlugin.register(with: registry.registrar(forPlugin: "SentryFlutterPlugin"))
   SharePlusMacosPlugin.register(with: registry.registrar(forPlugin: "SharePlusMacosPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   SqflitePlugin.register(with: registry.registrar(forPlugin: "SqflitePlugin"))

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -702,10 +702,10 @@ packages:
     dependency: "direct main"
     description:
       name: intl
-      sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
+      sha256: "1ca20c894b1717686a2319b8548763d812bc0aabdac580420a44c5178c57a867"
       url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "0.20.2"
+    version: "0.20.3"
   io:
     dependency: transitive
     description:
@@ -718,26 +718,10 @@ packages:
     dependency: transitive
     description:
       name: jni
-      sha256: f038e58b4dc2c9037f50e233175086337e0b305e356d28211bf55f21c504cbd3
+      sha256: d2c361082d554d4593c3012e26f6b188f902acd291330f13d6427641a92b3da1
       url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.0.3"
-  jni_flutter:
-    dependency: transitive
-    description:
-      name: jni_flutter
-      sha256: "7b717011ea40d04fd47c2731d3d1d36eb99eba3435c2753d62489e8c3c9991d5"
-      url: "https://pub.flutter-io.cn"
-    source: hosted
-    version: "1.0.2"
-  jni_util:
-    dependency: transitive
-    description:
-      name: jni_util
-      sha256: "1ba86da04a5f2bf18fde2edb235587e70c5b0fc5bd4ba955f46b00942c3fc35f"
-      url: "https://pub.flutter-io.cn"
-    source: hosted
-    version: "1.0.0"
+    version: "0.14.2"
   json_annotation:
     dependency: "direct main"
     description:
@@ -814,10 +798,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: "31bd099b47c10cd1aeb55146a2d46ce0277630ecef3f7dae54ad7873f36696cd"
       url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.20"
   material_color_utilities:
     dependency: transitive
     description:
@@ -830,10 +814,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: "307249ce4ff29d58a18e97f6345f539382eb9c9c29ecda628900f31de0443dd9"
       url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.0"
   mime:
     dependency: transitive
     description:
@@ -918,10 +902,10 @@ packages:
     dependency: transitive
     description:
       name: path_provider_android
-      sha256: "69cbd515a62b94d32a7944f086b2f82b4ac40a1d45bebfc00813a430ab2dabcd"
+      sha256: "149441ca6e4f38193b2e004c0ca6376a3d11f51fa5a77552d8bd4d2b0c0912ba"
       url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "2.3.1"
+    version: "2.2.23"
   path_provider_foundation:
     dependency: transitive
     description:
@@ -1091,6 +1075,22 @@ packages:
       url: "https://github.com/The-Brotherhood-of-SCU/scu_ocr_lite_dart.git"
     source: git
     version: "2.0.0"
+  sentry:
+    dependency: transitive
+    description:
+      name: sentry
+      sha256: c2ecd8abe82e63cdcb6947f71320612ced56e10ba94db7529d85cc02be47cb3b
+      url: "https://pub.flutter-io.cn"
+    source: hosted
+    version: "9.27.0"
+  sentry_flutter:
+    dependency: "direct main"
+    description:
+      name: sentry_flutter
+      sha256: ec89cc6ba939ca19155ea83900d9740a36544f50b3b6baf265518e3348fb0f50
+      url: "https://pub.flutter-io.cn"
+    source: hosted
+    version: "9.27.0"
   share_plus:
     dependency: "direct main"
     description:
@@ -1340,10 +1340,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
+      sha256: "2a122cbe059f8b610d3a5415f42e255b6c17b1f21eee1d960f31080237fb4f11"
       url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "0.7.11"
+    version: "0.7.12"
   tyme:
     dependency: "direct main"
     description:
@@ -1436,10 +1436,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
+      sha256: f36f9f3be64c6198714492bb455c11056e33e2f85d9a0b676a48301e44fdcf47
       url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "2.2.0"
+    version: "2.4.2"
   vm_service:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -51,6 +51,7 @@ dependencies:
   tyme: ^1.4.4
   json_annotation: ^4.12.0
   device_info_plus: ^13.2.0
+  sentry_flutter: ^9.27.0
 
 dev_dependencies:
   flutter_test:

--- a/test/auth_logger_test.dart
+++ b/test/auth_logger_test.dart
@@ -26,5 +26,19 @@ void main() {
       expect(redacted, isNot(contains('secret.token')));
       expect(redacted, isNot(contains('plain')));
     });
+
+    test('截断 URL 查询参数中的 sp_code 和 state', () {
+      final redacted = AuthLogRedactor.apply(
+        'https://example.com/cb?sp_code=very-long-secret-sp-code'
+        '&state=0123456789abcdef&code=shortcode',
+      );
+
+      expect(redacted, contains('sp_code=very…'));
+      expect(redacted, contains('state=0123…'));
+      expect(redacted, contains('code=shor…'));
+      expect(redacted, isNot(contains('very-long-secret-sp-code')));
+      expect(redacted, isNot(contains('0123456789abcdef')));
+      expect(redacted, isNot(contains('shortcode')));
+    });
   });
 }

--- a/test/sentry_service_test.dart
+++ b/test/sentry_service_test.dart
@@ -1,0 +1,24 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:bugaoshan/services/sentry/sentry_service.dart';
+import 'package:bugaoshan/utils/auth_logger.dart';
+
+void main() {
+  test(
+    'SentryService disables submission when DSN is not configured',
+    () async {
+      final service = SentryService(AuthLogger());
+
+      expect(service.isEnabled, isFalse);
+      await expectLater(
+        service.submitFeedback(
+          const FeedbackSubmission(
+            description: 'test',
+            trigger: FeedbackTrigger.manual,
+          ),
+        ),
+        throwsA(isA<SentryNotConfiguredException>()),
+      );
+    },
+  );
+}

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -11,6 +11,7 @@
 #include <flutter_secure_storage_windows/flutter_secure_storage_windows_plugin.h>
 #include <gal/gal_plugin_c_api.h>
 #include <screen_retriever_windows/screen_retriever_windows_plugin_c_api.h>
+#include <sentry_flutter/sentry_flutter_plugin.h>
 #include <share_plus/share_plus_windows_plugin_c_api.h>
 #include <system_theme/system_theme_plugin.h>
 #include <url_launcher_windows/url_launcher_windows.h>
@@ -27,6 +28,8 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("GalPluginCApi"));
   ScreenRetrieverWindowsPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("ScreenRetrieverWindowsPluginCApi"));
+  SentryFlutterPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("SentryFlutterPlugin"));
   SharePlusWindowsPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("SharePlusWindowsPluginCApi"));
   SystemThemePluginRegisterWithRegistrar(

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -8,6 +8,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
   flutter_secure_storage_windows
   gal
   screen_retriever_windows
+  sentry_flutter
   share_plus
   system_theme
   url_launcher_windows


### PR DESCRIPTION
# feat: 接入 Sentry 错误收集与用户反馈（异常自动弹窗 + 截图/日志上传）

## 背景

应用此前缺少远程错误收集能力：运行时异常只在本机显示/打印，开发者难以感知线上问题；用户反馈依赖手动提 Issue，且缺少日志、截图等定位信息。本次改动接入 `sentry_flutter`，实现：

- 运行时异常自动上报 Sentry，并自动弹出问题反馈页；
- 用户可在「我的」页面主动打开同一反馈页；
- 反馈支持填写问题描述、联系方式，并上传截图与日志。

## 设计概要

- **DSN 通过编译参数注入**：`--dart-define=SENTRY_DSN=...`，未配置时 Sentry 完全禁用，不影响应用运行；CI 从 GitHub Secret `SENTRY_DSN` 注入。
- **启动时序**：`main.dart` 在 `runApp` 前初始化 Sentry，并尽早接管 `FlutterError.onError` 与 `PlatformDispatcher.instance.onError`，依赖初始化阶段的异常也能被采集。
- **异常 → 弹窗链路解耦**：
  - Flutter 框架异常由 Sentry 自带 `FlutterErrorIntegration` 上报，协调器只负责弹窗，避免重复上报；
  - Zone/异步未捕获异常由 `SentryService.captureException` 上报后再弹窗；
  - 同一时间只弹一个反馈页，15 秒内连续异常不重复打扰。
- **反馈页自动/手动共用**：手机全屏、平板/桌面弹窗（复用 `popupOrNavigate`），两种触发方式进入完全相同的表单。
- **反馈提交**：使用 `Sentry.captureFeedback` 创建 User Feedback 事件，通过 scope 挂载截图与日志附件，并关联最近一次异常 `associatedEventId`。
- **日志来源**：应用认证/运行日志由 `AuthLogger` 内存缓冲实时导出，无需本地预先生成文件；用户也可额外选择 `.log` / `.txt` 文件。
- **脱敏增强**：`AuthLogRedactor` 新增对 `sp_code`、`state` 查询参数的截断脱敏。
- **本地生成物隔离**：`.sentry-native/` 加入 `.gitignore`，不进入仓库。

### 修改文件

| 文件 | 改动 |
| --- | --- |
| `pubspec.yaml` / `pubspec.lock` | 新增 `sentry_flutter: ^9.27.0` 依赖 |
| `lib/main.dart` | 启动时初始化 Sentry、接管全局错误处理；启动失败时上报异常 |
| `lib/injection/injector.dart` | 注册 `SentryService`、`ErrorFeedbackCoordinator`，惰性注入版本号 |
| `lib/services/sentry/sentry_service.dart` | **新增**：Sentry 初始化、异常上报、`Sentry.captureFeedback` 反馈提交与附件组装 |
| `lib/services/sentry/error_feedback_coordinator.dart` | **新增**：全局错误处理器包装、自动弹窗协调、15 秒防抖 |
| `lib/pages/feedback/feedback_page.dart` | **新增**：共用反馈表单（描述、联系方式、截图、日志、隐私提示） |
| `lib/pages/profile/profile_menu_card.dart` | 「我的」页面新增「问题反馈」入口 |
| `lib/pages/dev/feedback_test_tile.dart` / `dev_page.dart` | **新增**：开发者页「打开反馈页 / 触发测试异常」调试入口 |
| `lib/utils/auth_logger.dart` | `sp_code`、`state` 等敏感查询参数纳入脱敏 |
| `lib/l10n/app_en.arb` / `app_zh.arb` 及生成文件 | 新增反馈页与调试入口中英文本地化 |
| `.github/workflows/build-*.yml` | 三平台构建注入 `SENTRY_DSN` |
| `.gitignore` | 忽略 `.sentry-native/` 本地运行数据 |
| `docs/architecture/sentry-feedback.md`、`docs/README.md`、`AGENTS.md` | 新增架构说明并同步索引 |
| `test/sentry_service_test.dart` | **新增**：未配置 DSN 时提交反馈抛出 `SentryNotConfiguredException` |
| `test/auth_logger_test.dart` | 新增 `sp_code` / `state` 脱敏测试 |
| 各平台 `generated_plugin_registrant.*` | `flutter pub get` 自动生成 |

### UI 布局

<img width="808" height="797" alt="image" src="https://github.com/user-attachments/assets/16a7b116-b25d-4b58-a928-e137d61fa122" />
<img width="788" height="793" alt="image" src="https://github.com/user-attachments/assets/a6253daa-5abc-4a69-9d0a-16ed9064bc35" />


### 关键流程

```
应用运行
  ├─ Flutter 框架异常
  │    └─ Sentry FlutterErrorIntegration 自动上报
  │         └─ ErrorFeedbackCoordinator 弹出反馈页
  └─ Zone / 异步未捕获异常
       └─ SentryService.captureException 上报
            └─ ErrorFeedbackCoordinator 弹出反馈页（15 秒防抖）

用户主动入口
  └─ 「我的」→「问题反馈」→ 打开同一反馈页

反馈页提交
  ├─ 校验问题描述非空
  ├─ Sentry.captureFeedback
  │    ├─ message：问题描述
  │    ├─ contactEmail：邮箱格式联系方式
  │    └─ associatedEventId：关联最近一次异常
  └─ scope 附件
       ├─ 截图（image_picker）
       ├─ 应用运行日志（内存实时导出，文件名 yyyyMMdd-HHmmss-<版本>.log）
       └─ 用户选择的 .log / .txt 日志文件
```

### 调试/测试入口

- 开发者页面 →「打开问题反馈页」：验证手动反馈链路；
- 开发者页面 →「触发测试异常」：验证异常上报 + 自动弹窗链路（需配置 DSN）。

## 测试情况

- [x] `dart analyze` 全项目通过，无静态错误
- [x] `flutter test test/auth_logger_test.dart test/sentry_service_test.dart` 全部通过
- [x] 配置 DSN 后，反馈内容可正常上传至 Sentry（用户实测）
- [x] 日志脱敏单测覆盖 `sp_code` / `state` / `code` 参数
- [x] 未配置 DSN 时，自动弹窗禁用且手动提交给出明确提示
- [ ] 各平台 release 构建 + 异常自动弹窗端到端验证

## 兼容性说明

- 仅接入错误采集与反馈功能，不影响既有业务逻辑与登录认证流程
- 未配置 `SENTRY_DSN` 时，行为与改动前一致（仅多一个手动反馈入口）
- 反馈页使用项目已有的 `image_picker`、`file_picker` 依赖，无新增平台权限要求
- 新增本地化键不影响现有键值；`app_zh_Hans_CN.arb` 按项目约定未添加翻译项

## 已知局限

- 应用运行日志默认只存在于内存（文件落盘默认关闭），反馈提交时实时导出；如需崩溃后人工取本地日志，需后续增加带轮转的文件日志
- 截图由用户从相册/文件选择，不支持异常发生时自动截取当前屏幕
- Android 混淆构建暂未接入 ProGuard mapping 上传，Sentry 中部分异常堆栈可能为混淆后符号（后续可接入 `sentry_dart_plugin`）
- 反馈事件与 Flutter 框架异常的关联依赖 Sentry 自身集成，异步异常可精确关联 `associatedEventId`

## 检查项

- [x] 遵循现有代码风格，`dart format` / `dart analyze` 通过
- [x] DSN 未硬编码，统一由编译参数注入
- [x] 自动弹窗有防抖与单实例保护，不阻塞异常处理链路
- [x] 日志上传前经过脱敏（含新增 `sp_code` / `state`）
- [x] 本地化已覆盖 zh-cn / en-us
- [x] 生成文件（`pubspec.lock`、`app_localizations*.dart`、插件注册文件）一并提交
- [x] 仓库需在 GitHub Actions Secrets 中配置 `SENTRY_DSN`（合并后由维护者添加）
者添加）