### PR TITLE
fix: 方案修读情况统计修正与无子节点模块显示

### DIFF
--- a/android/app/src/main/kotlin/io/github/the_brotherhood_of_scu/bugaoshan/CourseGlanceWidget.kt
+++ b/android/app/src/main/kotlin/io/github/the_brotherhood_of_scu/bugaoshan/CourseGlanceWidget.kt
@@ -17,9 +17,9 @@ import androidx.glance.appwidget.GlanceAppWidgetReceiver
 import androidx.glance.appwidget.SizeMode
 import androidx.glance.appwidget.action.actionStartActivity
 import androidx.glance.appwidget.cornerRadius
+import androidx.glance.appwidget.provideContent
 import androidx.glance.appwidget.lazy.LazyColumn
 import androidx.glance.appwidget.lazy.items
-import androidx.glance.appwidget.provideContent
 import androidx.glance.background
 import androidx.glance.layout.Alignment
 import androidx.glance.layout.Box
@@ -738,7 +738,6 @@ class CourseGlanceWidget : GlanceAppWidget() {
                     )
                 }
             } else {
-                // 课程列表：用 LazyColumn 支持滚动查看全部课程
                 LazyColumn(modifier = GlanceModifier.fillMaxSize()) {
                     items(courses.length()) { index ->
                         val course = courses.getJSONObject(index)

--- a/android/app/src/main/kotlin/io/github/the_brotherhood_of_scu/bugaoshan/CourseGlanceWidget.kt
+++ b/android/app/src/main/kotlin/io/github/the_brotherhood_of_scu/bugaoshan/CourseGlanceWidget.kt
@@ -18,8 +18,6 @@ import androidx.glance.appwidget.SizeMode
 import androidx.glance.appwidget.action.actionStartActivity
 import androidx.glance.appwidget.cornerRadius
 import androidx.glance.appwidget.provideContent
-import androidx.glance.appwidget.lazy.LazyColumn
-import androidx.glance.appwidget.lazy.items
 import androidx.glance.background
 import androidx.glance.layout.Alignment
 import androidx.glance.layout.Box
@@ -35,6 +33,7 @@ import androidx.glance.text.FontWeight
 import androidx.glance.text.Text
 import androidx.glance.text.TextStyle
 import androidx.glance.unit.ColorProvider
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import io.github.the_brotherhood_of_scu.bugaoshan.R
@@ -74,6 +73,10 @@ private val TITLE_FONT_SIZE_SP = 14.sp
 private val META_FONT_SIZE_SP = 13.sp
 private val META_SMALL_FONT_SIZE_SP = 11.sp
 private val EMPTY_FONT_SIZE_SP = 13.sp
+
+// 小组件最多渲染的课程数：避免 RemoteViews 元素过多导致系统「无法添加微件」。
+// 小组件空间有限，超出的课程本也显示不下。
+private const val MAX_VISIBLE_COURSES = 6
 
 // Cached layout parameters per widget instance
 data class CachedLayout(
@@ -737,8 +740,13 @@ class CourseGlanceWidget : GlanceAppWidget() {
                     )
                 }
             } else {
-                LazyColumn(modifier = GlanceModifier.fillMaxSize()) {
-                    items(courses.length()) { index ->
+                // 用普通 Column 而非 LazyColumn：Glance 1.1.x 的 LazyColumn 在
+                // SizeMode.Exact 下渲染 RemoteViews 存在兼容问题，会导致
+                // 系统提示「无法添加微件」。课程数量有限（一天最多十余节），
+                // 直接渲染即可。
+                val visibleCount = minOf(courses.length(), MAX_VISIBLE_COURSES)
+                Column(modifier = GlanceModifier.fillMaxSize()) {
+                    for (index in 0 until visibleCount) {
                         val course = courses.getJSONObject(index)
                         Box(modifier = GlanceModifier.padding(vertical = ITEM_VERTICAL_PADDING_DP)) {
                             CourseCard(
@@ -785,7 +793,10 @@ class CourseGlanceWidget : GlanceAppWidget() {
         val rawColor = course.optInt("colorValue", 0)
         val indicatorColor = when {
             isTomorrow -> ColorProvider(R.color.widget_tomorrow_accent)
-            (rawColor ushr 24) != 0 -> ColorProvider(rawColor)
+            // rawColor 是课程自定义 ARGB 颜色值（如 0xff9c27b0），需转为 Compose Color。
+            // 直接传 Int 会被 Glance 当作 color resource ID，渲染时 Resources 找不到
+            // → RemoteViews$ActionException → 系统提示「无法添加微件」。
+            (rawColor ushr 24) != 0 -> ColorProvider(Color(rawColor))
             else -> ColorProvider(R.color.widget_header_default)
         }
         val nameColor = if (isTomorrow) R.color.widget_tomorrow_text_primary else R.color.widget_text_primary

--- a/android/app/src/main/kotlin/io/github/the_brotherhood_of_scu/bugaoshan/CourseGlanceWidget.kt
+++ b/android/app/src/main/kotlin/io/github/the_brotherhood_of_scu/bugaoshan/CourseGlanceWidget.kt
@@ -74,8 +74,8 @@ private val META_FONT_SIZE_SP = 13.sp
 private val META_SMALL_FONT_SIZE_SP = 11.sp
 private val EMPTY_FONT_SIZE_SP = 13.sp
 
-// 小组件最多渲染的课程数：避免 RemoteViews 元素过多导致系统「无法添加微件」。
-// 小组件空间有限，超出的课程本也显示不下。
+// 小组件最多渲染的课程数：widget 空间有限，超出的课程本也显示不下；
+// 限制数量可避免 RemoteViews 元素过多（Glance 在元素过多时可能渲染失败）。
 private const val MAX_VISIBLE_COURSES = 6
 
 // Cached layout parameters per widget instance
@@ -740,10 +740,12 @@ class CourseGlanceWidget : GlanceAppWidget() {
                     )
                 }
             } else {
-                // 用普通 Column 而非 LazyColumn：Glance 1.1.x 的 LazyColumn 在
-                // SizeMode.Exact 下渲染 RemoteViews 存在兼容问题，会导致
-                // 系统提示「无法添加微件」。课程数量有限（一天最多十余节），
-                // 直接渲染即可。
+                // 用普通 Column 渲染课程（防御性改进）：
+                // 此前「有课时无法添加微件」的根因是下方 CourseCard 的
+                // ColorProvider 误用（logcat 中 Resources$NotFoundException，
+                // 已修复）。widget 课程数量有限，用 LazyColumn 意义不大；
+                // 改普通 Column 并限制数量，避免 RemoteViews 元素过多等
+                // 潜在兼容问题。
                 val visibleCount = minOf(courses.length(), MAX_VISIBLE_COURSES)
                 Column(modifier = GlanceModifier.fillMaxSize()) {
                     for (index in 0 until visibleCount) {

--- a/android/app/src/main/kotlin/io/github/the_brotherhood_of_scu/bugaoshan/CourseGlanceWidget.kt
+++ b/android/app/src/main/kotlin/io/github/the_brotherhood_of_scu/bugaoshan/CourseGlanceWidget.kt
@@ -17,6 +17,8 @@ import androidx.glance.appwidget.GlanceAppWidgetReceiver
 import androidx.glance.appwidget.SizeMode
 import androidx.glance.appwidget.action.actionStartActivity
 import androidx.glance.appwidget.cornerRadius
+import androidx.glance.appwidget.lazy.LazyColumn
+import androidx.glance.appwidget.lazy.items
 import androidx.glance.appwidget.provideContent
 import androidx.glance.background
 import androidx.glance.layout.Alignment
@@ -73,10 +75,6 @@ private val TITLE_FONT_SIZE_SP = 14.sp
 private val META_FONT_SIZE_SP = 13.sp
 private val META_SMALL_FONT_SIZE_SP = 11.sp
 private val EMPTY_FONT_SIZE_SP = 13.sp
-
-// 小组件最多渲染的课程数：widget 空间有限，超出的课程本也显示不下；
-// 限制数量可避免 RemoteViews 元素过多（Glance 在元素过多时可能渲染失败）。
-private const val MAX_VISIBLE_COURSES = 6
 
 // Cached layout parameters per widget instance
 data class CachedLayout(
@@ -740,15 +738,9 @@ class CourseGlanceWidget : GlanceAppWidget() {
                     )
                 }
             } else {
-                // 用普通 Column 渲染课程（防御性改进）：
-                // 此前「有课时无法添加微件」的根因是下方 CourseCard 的
-                // ColorProvider 误用（logcat 中 Resources$NotFoundException，
-                // 已修复）。widget 课程数量有限，用 LazyColumn 意义不大；
-                // 改普通 Column 并限制数量，避免 RemoteViews 元素过多等
-                // 潜在兼容问题。
-                val visibleCount = minOf(courses.length(), MAX_VISIBLE_COURSES)
-                Column(modifier = GlanceModifier.fillMaxSize()) {
-                    for (index in 0 until visibleCount) {
+                // 课程列表：用 LazyColumn 支持滚动查看全部课程
+                LazyColumn(modifier = GlanceModifier.fillMaxSize()) {
+                    items(courses.length()) { index ->
                         val course = courses.getJSONObject(index)
                         Box(modifier = GlanceModifier.padding(vertical = ITEM_VERTICAL_PADDING_DP)) {
                             CourseCard(

--- a/lib/pages/campus/plan_completion/plan_completion_page.dart
+++ b/lib/pages/campus/plan_completion/plan_completion_page.dart
@@ -135,12 +135,7 @@ class _PlanCompletionPageState extends State<PlanCompletionPage> {
     }
 
     // Build summary card
-    final categoryNodes = _provider.nodes.where((n) => n.isCategory).toList();
-    final totalEarned = categoryNodes.fold<double>(
-      0,
-      (sum, n) => sum + (double.tryParse(n.earnedCredits) ?? 0),
-    );
-    final completedCount = categoryNodes.where((n) => n.completed).length;
+    final stats = computeSummaryStats(_provider.nodes);
 
     return ListView(
       padding: const EdgeInsets.all(16),
@@ -148,9 +143,9 @@ class _PlanCompletionPageState extends State<PlanCompletionPage> {
         _buildSummaryCard(
           context,
           l10n,
-          totalEarned,
-          completedCount,
-          categoryNodes.length,
+          stats.totalEarned,
+          stats.completedCount,
+          stats.moduleCount,
         ),
         const SizedBox(height: 16),
         ...rootNodes.map((node) => _buildCategoryTile(context, node, 0)),
@@ -215,11 +210,12 @@ class _PlanCompletionPageState extends State<PlanCompletionPage> {
     final l10n = AppLocalizations.of(context)!;
     final children = _provider.getChildren(node.id);
 
+    // 无子节点的模块（如美育、创新创业教育、跨学科专业教育）以列表项形式展示，
+    // 与教务处方案层级保持一致。
     if (children.isEmpty && !node.isCourse) {
-      return const SizedBox.shrink();
+      return _buildLeafModuleTile(context, node, depth);
     }
 
-    // If this is a leaf category with no children, skip
     if (node.isCourse) {
       return _buildCourseTile(context, node, depth);
     }
@@ -302,6 +298,72 @@ class _PlanCompletionPageState extends State<PlanCompletionPage> {
       return '${l10n.planCompletionCourses}: $passed/$total';
     }
     return '';
+  }
+
+  Widget _buildLeafModuleTile(
+    BuildContext context,
+    PlanCompletionNode node,
+    int depth,
+  ) {
+    final l10n = AppLocalizations.of(context)!;
+    final earned = double.tryParse(node.earnedCredits) ?? 0;
+    final required = double.tryParse(node.requiredCredits) ?? 0;
+    final theme = Theme.of(context);
+
+    return StyledCard(
+      margin: const EdgeInsets.only(bottom: 8),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            Icon(
+              node.completed
+                  ? Icons.check_circle
+                  : Icons.radio_button_unchecked,
+              color: node.completed
+                  ? theme.colorScheme.primary
+                  : theme.colorScheme.onSurfaceVariant,
+              size: 22,
+            ),
+            const SizedBox(width: 16),
+            Expanded(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    _extractCategoryDisplayName(node.name),
+                    style: theme.textTheme.titleSmall?.copyWith(
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    '${l10n.planCompletionCredits}: ${node.earnedCredits}/${node.requiredCredits}',
+                    style: theme.textTheme.bodySmall,
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(width: 16),
+            SizedBox(
+              width: 64,
+              child: ClipRRect(
+                borderRadius: BorderRadius.circular(AppShapes.xs),
+                child: LinearProgressIndicator(
+                  value: required > 0
+                      ? (earned / required).clamp(0.0, 1.0)
+                      : 0.0,
+                  minHeight: 4,
+                  backgroundColor: theme.colorScheme.surfaceContainerHighest,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
   }
 
   Widget _buildCourseTile(
@@ -402,4 +464,39 @@ class _PlanCompletionPageState extends State<PlanCompletionPage> {
       ),
     );
   }
+}
+
+/// 摘要卡的统计结果。
+class PlanCompletionSummaryStats {
+  final double totalEarned;
+  final int completedCount;
+  final int moduleCount;
+
+  const PlanCompletionSummaryStats({
+    required this.totalEarned,
+    required this.completedCount,
+    required this.moduleCount,
+  });
+}
+
+/// 计算摘要卡的统计值。
+///
+/// 统计根级模块（pId == '-1'）的完成情况，与教务处方案层级一致。
+/// 根级模块包括 '001' 大类（如公共基础课、学科基础课）和 '002' 课程组
+/// （如选择性思政、通用英语等），不含子层的必修/选修/限选分类节点。
+/// 已获学分取各根级模块自身的 yxxf 之和。
+PlanCompletionSummaryStats computeSummaryStats(List<PlanCompletionNode> nodes) {
+  final rootModuleNodes = nodes
+      .where((n) => n.pId == '-1' && (n.isCategory || n.isSubCategory))
+      .toList();
+  final totalEarned = rootModuleNodes.fold<double>(
+    0,
+    (sum, n) => sum + (double.tryParse(n.earnedCredits) ?? 0),
+  );
+  final completedCount = rootModuleNodes.where((n) => n.completed).length;
+  return PlanCompletionSummaryStats(
+    totalEarned: totalEarned,
+    completedCount: completedCount,
+    moduleCount: rootModuleNodes.length,
+  );
 }

--- a/test/plan_completion_provider_test.dart
+++ b/test/plan_completion_provider_test.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:bugaoshan/pages/campus/plan_completion/models/plan_completion.dart';
+import 'package:bugaoshan/pages/campus/plan_completion/plan_completion_page.dart';
 import 'package:bugaoshan/providers/plan_completion_provider.dart';
 import 'package:bugaoshan/services/api/zhjw_api_service.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -36,6 +37,130 @@ void main() {
       );
     },
   );
+
+  test(
+    'summary stats only count root-level modules (pId=-1) matching school hierarchy',
+    () {
+      // 模拟真实场景：根级模块（pId=-1）包括 001 大类和 002 课程组，
+      // 子层分类（002 必修/选修/限选）不参与统计。
+      //   公共基础课(001, pId=-1, yxxf=25, sfwc=否)
+      //   ├─ 必修(002, pId=cat1, yxxf=25, sfwc=否) ← 子层，不计入
+      //   选择性思政(002, pId=-1, yxxf=2, sfwc=是)
+      //   ├─ 课程A(kch, pId=sub1)
+      //   专业课(001, pId=-1, yxxf=10, sfwc=否)
+      //   ├─ 限选(002, pId=cat2, yxxf=2, sfwc=否) ← 子层，不计入
+      final nodes = <PlanCompletionNode>[
+        PlanCompletionNode.fromJson({
+          'id': 'cat1',
+          'pId': '-1',
+          'flagId': 'cat1',
+          'flagType': '001',
+          'name': '公共基础课',
+          'sfwc': '否',
+          'yxxf': '25',
+          'zsxf': '27',
+        }),
+        PlanCompletionNode.fromJson({
+          'id': 'sub_classify',
+          'pId': 'cat1',
+          'flagId': 'sub_c',
+          'flagType': '002',
+          'name': '必修',
+          'sfwc': '否',
+          'yxxf': '25',
+          'zsxf': '27',
+        }),
+        PlanCompletionNode.fromJson({
+          'id': 'sub1',
+          'pId': '-1',
+          'flagId': 'sub1',
+          'flagType': '002',
+          'name': '选择性思政必修课（N选1）',
+          'sfwc': '是',
+          'yxxf': '2',
+          'zsxf': '2',
+        }),
+        PlanCompletionNode.fromJson({
+          'id': 'c1',
+          'pId': 'sub1',
+          'flagId': 'c1',
+          'flagType': 'kch',
+          'name': '[102620020]改革开放史[2学分,2024-2025学年春](必修,86.0(20250625))',
+          'sfwc': '是',
+          'yxxf': '0',
+          'zsxf': '0',
+        }),
+        PlanCompletionNode.fromJson({
+          'id': 'cat2',
+          'pId': '-1',
+          'flagId': 'cat2',
+          'flagType': '001',
+          'name': '专业课',
+          'sfwc': '否',
+          'yxxf': '10',
+          'zsxf': '40',
+        }),
+        PlanCompletionNode.fromJson({
+          'id': 'sub_classify2',
+          'pId': 'cat2',
+          'flagId': 'sub_c2',
+          'flagType': '002',
+          'name': '限选',
+          'sfwc': '否',
+          'yxxf': '2',
+          'zsxf': '9',
+        }),
+      ];
+
+      final childMap = <String, List<PlanCompletionNode>>{};
+      for (final n in nodes) {
+        if (n.pId != '-1') {
+          childMap.putIfAbsent(n.pId, () => []).add(n);
+        }
+      }
+
+      final stats = computeSummaryStats(nodes);
+
+      // 根级模块 = 3（cat1 + sub1 + cat2），不含子层分类
+      expect(stats.moduleCount, 3);
+      // 已完成 = 1（选择性思政）
+      expect(stats.completedCount, 1);
+      // 已获学分 = 根级模块 yxxf 之和（25 + 2 + 10 = 37）
+      expect(stats.totalEarned, 37.0);
+    },
+  );
+
+  test('summary stats with single root-level module', () {
+    // 仅一个根级模块
+    final nodes = <PlanCompletionNode>[
+      PlanCompletionNode.fromJson({
+        'id': 'cat1',
+        'pId': '-1',
+        'flagId': 'cat1',
+        'flagType': '001',
+        'name': '公共课',
+        'sfwc': '是',
+        'yxxf': '6',
+        'zsxf': '6',
+      }),
+      PlanCompletionNode.fromJson({
+        'id': 'c1',
+        'pId': 'cat1',
+        'flagId': 'c1',
+        'flagType': 'kch',
+        'name': '[101]体育[1学分,2023](必修,90)',
+        'sfwc': '是',
+        'yxxf': '0',
+        'zsxf': '0',
+      }),
+    ];
+
+    final stats = computeSummaryStats(nodes);
+
+    expect(stats.moduleCount, 1);
+    expect(stats.completedCount, 1);
+    expect(stats.totalEarned, 6.0);
+  });
 }
 
 PlanCompletionNode _node(String id) => PlanCompletionNode.fromJson({


### PR DESCRIPTION
### PR 描述

**关联 Issue:**  #227

**问题描述：**
方案修读情况页面的摘要卡「已完成模块 x/y」显示错误——原来只统计 `flagType=='001'` 的大类（5 个），实际方案树有 17 个根级模块（5 个 001 大类 + 12 个 002 课程组），导致分母与实际方案层级不一致。同时，3 个无子节点的模块（美育、创新创业教育、跨学科专业教育）在 UI 中被隐藏，与教务处 zTree 显示不一致。

**修复内容：**

1. **统计逻辑修正** — 新增 `computeSummaryStats(List<PlanCompletionNode>)` 纯函数，仅统计 `pId == '-1'` 的根级模块（`flagType` 为 `'001'` 大类或 `'002'` 课程组），排除子层的必修/选修/限选分类节点。已获学分取各根级模块自身的 `yxxf` 之和。

2. **无子节点模块 UI 显示** — 新增 `_buildLeafModuleTile` 方法，对无子节点的 `002` 模块（美育、创新创业教育、跨学科专业教育）以 `Row` + `Column` 布局展示，含完成图标、名称、学分和进度条，视觉风格与 `ExpansionTile` 头部一致。使用 `Row`/`Column` 而非 `ListTile` 以避免在 `ListView` unbounded height 约束下的布局崩溃。

3. **新增测试** — plan_completion_provider_test.dart 新增 2 个测试用例，覆盖根级模块统计逻辑（含子层分类排除场景）和单根级模块场景。

**数据验证（真机调试）：**
- 修复前：`1/5`
- 修复后：`9/17`（与教务处层级一致）

**文件变更：**
- plan_completion_page.dart — 新增 `computeSummaryStats`、`PlanCompletionSummaryStats` 类、`_buildLeafModuleTile` 方法
- plan_completion_provider_test.dart — 新增 2 个测试 + 清理未使用代码