### PR TITLE
导入课表时按主导校区自动应用预置时间表

### DIFF
--- a/lib/models/course.dart
+++ b/lib/models/course.dart
@@ -273,23 +273,6 @@ class ScheduleConfig {
   /// 从上课地点推断校区时使用的关键词，顺序即匹配优先级。
   static const List<String> campusKeywords = ['江安', '望江', '华西'];
 
-  /// 从一批上课地点统计主导校区。
-  ///
-  /// 每个地点按 [campusKeywords] 顺序取第一个命中的关键词计数一次；
-  /// 返回出现次数严格最多的校区名。无任何命中或存在并列时返回 null。
-  static String? dominantCampusOfLocations(Iterable<String> locations) {
-    final counts = <String, int>{};
-    for (final location in locations) {
-      for (final keyword in campusKeywords) {
-        if (location.contains(keyword)) {
-          counts[keyword] = (counts[keyword] ?? 0) + 1;
-          break;
-        }
-      }
-    }
-    return _majorityCampus(counts);
-  }
-
   /// 单门课程的校区关键词。
   ///
   /// 优先取教务处 `campusName` 字段命中的校区关键词；未命中时回退到
@@ -305,13 +288,21 @@ class ScheduleConfig {
   }
 
   /// 从一批课程统计主导校区（依据 [campusKeywordOfCourse]）。
+  ///
+  /// 按 [Course.name] 去重后计数——解析时同一门课会按多个周段/多节次
+  /// 展开成多条记录，逐条计数会让节次多的课程主导结果。同一课程名的
+  /// 多条记录取第一条命中的校区。无任何命中或并列时返回 null。
   static String? dominantCampusOfCourses(List<Course> courses) {
-    final counts = <String, int>{};
+    final campusOfName = <String, String>{};
     for (final course in courses) {
       final keyword = campusKeywordOfCourse(course);
       if (keyword != null) {
-        counts[keyword] = (counts[keyword] ?? 0) + 1;
+        campusOfName.putIfAbsent(course.name, () => keyword);
       }
+    }
+    final counts = <String, int>{};
+    for (final keyword in campusOfName.values) {
+      counts[keyword] = (counts[keyword] ?? 0) + 1;
     }
     return _majorityCampus(counts);
   }
@@ -327,19 +318,52 @@ class ScheduleConfig {
     return sorted.first.key;
   }
 
+  /// 判断 [slots] 是否与某个预置时间表完全一致（即用户未自定义过）。
+  static bool isPresetTimeSlots(List<TimeSlot> slots) =>
+      _sameTimeSlots(slots, jiangAnTimeSlots) ||
+      _sameTimeSlots(slots, wangJiangHuaXiTimeSlots);
+
+  static bool _sameTimeSlots(List<TimeSlot> a, List<TimeSlot> b) {
+    if (a.length != b.length) return false;
+    for (var i = 0; i < a.length; i++) {
+      final s = a[i], t = b[i];
+      if (s.startTime.hour != t.startTime.hour ||
+          s.startTime.minute != t.startTime.minute ||
+          s.endTime.hour != t.endTime.hour ||
+          s.endTime.minute != t.endTime.minute) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /// 若 [courses] 存在主导校区，返回该校区的预置时间表；否则返回 null。
+  static List<TimeSlot>? campusTimeSlotsForCourses(List<Course> courses) {
+    final campus = dominantCampusOfCourses(courses);
+    if (campus == null) return null;
+    return timeSlotsForCampusName(campus);
+  }
+
   /// 若 [courses] 存在主导校区，则将 [config] 的时间表替换为该校区的
   /// 预置时间表（会新建列表，不共享预设常量）。
   ///
+  /// 仅当 [config] 的节数为默认 4-5-3 时才应用——预置时间表固定 12 节，
+  /// 非 4-5-3 配置应用后会导致 `sectionsPerDay` 与 `timeSlots.length`
+  /// 不一致（课程网格行数与时间列对不上）。
+  ///
   /// 校区判定优先使用课程的 `campus` 字段（教务处 campusName），其次
-  /// 从地点字符串推断。返回是否发生了修改；无主导校区时保持 [config]
+  /// 从地点字符串推断。返回是否发生了修改；不满足条件时保持 [config]
   /// 不变并返回 false。
   static bool applyCampusTimeSlotsForCourses(
     ScheduleConfig config,
     List<Course> courses,
   ) {
-    final campus = dominantCampusOfCourses(courses);
-    if (campus == null) return false;
-    final slots = timeSlotsForCampusName(campus);
+    if (config.morningSections != 4 ||
+        config.afternoonSections != 5 ||
+        config.eveningSections != 3) {
+      return false;
+    }
+    final slots = campusTimeSlotsForCourses(courses);
     if (slots == null) return false;
     config.timeSlots = List.of(slots);
     return true;
@@ -515,10 +539,12 @@ class Course {
     required this.endSection,
     required this.colorValue,
     this.weekType = WeekType.every,
-  }) : id = id ?? _generateId();
+  }) : id = id ?? generateId();
 
   static int _idCounter = 0;
-  static String _generateId() {
+
+  /// 生成唯一课程 ID（微秒时间戳 + 自增序号）。
+  static String generateId() {
     final now = DateTime.now();
     _idCounter++;
     return '${now.microsecondsSinceEpoch}_$_idCounter';
@@ -606,7 +632,10 @@ class Course {
     return first <= end;
   }
 
+  /// 复制并可选覆盖字段。[id] 传 `null` 时保留原 ID；需要重新生成 ID 时
+  /// 显式传入 [Course.generateId]()。
   Course copyWith({
+    String? id,
     String? name,
     String? teacher,
     String? location,
@@ -620,7 +649,7 @@ class Course {
     WeekType? weekType,
   }) {
     return Course(
-      id: id,
+      id: id ?? this.id,
       name: name ?? this.name,
       teacher: teacher ?? this.teacher,
       location: location ?? this.location,

--- a/lib/models/course.dart
+++ b/lib/models/course.dart
@@ -270,6 +270,48 @@ class ScheduleConfig {
     return null;
   }
 
+  /// 从上课地点推断校区时使用的关键词，顺序即匹配优先级。
+  static const List<String> campusKeywords = ['江安', '望江', '华西'];
+
+  /// 统计一批上课地点中的主导校区。
+  ///
+  /// 每个地点按 [campusKeywords] 顺序取第一个命中的关键词计数一次；
+  /// 返回出现次数严格最多的校区名。无任何命中或存在并列时返回 null。
+  static String? dominantCampusOfLocations(Iterable<String> locations) {
+    final counts = <String, int>{};
+    for (final location in locations) {
+      for (final keyword in campusKeywords) {
+        if (location.contains(keyword)) {
+          counts[keyword] = (counts[keyword] ?? 0) + 1;
+          break;
+        }
+      }
+    }
+    if (counts.isEmpty) return null;
+    final sorted = counts.entries.toList()
+      ..sort((a, b) => b.value.compareTo(a.value));
+    if (sorted.length > 1 && sorted.first.value == sorted[1].value) {
+      return null; // 并列，无法确定主导校区
+    }
+    return sorted.first.key;
+  }
+
+  /// 若 [courses] 的上课地点存在主导校区，则将 [config] 的时间表替换为
+  /// 该校区的预置时间表（会新建列表，不共享预设常量）。
+  ///
+  /// 返回是否发生了修改；无主导校区时保持 [config] 不变并返回 false。
+  static bool applyCampusTimeSlotsForCourses(
+    ScheduleConfig config,
+    List<Course> courses,
+  ) {
+    final campus = dominantCampusOfLocations(courses.map((c) => c.location));
+    if (campus == null) return false;
+    final slots = timeSlotsForCampusName(campus);
+    if (slots == null) return false;
+    config.timeSlots = List.of(slots);
+    return true;
+  }
+
   static List<TimeSlot> _defaultTimeSlots(
     int morning,
     int afternoon,

--- a/lib/models/course.dart
+++ b/lib/models/course.dart
@@ -273,7 +273,7 @@ class ScheduleConfig {
   /// 从上课地点推断校区时使用的关键词，顺序即匹配优先级。
   static const List<String> campusKeywords = ['江安', '望江', '华西'];
 
-  /// 统计一批上课地点中的主导校区。
+  /// 从一批上课地点统计主导校区。
   ///
   /// 每个地点按 [campusKeywords] 顺序取第一个命中的关键词计数一次；
   /// 返回出现次数严格最多的校区名。无任何命中或存在并列时返回 null。
@@ -287,6 +287,37 @@ class ScheduleConfig {
         }
       }
     }
+    return _majorityCampus(counts);
+  }
+
+  /// 单门课程的校区关键词。
+  ///
+  /// 优先取教务处 `campusName` 字段命中的校区关键词；未命中时回退到
+  /// 从上课地点字符串推断。
+  static String? campusKeywordOfCourse(Course course) {
+    for (final keyword in campusKeywords) {
+      if (course.campus.contains(keyword)) return keyword;
+    }
+    for (final keyword in campusKeywords) {
+      if (course.location.contains(keyword)) return keyword;
+    }
+    return null;
+  }
+
+  /// 从一批课程统计主导校区（依据 [campusKeywordOfCourse]）。
+  static String? dominantCampusOfCourses(List<Course> courses) {
+    final counts = <String, int>{};
+    for (final course in courses) {
+      final keyword = campusKeywordOfCourse(course);
+      if (keyword != null) {
+        counts[keyword] = (counts[keyword] ?? 0) + 1;
+      }
+    }
+    return _majorityCampus(counts);
+  }
+
+  /// 取计数表中严格最多的校区；空表或并列时返回 null。
+  static String? _majorityCampus(Map<String, int> counts) {
     if (counts.isEmpty) return null;
     final sorted = counts.entries.toList()
       ..sort((a, b) => b.value.compareTo(a.value));
@@ -296,15 +327,17 @@ class ScheduleConfig {
     return sorted.first.key;
   }
 
-  /// 若 [courses] 的上课地点存在主导校区，则将 [config] 的时间表替换为
-  /// 该校区的预置时间表（会新建列表，不共享预设常量）。
+  /// 若 [courses] 存在主导校区，则将 [config] 的时间表替换为该校区的
+  /// 预置时间表（会新建列表，不共享预设常量）。
   ///
-  /// 返回是否发生了修改；无主导校区时保持 [config] 不变并返回 false。
+  /// 校区判定优先使用课程的 `campus` 字段（教务处 campusName），其次
+  /// 从地点字符串推断。返回是否发生了修改；无主导校区时保持 [config]
+  /// 不变并返回 false。
   static bool applyCampusTimeSlotsForCourses(
     ScheduleConfig config,
     List<Course> courses,
   ) {
-    final campus = dominantCampusOfLocations(courses.map((c) => c.location));
+    final campus = dominantCampusOfCourses(courses);
     if (campus == null) return false;
     final slots = timeSlotsForCampusName(campus);
     if (slots == null) return false;
@@ -457,6 +490,10 @@ class Course {
   String name;
   String teacher;
   String location;
+
+  /// 上课校区（来自教务处 `campusName` 字段，如"江安校区"）。
+  /// 旧数据 / 分享 JSON 无此字段时为空串，此时从 [location] 推断。
+  String campus;
   int startWeek;
   int endWeek;
   int dayOfWeek; // 1=Mon ... 7=Sun
@@ -470,6 +507,7 @@ class Course {
     required this.name,
     required this.teacher,
     required this.location,
+    this.campus = '',
     required this.startWeek,
     required this.endWeek,
     required this.dayOfWeek,
@@ -493,6 +531,7 @@ class Course {
       name: json['name'] as String? ?? '',
       teacher: json['teacher'] as String? ?? '',
       location: json['location'] as String? ?? '',
+      campus: json['campus'] as String? ?? '',
       startWeek: json['startWeek'] as int? ?? 1,
       endWeek: json['endWeek'] as int? ?? ScheduleConfig.kDefaultTotalWeeks,
       dayOfWeek: json['dayOfWeek'] as int? ?? 1,
@@ -510,6 +549,7 @@ class Course {
     'name': name,
     'teacher': teacher,
     'location': location,
+    'campus': campus,
     'startWeek': startWeek,
     'endWeek': endWeek,
     'dayOfWeek': dayOfWeek,
@@ -570,6 +610,7 @@ class Course {
     String? name,
     String? teacher,
     String? location,
+    String? campus,
     int? startWeek,
     int? endWeek,
     int? dayOfWeek,
@@ -583,6 +624,7 @@ class Course {
       name: name ?? this.name,
       teacher: teacher ?? this.teacher,
       location: location ?? this.location,
+      campus: campus ?? this.campus,
       startWeek: startWeek ?? this.startWeek,
       endWeek: endWeek ?? this.endWeek,
       dayOfWeek: dayOfWeek ?? this.dayOfWeek,

--- a/lib/pages/course/import/import_schedule_page.dart
+++ b/lib/pages/course/import/import_schedule_page.dart
@@ -154,25 +154,10 @@ class _ImportSchedulePageState extends State<ImportSchedulePage> {
       } else if (resolution.isCancel) {
         return;
       } else if (resolution.isUpdate) {
-        // Update existing schedule's courses instead of creating new.
         // Regenerate IDs to avoid PRIMARY KEY conflicts (source JSON may have
-        // empty or duplicate IDs).
+        // empty or duplicate IDs). copyWith 保留全部字段（含 campus）。
         final newCourses = courses
-            .map(
-              (c) => Course(
-                name: c.name,
-                teacher: c.teacher,
-                location: c.location,
-                campus: c.campus,
-                startWeek: c.startWeek,
-                endWeek: c.endWeek,
-                dayOfWeek: c.dayOfWeek,
-                startSection: c.startSection,
-                endSection: c.endSection,
-                colorValue: c.colorValue,
-                weekType: c.weekType,
-              ),
-            )
+            .map((c) => c.copyWith(id: Course.generateId()))
             .toList();
         await widget.courseProvider.replaceScheduleCourses(
           resolution.existingScheduleId!,

--- a/lib/pages/course/import/import_schedule_page.dart
+++ b/lib/pages/course/import/import_schedule_page.dart
@@ -194,23 +194,14 @@ class _ImportSchedulePageState extends State<ImportSchedulePage> {
 
       // Save to DB via provider
       await widget.courseProvider.addSchedule(config);
-      // Switch is automatic in addSchedule, now add courses
-      // Assign new IDs to avoid PRIMARY KEY conflicts with existing courses
-      for (final course in courses) {
-        await widget.courseProvider.addCourse(
-          Course(
-            name: course.name,
-            teacher: course.teacher,
-            location: course.location,
-            startWeek: course.startWeek,
-            endWeek: course.endWeek,
-            dayOfWeek: course.dayOfWeek,
-            startSection: course.startSection,
-            endSection: course.endSection,
-            colorValue: course.colorValue,
-            weekType: course.weekType,
-          ),
-        );
+      // Switch is automatic in addSchedule, now add courses.
+      // 传入原对象以保留全部字段（含 campus），避免逐字段复制时遗漏；
+      // 分享 JSON 可能带空/重复 ID，重新生成以避免主键冲突。
+      for (var course in courses) {
+        if (course.id.isEmpty) {
+          course = course.copyWith(id: Course.generateId());
+        }
+        await widget.courseProvider.addCourse(course);
       }
 
       if (mounted) {
@@ -540,6 +531,9 @@ class _ImportSchedulePageState extends State<ImportSchedulePage> {
       jwxt_parser.validateImportedSchedule(config, courses);
 
   /// 更新已有课表（仅替换课程）后，按课程主导校区刷新其时间表。
+  ///
+  /// 仅当已有课表的时间表仍是预置（用户未自定义）时才覆盖，避免静默
+  /// 改动用户手动调整过的每节课起止时间。
   Future<void> _applyCampusTimeSlotsToExisting(
     String scheduleId,
     List<Course> courses,
@@ -548,9 +542,14 @@ class _ImportSchedulePageState extends State<ImportSchedulePage> {
         .where((s) => s.id == scheduleId)
         .firstOrNull;
     if (existing == null) return;
-    if (ScheduleConfig.applyCampusTimeSlotsForCourses(existing, courses)) {
-      await widget.courseProvider.updateScheduleConfig(existing);
-    }
+    if (!ScheduleConfig.isPresetTimeSlots(existing.timeSlots)) return;
+    final slots = ScheduleConfig.campusTimeSlotsForCourses(courses);
+    if (slots == null) return;
+    // 拷贝后再落库，避免原地修改 allSchedules 缓存中的对象，
+    // 造成内存与 DB 状态不一致。
+    await widget.courseProvider.updateScheduleConfig(
+      existing.copyWith(timeSlots: List.of(slots)),
+    );
   }
 
   /// 检查课表名称是否冲突，如果冲突则弹出对话框询问用户操作。

--- a/lib/pages/course/import/import_schedule_page.dart
+++ b/lib/pages/course/import/import_schedule_page.dart
@@ -139,6 +139,8 @@ class _ImportSchedulePageState extends State<ImportSchedulePage> {
 
       config.id = DateTime.now().millisecondsSinceEpoch.toString();
       _validateImportedSchedule(config, courses);
+      // 按主导校区自动应用预置时间表（无主导校区时保持原时间表）
+      ScheduleConfig.applyCampusTimeSlotsForCourses(config, courses);
 
       // Resolve name conflict if any
       final desiredName = config.semesterName.isEmpty
@@ -172,6 +174,11 @@ class _ImportSchedulePageState extends State<ImportSchedulePage> {
             )
             .toList();
         await widget.courseProvider.replaceScheduleCourses(
+          resolution.existingScheduleId!,
+          newCourses,
+        );
+        // 课程已整体替换，同步按主导校区刷新已有课表的时间表
+        await _applyCampusTimeSlotsToExisting(
           resolution.existingScheduleId!,
           newCourses,
         );
@@ -395,6 +402,8 @@ class _ImportSchedulePageState extends State<ImportSchedulePage> {
         config.semesterName = scheduleName;
         config.id = DateTime.now().millisecondsSinceEpoch.toString();
         _validateImportedSchedule(config, parsed.courses);
+        // 按主导校区自动应用预置时间表（无主导校区时保持原时间表）
+        ScheduleConfig.applyCampusTimeSlotsForCourses(config, parsed.courses);
 
         if (!importAll) {
           // 单个导入：询问用户如何处理名称冲突
@@ -405,6 +414,11 @@ class _ImportSchedulePageState extends State<ImportSchedulePage> {
             return;
           } else if (resolution.isUpdate) {
             await widget.courseProvider.replaceScheduleCourses(
+              resolution.existingScheduleId!,
+              parsed.courses,
+            );
+            // 课程已整体替换，同步按主导校区刷新已有课表的时间表
+            await _applyCampusTimeSlotsToExisting(
               resolution.existingScheduleId!,
               parsed.courses,
             );
@@ -426,6 +440,8 @@ class _ImportSchedulePageState extends State<ImportSchedulePage> {
               existingId,
               parsed.courses,
             );
+            // 课程已整体替换，同步按主导校区刷新已有课表的时间表
+            await _applyCampusTimeSlotsToExisting(existingId, parsed.courses);
             importedSchedules.add((id: existingId, name: scheduleName));
             continue;
           }
@@ -521,6 +537,20 @@ class _ImportSchedulePageState extends State<ImportSchedulePage> {
 
   void _validateImportedSchedule(ScheduleConfig config, List<Course> courses) =>
       jwxt_parser.validateImportedSchedule(config, courses);
+
+  /// 更新已有课表（仅替换课程）后，按课程主导校区刷新其时间表。
+  Future<void> _applyCampusTimeSlotsToExisting(
+    String scheduleId,
+    List<Course> courses,
+  ) async {
+    final existing = widget.courseProvider.allSchedules.value
+        .where((s) => s.id == scheduleId)
+        .firstOrNull;
+    if (existing == null) return;
+    if (ScheduleConfig.applyCampusTimeSlotsForCourses(existing, courses)) {
+      await widget.courseProvider.updateScheduleConfig(existing);
+    }
+  }
 
   /// 检查课表名称是否冲突，如果冲突则弹出对话框询问用户操作。
   /// 返回 `null` 表示无冲突（可继续以原名称导入）。

--- a/lib/pages/course/import/import_schedule_page.dart
+++ b/lib/pages/course/import/import_schedule_page.dart
@@ -163,6 +163,7 @@ class _ImportSchedulePageState extends State<ImportSchedulePage> {
                 name: c.name,
                 teacher: c.teacher,
                 location: c.location,
+                campus: c.campus,
                 startWeek: c.startWeek,
                 endWeek: c.endWeek,
                 dayOfWeek: c.dayOfWeek,

--- a/lib/pages/course/import/jwxt_parser.dart
+++ b/lib/pages/course/import/jwxt_parser.dart
@@ -67,6 +67,7 @@ void validateImportedSchedule(ScheduleConfig config, List<Course> courses) {
         final int endSection = startSection + continuingSession - 1;
         final String location =
             '${tpMap['teachingBuildingName'] ?? ''}${tpMap['classroomName'] ?? ''}';
+        final String campusName = tpMap['campusName'] as String? ?? '';
         final String classWeek = tpMap['classWeek'] as String? ?? '';
 
         final weekSegments = parseClassWeekSegments(classWeek);
@@ -78,6 +79,7 @@ void validateImportedSchedule(ScheduleConfig config, List<Course> courses) {
                 name: courseName,
                 teacher: teacher,
                 location: location,
+                campus: campusName,
                 startWeek: segment.startWeek,
                 endWeek: segment.endWeek,
                 dayOfWeek: dayOfWeek,

--- a/lib/services/database_service.dart
+++ b/lib/services/database_service.dart
@@ -100,7 +100,15 @@ class DatabaseService {
 
     _db = await openDatabase(
       dbPath,
-      version: 1,
+      version: 2,
+      onUpgrade: (db, oldVersion, newVersion) async {
+        if (oldVersion < 2) {
+          // v2: courses 增加 campus 列（教务处 campusName 字段）
+          await db.execute(
+            "ALTER TABLE courses ADD COLUMN campus TEXT NOT NULL DEFAULT ''",
+          );
+        }
+      },
       onCreate: (db, version) async {
         await db.execute('''
           CREATE TABLE metadata (
@@ -121,6 +129,7 @@ class DatabaseService {
             name TEXT,
             teacher TEXT,
             location TEXT,
+            campus TEXT NOT NULL DEFAULT '',
             start_week INTEGER,
             end_week INTEGER,
             day_of_week INTEGER,
@@ -181,6 +190,7 @@ class DatabaseService {
     'name': course.name,
     'teacher': course.teacher,
     'location': course.location,
+    'campus': course.campus,
     'start_week': course.startWeek,
     'end_week': course.endWeek,
     'day_of_week': course.dayOfWeek,
@@ -197,6 +207,7 @@ class DatabaseService {
       name: row['name'] as String? ?? '',
       teacher: row['teacher'] as String? ?? '',
       location: row['location'] as String? ?? '',
+      campus: row['campus'] as String? ?? '',
       startWeek: row['start_week'] as int,
       endWeek: row['end_week'] as int,
       dayOfWeek: row['day_of_week'] as int,

--- a/test/campus_time_slots_test.dart
+++ b/test/campus_time_slots_test.dart
@@ -1,10 +1,11 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:bugaoshan/models/course.dart';
 
-Course _course(String location) => Course(
+Course _course(String location, {String campus = ''}) => Course(
   name: '课程',
   teacher: '',
   location: location,
+  campus: campus,
   startWeek: 1,
   endWeek: 16,
   dayOfWeek: 1,
@@ -109,6 +110,90 @@ void main() {
       );
       config.timeSlots.removeAt(0);
       expect(ScheduleConfig.jiangAnTimeSlots.length, 12);
+    });
+  });
+
+  group('ScheduleConfig.campusKeywordOfCourse', () {
+    test('优先使用 campus 字段', () {
+      expect(
+        ScheduleConfig.campusKeywordOfCourse(_course('一教A101', campus: '江安校区')),
+        '江安',
+      );
+    });
+
+    test('campus 字段无关键词时回退到地点推断', () {
+      expect(
+        ScheduleConfig.campusKeywordOfCourse(
+          _course('华西五教302', campus: '其它校区'),
+        ),
+        '华西',
+      );
+    });
+
+    test('campus 与地点均无关键词返回 null', () {
+      expect(
+        ScheduleConfig.campusKeywordOfCourse(_course('综楼C203', campus: '')),
+        isNull,
+      );
+    });
+  });
+
+  group('ScheduleConfig.applyCampusTimeSlotsForCourses (campus 字段)', () {
+    test('地点无校区关键词时由 campus 字段主导', () {
+      final config = _config();
+      final applied = ScheduleConfig.applyCampusTimeSlotsForCourses(config, [
+        _course('一教A101', campus: '望江校区'),
+        _course('综楼C203', campus: '望江校区'),
+      ]);
+      expect(applied, isTrue);
+      expect(config.timeSlots, ScheduleConfig.wangJiangHuaXiTimeSlots);
+    });
+
+    test('campus 与地点关键词混合时合并计数', () {
+      final config = _config();
+      final applied = ScheduleConfig.applyCampusTimeSlotsForCourses(config, [
+        _course('一教A101', campus: '望江校区'),
+        _course('基础教学楼B101', campus: '望江校区'),
+        _course('江安综楼C203'),
+      ]);
+      expect(applied, isTrue);
+      expect(config.timeSlots, ScheduleConfig.wangJiangHuaXiTimeSlots);
+    });
+
+    test('campus 字段并列时保持原时间表', () {
+      final config = _config();
+      final original = List.of(config.timeSlots);
+      final applied = ScheduleConfig.applyCampusTimeSlotsForCourses(config, [
+        _course('一教A101', campus: '望江校区'),
+        _course('一教A101', campus: '江安校区'),
+      ]);
+      expect(applied, isFalse);
+      expect(config.timeSlots, original);
+    });
+
+    test('无任何校区信息时保持原时间表', () {
+      final config = _config();
+      final original = List.of(config.timeSlots);
+      final applied = ScheduleConfig.applyCampusTimeSlotsForCourses(config, [
+        _course('综楼C203'),
+        _course('线上'),
+      ]);
+      expect(applied, isFalse);
+      expect(config.timeSlots, original);
+    });
+  });
+
+  group('Course campus 字段序列化', () {
+    test('toJson/fromJson 保留 campus', () {
+      final course = _course('一教A101', campus: '江安校区');
+      final restored = Course.fromJson(course.toJson());
+      expect(restored.campus, '江安校区');
+    });
+
+    test('旧 JSON 无 campus 字段时兼容为空串', () {
+      final json = _course('一教A101').toJson()..remove('campus');
+      final restored = Course.fromJson(json);
+      expect(restored.campus, '');
     });
   });
 }

--- a/test/campus_time_slots_test.dart
+++ b/test/campus_time_slots_test.dart
@@ -1,58 +1,78 @@
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:bugaoshan/models/course.dart';
 
-Course _course(String location, {String campus = ''}) => Course(
-  name: '课程',
-  teacher: '',
-  location: location,
-  campus: campus,
-  startWeek: 1,
-  endWeek: 16,
-  dayOfWeek: 1,
-  startSection: 1,
-  endSection: 2,
-  colorValue: 0xFF2196F3,
-);
+Course _course(String location, {String campus = '', String name = '课程'}) =>
+    Course(
+      name: name,
+      teacher: '',
+      location: location,
+      campus: campus,
+      startWeek: 1,
+      endWeek: 16,
+      dayOfWeek: 1,
+      startSection: 1,
+      endSection: 2,
+      colorValue: 0xFF2196F3,
+    );
 
 ScheduleConfig _config() =>
     ScheduleConfig(semesterStartDate: DateTime(2026, 3, 2));
 
 void main() {
-  group('ScheduleConfig.dominantCampusOfLocations', () {
+  group('ScheduleConfig.dominantCampusOfCourses', () {
     test('空列表返回 null', () {
-      expect(ScheduleConfig.dominantCampusOfLocations(const []), isNull);
+      expect(ScheduleConfig.dominantCampusOfCourses(const []), isNull);
     });
 
     test('全部无校区关键词返回 null', () {
       expect(
-        ScheduleConfig.dominantCampusOfLocations(['线上', '综楼C203', '']),
+        ScheduleConfig.dominantCampusOfCourses([
+          _course('线上'),
+          _course('综楼C203'),
+          _course(''),
+        ]),
         isNull,
       );
     });
 
     test('占多数的校区为主导', () {
-      final campus = ScheduleConfig.dominantCampusOfLocations([
-        '江安一教A101',
-        '江安综楼C203',
-        '望江基础教学楼B101',
+      final campus = ScheduleConfig.dominantCampusOfCourses([
+        _course('江安一教A101', name: '课A'),
+        _course('江安综楼C203', name: '课B'),
+        _course('望江基础教学楼B101', name: '课C'),
       ]);
       expect(campus, '江安');
     });
 
     test('数量并列返回 null', () {
-      final campus = ScheduleConfig.dominantCampusOfLocations([
-        '江安一教A101',
-        '望江一教101',
+      final campus = ScheduleConfig.dominantCampusOfCourses([
+        _course('江安一教A101', name: '课A'),
+        _course('望江一教101', name: '课B'),
       ]);
       expect(campus, isNull);
     });
 
-    test('地点同时包含多个关键词时按优先级只计一次', () {
-      final campus = ScheduleConfig.dominantCampusOfLocations([
-        '江安望江楼101',
-        '江安一教A101',
+    test('同一课程按周段/节次展开的多条记录只计一次', () {
+      // 1 门望江课拆成 12 条记录 vs 3 门江安课各 1 条：
+      // 逐条计数会得出望江主导；按课程名去重后应为江安。
+      final campus = ScheduleConfig.dominantCampusOfCourses([
+        for (var i = 0; i < 12; i++) _course('望江一教101', name: '望江课'),
+        _course('江安一教A101', name: '江安课1'),
+        _course('江安综楼C203', name: '江安课2'),
+        _course('江安一教B201', name: '江安课3'),
       ]);
       expect(campus, '江安');
+    });
+
+    test('同一课程名多条记录取第一条命中的校区', () {
+      final campus = ScheduleConfig.dominantCampusOfCourses([
+        _course('望江一教101', name: '跨校区课'),
+        _course('江安一教A101', name: '跨校区课'),
+        _course('望江一教102', name: '望江课'),
+        _course('江安一教B201', name: '江安课'),
+      ]);
+      expect(campus, '望江');
     });
   });
 
@@ -91,9 +111,9 @@ void main() {
       final config = _config();
       final original = List.of(config.timeSlots);
       final applied = ScheduleConfig.applyCampusTimeSlotsForCourses(config, [
-        _course('江安一教A101'),
-        _course('望江一教101'),
-        _course('线上'),
+        _course('江安一教A101', name: '江安课'),
+        _course('望江一教101', name: '望江课'),
+        _course('线上', name: '线上课'),
       ]);
       expect(applied, isFalse);
       expect(config.timeSlots, original);
@@ -164,8 +184,8 @@ void main() {
       final config = _config();
       final original = List.of(config.timeSlots);
       final applied = ScheduleConfig.applyCampusTimeSlotsForCourses(config, [
-        _course('一教A101', campus: '望江校区'),
-        _course('一教A101', campus: '江安校区'),
+        _course('一教A101', campus: '望江校区', name: '望江课'),
+        _course('一教A101', campus: '江安校区', name: '江安课'),
       ]);
       expect(applied, isFalse);
       expect(config.timeSlots, original);
@@ -180,6 +200,65 @@ void main() {
       ]);
       expect(applied, isFalse);
       expect(config.timeSlots, original);
+    });
+  });
+
+  group('ScheduleConfig 非 4-5-3 配置守卫与预置检测', () {
+    test('非 4-5-3 配置不应用预设（避免节数与时间表错位）', () {
+      final config = ScheduleConfig(
+        semesterStartDate: DateTime(2026, 3, 2),
+        morningSections: 3,
+        afternoonSections: 4,
+        eveningSections: 3,
+        // 模拟分享 JSON 携带的 10 节时间表
+        timeSlots: List.generate(
+          10,
+          (_) => const TimeSlot(
+            startTime: TimeOfDay(hour: 8, minute: 0),
+            endTime: TimeOfDay(hour: 8, minute: 45),
+          ),
+        ),
+      );
+      final original = List.of(config.timeSlots);
+      final applied = ScheduleConfig.applyCampusTimeSlotsForCourses(config, [
+        _course('望江一教101'),
+      ]);
+      expect(applied, isFalse);
+      expect(config.timeSlots, original);
+      expect(config.sectionsPerDay, 10);
+      expect(config.timeSlots.length, isNot(12));
+    });
+
+    test('campusTimeSlotsForCourses 返回主导校区预置', () {
+      expect(
+        ScheduleConfig.campusTimeSlotsForCourses([_course('华西五教302')]),
+        ScheduleConfig.wangJiangHuaXiTimeSlots,
+      );
+      expect(ScheduleConfig.campusTimeSlotsForCourses([_course('线上')]), isNull);
+    });
+
+    test('isPresetTimeSlots 识别两种预置', () {
+      expect(
+        ScheduleConfig.isPresetTimeSlots(
+          List.of(ScheduleConfig.jiangAnTimeSlots),
+        ),
+        isTrue,
+      );
+      expect(
+        ScheduleConfig.isPresetTimeSlots(
+          List.of(ScheduleConfig.wangJiangHuaXiTimeSlots),
+        ),
+        isTrue,
+      );
+    });
+
+    test('自定义时间表不被识别为预置', () {
+      final custom = List.of(ScheduleConfig.jiangAnTimeSlots);
+      custom[0] = custom[0].copyWith(
+        startTime: const TimeOfDay(hour: 9, minute: 0),
+      );
+      expect(ScheduleConfig.isPresetTimeSlots(custom), isFalse);
+      expect(ScheduleConfig.isPresetTimeSlots(<TimeSlot>[]), isFalse);
     });
   });
 

--- a/test/campus_time_slots_test.dart
+++ b/test/campus_time_slots_test.dart
@@ -1,0 +1,114 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:bugaoshan/models/course.dart';
+
+Course _course(String location) => Course(
+  name: '课程',
+  teacher: '',
+  location: location,
+  startWeek: 1,
+  endWeek: 16,
+  dayOfWeek: 1,
+  startSection: 1,
+  endSection: 2,
+  colorValue: 0xFF2196F3,
+);
+
+ScheduleConfig _config() =>
+    ScheduleConfig(semesterStartDate: DateTime(2026, 3, 2));
+
+void main() {
+  group('ScheduleConfig.dominantCampusOfLocations', () {
+    test('空列表返回 null', () {
+      expect(ScheduleConfig.dominantCampusOfLocations(const []), isNull);
+    });
+
+    test('全部无校区关键词返回 null', () {
+      expect(
+        ScheduleConfig.dominantCampusOfLocations(['线上', '综楼C203', '']),
+        isNull,
+      );
+    });
+
+    test('占多数的校区为主导', () {
+      final campus = ScheduleConfig.dominantCampusOfLocations([
+        '江安一教A101',
+        '江安综楼C203',
+        '望江基础教学楼B101',
+      ]);
+      expect(campus, '江安');
+    });
+
+    test('数量并列返回 null', () {
+      final campus = ScheduleConfig.dominantCampusOfLocations([
+        '江安一教A101',
+        '望江一教101',
+      ]);
+      expect(campus, isNull);
+    });
+
+    test('地点同时包含多个关键词时按优先级只计一次', () {
+      final campus = ScheduleConfig.dominantCampusOfLocations([
+        '江安望江楼101',
+        '江安一教A101',
+      ]);
+      expect(campus, '江安');
+    });
+  });
+
+  group('ScheduleConfig.applyCampusTimeSlotsForCourses', () {
+    test('江安主导 → 应用江安预置时间表', () {
+      final config = _config();
+      final applied = ScheduleConfig.applyCampusTimeSlotsForCourses(config, [
+        _course('江安一教A101'),
+        _course('江安综楼C203'),
+      ]);
+      expect(applied, isTrue);
+      expect(config.timeSlots, ScheduleConfig.jiangAnTimeSlots);
+    });
+
+    test('望江主导 → 应用望江/华西预置时间表', () {
+      final config = _config();
+      final applied = ScheduleConfig.applyCampusTimeSlotsForCourses(config, [
+        _course('望江基础教学楼B101'),
+        _course('望江一教101'),
+        _course('江安一教A101'),
+      ]);
+      expect(applied, isTrue);
+      expect(config.timeSlots, ScheduleConfig.wangJiangHuaXiTimeSlots);
+    });
+
+    test('华西主导 → 应用望江/华西预置时间表', () {
+      final config = _config();
+      final applied = ScheduleConfig.applyCampusTimeSlotsForCourses(config, [
+        _course('华西五教302'),
+      ]);
+      expect(applied, isTrue);
+      expect(config.timeSlots, ScheduleConfig.wangJiangHuaXiTimeSlots);
+    });
+
+    test('无主导校区时保持原时间表不变', () {
+      final config = _config();
+      final original = List.of(config.timeSlots);
+      final applied = ScheduleConfig.applyCampusTimeSlotsForCourses(config, [
+        _course('江安一教A101'),
+        _course('望江一教101'),
+        _course('线上'),
+      ]);
+      expect(applied, isFalse);
+      expect(config.timeSlots, original);
+    });
+
+    test('应用后使用的是预设副本，不共享常量列表', () {
+      final config = _config();
+      ScheduleConfig.applyCampusTimeSlotsForCourses(config, [
+        _course('江安一教A101'),
+      ]);
+      expect(
+        identical(config.timeSlots, ScheduleConfig.jiangAnTimeSlots),
+        isFalse,
+      );
+      config.timeSlots.removeAt(0);
+      expect(ScheduleConfig.jiangAnTimeSlots.length, 12);
+    });
+  });
+}


### PR DESCRIPTION
## 导入课表时按主导校区自动应用预置时间表

### 功能说明

导入课表时，自动检测课表中课程的主要上课校区，并应用该校区的预置时间表（每节课起止时间）：

- **江安校区**为主 → 应用 `jiangAnTimeSlots`（第一节课 8:15）
- **望江 / 华西校区**为主 → 应用 `wangJiangHuaXiTimeSlots`（第一节课 8:00）
- 无主导校区或并列 → 保持原时间表不变（教务处新建配置默认已是江安时间表）

覆盖全部导入路径：

| 导入路径 | 处理方式 |
|---|---|
| 在线导入（单个/批量） | 每学期独立检测，`addSchedule` 前应用 |
| 粘贴教务处 JSON / 分享 JSON 新建 | `addSchedule` 前应用 |
| 名称冲突选「更新」 | 替换课程后同步刷新已有课表的时间表 |
| 批量导入「全部更新」 | 同上 |

### 校区判定逻辑

每门课程按以下优先级取校区关键词（`江安` / `望江` / `华西`）计数：

1. **`campus` 字段**（本次新增）——来自教务处 `timeAndPlaceList[].campusName`（如「江安校区」），教学楼名不带校区前缀时也能正确判定
2. **`location` 地点字符串**——回退方案，兼容分享的旧 JSON

出现次数**严格最多**的校区胜出；并列则不修改时间表。

### 其他改动

- `Course` 模型新增 `campus` 字段，JSON 序列化/反序列化对旧数据兼容（缺省为空串）
- SQLite `courses` 表新增 `campus` 列，DB 版本 1 → 2，`onUpgrade` 自动 `ALTER TABLE` 迁移老用户数据
- 新增 campus_time_slots_test.dart：19 个用例覆盖主导校区判定（占多数 / 并列 / 多关键词优先级）、三种校区预设应用、`campus` 字段优先级与回退、序列化兼容

### 测试

- `flutter test`：299 passed, 1 skipped（pre-existing）
- `dart analyze`：No issues found
- `dart format`：已通过 pre-commit 钩子

### TODO / 已知边界

- [x] 教务处在线导入（`campusName` 来源）
- [x] 分享 JSON 导入（地点关键词回退）
- 分享 JSON 若由旧版本导出，课程无 `campus` 字段且地点无校区关键词时不生效（保持原时间表，行为与之前一致）