### PR TITLE
fix(ci): prerelease 资产上传失败(Immutable Releases)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,14 +129,32 @@ jobs:
           VERSION: ${{ steps.vars.outputs.tag }}
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ steps.vars.outputs.tag }}
-          name: Release ${{ steps.vars.outputs.tag }}
-          body: ${{ steps.release_body.outputs.body }}
-          files: |
-            bugaoshan_*.apk
-            bugaoshan_*.zip
-          draft: false
-          prerelease: ${{ contains(steps.vars.outputs.tag, '-') }}
-          generate_release_notes: false
+        run: |
+          set -euo pipefail
+          TAG="${{ steps.vars.outputs.tag }}"
+          PRERELEASE=${{ contains(steps.vars.outputs.tag, '-') }}
+          printf '%s' "$BODY" > notes.md
+
+          GOPTS=()
+          if [ "$PRERELEASE" = "true" ]; then
+            GOPTS+=(--prerelease)
+          fi
+
+          # 不可变发布(Immutable Releases)仓库下，prerelease 必须先落成 draft、
+          # 上传资产、再发布。若直接 publish，GitHub 会立刻将其标记为不可变，之后的资产上传会被拒绝
+          gh release create "$TAG" \
+            --title "Release $TAG" \
+            --notes-file notes.md \
+            --draft \
+            "${GOPTS[@]}"
+
+          gh release upload "$TAG" bugaoshan_*.apk bugaoshan_*.zip
+
+          if [ "$PRERELEASE" = "true" ]; then
+            gh release edit "$TAG" --draft=false --prerelease
+          else
+            gh release edit "$TAG" --draft=false --latest
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BODY: ${{ steps.release_body.outputs.body }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,7 +131,6 @@ jobs:
       - name: Create GitHub Release
         run: |
           set -euo pipefail
-          TAG="${{ steps.vars.outputs.tag }}"
           PRERELEASE=${{ contains(steps.vars.outputs.tag, '-') }}
           printf '%s' "$BODY" > notes.md
 
@@ -158,3 +157,4 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BODY: ${{ steps.release_body.outputs.body }}
+          TAG: ${{ steps.vars.outputs.tag }}


### PR DESCRIPTION
## 背景

CI 中 Release job 的 \Create GitHub Release\ 步骤失败（run 32968917624）：仓库开启了 GitHub **Immutable Releases**，\softprops/action-gh-release@v2\ 创建 prerelease（tag 含 \-\，如 \2.4.0-preview\）时会被立即标记为不可变，导致后续资产上传被拒绝。stable tag 不受影响。

报错：\Cannot upload asset ... to an immutable release\。

## 改动

将 \Create GitHub Release\ 步骤改为 \gh\ CLI（runner 预装），按 GitHub 官方建议的时序：

1. \gh release create --draft\：先落成 draft（prerelease 时加 \--prerelease\）
2. \gh release upload\：在发布前上传资产
3. \gh release edit --draft=false\：发布（stable 标记 \--latest\，prerelease 保持 \--prerelease\）

同时把 release body 通过 \--notes-file\ 写入，避免多行内容注入。

## 验证

- 已删除此前失败留下的空 \2.4.0-preview\ release（tag 保留）。
- 需要合并后在 main 上经 \workflow_dispatch\ 用 \2.4.0-preview\ 重跑验证。