### PR TITLE
ci: 在 Release 中链接 macOS 镜像构建

### DIFF
--- a/.github/scripts/release_body.py
+++ b/.github/scripts/release_body.py
@@ -12,6 +12,7 @@ def main():
 - Android: [arm64-Apk]({repo}/releases/download/v{version}/bugaoshan_{version}_arm64-v8a.apk)
 - Windows: [x64 Zip]({repo}/releases/download/v{version}/bugaoshan_{version}_windows_x64.zip)
 - Linux: [x64 Tar.gz]({repo}/releases/download/v{version}/bugaoshan_{version}_linux_x64.tar.gz)
+- macOS (Apple Silicon): [DMG](https://github.com/Visio-Vanitas/Bugaoshan/releases/download/v{version}/bugaoshan_{version}_macos_arm64.dmg)
 - IOS: 未发布正式版，可安装testflight后点击链接进行邀测: https://testflight.apple.com/join/Vyenb6gC
 
 > 💡 **Note**: 当前项目优先保障 Android 端的稳定与体验。 Windows,Linux 版本可能存在部分兼容性或体验问题。

--- a/.github/scripts/tests/test_release_workflow.py
+++ b/.github/scripts/tests/test_release_workflow.py
@@ -6,6 +6,17 @@ REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
 
 
 class ReleaseWorkflowTest(unittest.TestCase):
+    def test_macos_download_points_to_apple_mirror_release(self):
+        release_body = (
+            REPOSITORY_ROOT / ".github/scripts/release_body.py"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn(
+            "https://github.com/Visio-Vanitas/Bugaoshan/releases/download/"
+            "v{version}/bugaoshan_{version}_macos_arm64.dmg",
+            release_body,
+        )
+
     def test_linux_artifact_is_built_downloaded_and_required(self):
         workflow = (REPOSITORY_ROOT / ".github/workflows/release.yml").read_text(
             encoding="utf-8"


### PR DESCRIPTION
## 原因

macOS DMG 由个人公开镜像仓库的 Actions 使用 Apple 凭据完成签名与公证。主仓库不保存证书或个人 GitHub 令牌，因此 Release 正文按 tag 指向镜像仓库的同名制品；镜像构建完成后链接会自动生效。

## 改动

- 下载列表增加 macOS (Apple Silicon) DMG
- 添加回归测试，固定镜像 URL 与制品命名

## 验证

- `python3 -m unittest discover -s .github/scripts/tests -p "test_release_workflow.py"`
- 使用 v2.4.0 示例生成正文，确认链接为预期地址

注：主仓库 Release 创建后到镜像构建完成前，下载链接会短暂返回 404。