### PR TITLE
fix(widget): iOS/macOS 小组件 app resume 时同步数据

### DIFF
--- a/ios/CourseWidget/WidgetExtension.swift
+++ b/ios/CourseWidget/WidgetExtension.swift
@@ -1049,16 +1049,6 @@ struct LockScreenRectangularView: View {
             )
         }
     }
-
-    private var lockScreenEmptyStateTitle: String {
-        if entry.isOnVacation {
-            return widgetLocalizedString("widget.onVacation")
-        }
-        if entry.isTomorrow {
-            return widgetLocalizedString("widget.noClassesTomorrow")
-        }
-        return widgetLocalizedString("widget.todayClassesFinished")
-    }
 }
 
 struct CourseWidgetEntryView: View {

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -14,8 +14,6 @@
 		32A1DE7A3010E68D00E054EA /* WidgetExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32A1DE793010E68D00E054EA /* WidgetExtension.swift */; };
 		32A1DE7C3010E68E00E054EA /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 32A1DE7B3010E68E00E054EA /* Assets.xcassets */; };
 		A8C9D0E1F2A3456789BCDEF0 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = B9D0E1F2A3B4567890CDEF12 /* Localizable.xcstrings */; };
-		C1D2E3F4A5B6478899D0E1F2 /* InfoPlist.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = D2E3F4A5B6C748990AE1F2D3 /* InfoPlist.xcstrings */; };
-		E3F4A5B6C7D8499A0BE2F3A4 /* InfoPlist.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = F4A5B6C7D8E94A9B0CF3A4B5 /* InfoPlist.xcstrings */; };
 		32A1DE803010E68E00E054EA /* CourseWidgetExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 32A1DE713010E68D00E054EA /* CourseWidgetExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		048BF1A1065B47CDA3294652 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = DEFF419ACAB947F4B5DF4E96 /* Localizable.xcstrings */; };
 		331C808B294A63AB00263BE5 /* RunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331C807B294A618700263BE5 /* RunnerTests.swift */; };
@@ -84,8 +82,6 @@
 		32A1DE7B3010E68E00E054EA /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		32A1DE7D3010E68E00E054EA /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		B9D0E1F2A3B4567890CDEF12 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
-		D2E3F4A5B6C748990AE1F2D3 /* InfoPlist.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = InfoPlist.xcstrings; sourceTree = "<group>"; };
-		F4A5B6C7D8E94A9B0CF3A4B5 /* InfoPlist.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = InfoPlist.xcstrings; sourceTree = "<group>"; };
 		32E5A21A3010F48500D73941 /* CourseWidgetExtension.entitlements */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.entitlements; path = CourseWidgetExtension.entitlements; sourceTree = "<group>"; };
 		331C807B294A618700263BE5 /* RunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunnerTests.swift; sourceTree = "<group>"; };
 		331C8081294A63A400263BE5 /* RunnerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RunnerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -375,7 +371,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */,
-				C1D2E3F4A5B6478899D0E1F2 /* InfoPlist.xcstrings in Resources */,
 				3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */,
 				97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */,
 				97C146FC1CF9000F007C117D /* Main.storyboard in Resources */,

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -129,9 +129,7 @@ import WidgetKit
         sharedDefaults.set(colorStyle, forKey: "widget_color_style")
         sharedDefaults.set(density, forKey: "widget_density")
 
-        if #available(iOS 14.0, *) {
-            WidgetCenter.shared.reloadAllTimelines()
-        }
+        WidgetCenter.shared.reloadAllTimelines()
 
         result(nil)
     }

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -79,7 +79,7 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver {
   }
 
   Future<void> _updateWidget() async {
-    if (!kIsWeb && Platform.isAndroid) {
+    if (!kIsWeb && (Platform.isAndroid || Platform.isIOS || Platform.isMacOS)) {
       try {
         await getIt<WidgetUpdateService>().updateWidgetData();
       } catch (e) {


### PR DESCRIPTION
## 问题

iOS 桌面小组件在 app 从后台恢复前台时不会同步最新课表数据。

## 问题引入路线

| 时间 | 提交 | 作者 | 变更 | 影响 |
|------|------|------|------|------|
| 04-30 | `118395e` | jeanhua | feat: 桌面小组件 | 首次引入 Android 小组件，`_updateWidget()` 使用 `Platform.isAndroid` 守卫 — 此时正确 |
| 07-23 | `509f687` | nanguaguag | feat(ios): IOS端小组件实现 | 添加 iOS WidgetKit 实现、App Group 数据库共享、`WidgetUpdateService` 扩展为 iOS/macOS — **但遗漏了更新 `home_page.dart` 的平台守卫** |
| 07-23 | `03ff33a` | Visio Vanitas | fix(ios): align widget signing identifiers | 统一 App Group ID，未触及 HomePage |
| 08-15 | `90c95b0` | Visio Vanitas | feat(ios): add adaptive widget styles | 添加 `syncWidgetAppearance` 路径，iOS 可用 — 仍未更新 resume 守卫 |
| 08-15 | `99b1134` | Visio Vanitas | fix(ios): adopt UIScene lifecycle | 迁移至 `FlutterImplicitEngineDelegate` — 仍未更新 resume 守卫 |
| 08-15 | `5dbfe51` | Visio Vanitas | feat(ios): localize app and course widget | 添加本地化 — **同时向 Runner target 引入了重复的 InfoPlist.xcstrings file reference** |
| 08-16 | `5cc35e4` | Visio Vanitas | fix(ios): localize app and widget display names | **向 Runner target Resources build phase 添加了第二份 InfoPlist.xcstrings build file → Xcode 26 报错 "Cannot have multiple InfoPlist.xcstrings"** |
| 08-16 | `ecb7bae` | Liu Xinyu | fix(ios): 无课表数据时小组件不再显示示例课程 | 添加带 `hasNoScheduleData` 的新版 `lockScreenEmptyStateTitle` — **但未删除旧版，导致 Swift 编译报 Invalid redeclaration** |

### 根因分析

`509f687` 是问题的源头：它完整实现了 iOS 小组件的数据通道（共享 SQLite → WidgetKit extension 读取 → `updateWidget` MethodChannel → `reloadAllTimelines`），但没有将 `home_page.dart` 中 app resume 触发的 `_updateWidget()` 从 Android-only 扩展为跨平台。

后续所有 iOS 小组件相关提交都没有修正这个遗漏，因为它们各自关注的是独立功能（样式/本地化/UIScene 迁移等），而 `onCoursesChanged` 回调和设置同步路径在 iOS 上工作正常，掩盖了 resume 路径缺失的问题。

### iOS 小组件同步触发点（修复前 → 修复后）

| 触发点 | Android | iOS (修复前) | iOS (修复后) |
|--------|---------|------------|------------|
| 课程数据变更 (`onCoursesChanged`) | ✅ | ✅ | ✅ |
| App 恢复前台 (`didChangeAppLifecycleState`) | ✅ | ❌ | ✅ |
| 「课程结束后显示明天」开关 | ✅ | ✅ | ✅ |
| 小组件外观设置 | N/A | ✅ | ✅ |
| 应用启动初始化 | ✅ | ✅ | ✅ |

## 修复内容

### 1. `lib/pages/home_page.dart` — 核心修复
`Platform.isAndroid` → `Platform.isAndroid || Platform.isIOS || Platform.isMacOS`

### 2. `ios/Runner/AppDelegate.swift` — 清理
移除 `syncWidgetAppearance` 中冗余的 `#available(iOS 14.0, *)` 检查（iOS 最低版本已为 15，`updateWidget` 和 `syncWidgetShowTomorrow` 中同类检查已在 `7eb2e4b` 中移除）

### 3. `ios/Runner.xcodeproj/project.pbxproj` — 编译修复
移除 Runner target 重复的 InfoPlist.xcstrings build file 和悬空的 PBXFileReference（`5cc35e4` 引入）

### 4. `ios/CourseWidget/WidgetExtension.swift` — 编译修复
移除 `lockScreenEmptyStateTitle` 重复的计算属性（`ecb7bae` 引入）

## Test plan

- [x] `flutter test test/widget_update_service_test.dart` ✅
- [x] `flutter test test/add_widget_picker_test.dart` ✅
- [x] iOS 真机编译安装验证

🤖 Generated with [Claude Code](https://claude.com/claude-code)