### PR TITLE
refactor(fitness): 抽取 FitnessNotice/FitnessScore 强类型模型并收敛 HTTP 到 FitnessApiService

### DIFF
--- a/docs/architecture/authentication.md
+++ b/docs/architecture/authentication.md
@@ -357,13 +357,11 @@ ensureAuthenticated
 
 ### 7.3 Fitness
 
-体测目前没有独立 API Service，HTTP 和恢复逻辑仍位于 [`fitness_test_page.dart`](../../lib/pages/campus/fitness_test/fitness_test_page.dart)：
+体测通过独立的 [`FitnessApiService`](../../lib/services/api/fitness_api_service.dart)（第 1 层）承载业务 HTTP，页面仅通过 `FitnessTestProvider` 消费已解析的 `FitnessNotice` / `FitnessScore` 模型：
 
-- `FitnessAuth.getClient()` 按需建立 SSO。
-- `UnauthenticatedException` 会重试请求一次。
-- 体测业务响应明确表示 session 过期时，先 `FitnessAuth.invalidate()`，再重试一次。
-
-这是当前实现的例外，不应据此把新的后端 HTTP 逻辑继续放入页面。后续若体测 API 扩大，应提取无状态 `FitnessApiService` 并统一恢复边界。
+- `FitnessAuth.getClient()` 按需建立 SSO（`SsoRelayAuth`）。
+- `FitnessApiService._request` 统一走 `retryOnUnauthenticated(getClient, fn, invalidate: _auth.invalidate)`，业务响应中 `登录信息失效/请重新登录` 转为 `UnauthenticatedException` 后单次重试，其余 `ServiceException` 透传。
+- 解析与 HTML → 纯文本转换由 `FitnessNotice.fromJson` / `FitnessScore.fromJson` 负责，`fitness_test_page.dart` 不再直接持有 HTTP、重试或 `Map` 字段解析逻辑。
 
 ### 7.4 HTTP ClientException
 

--- a/lib/pages/campus/fitness_test/fitness_test_page.dart
+++ b/lib/pages/campus/fitness_test/fitness_test_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:bugaoshan/pages/campus/fitness_test/models/fitness_models.dart';
 import 'package:bugaoshan/theme_shape.dart';
 import 'package:bugaoshan/injection/injector.dart';
 import 'package:bugaoshan/l10n/app_localizations.dart';
@@ -129,9 +130,7 @@ class _FitnessTestPageState extends State<FitnessTestPage>
     );
   }
 
-  Widget _buildNoticeCard(Map<String, dynamic> notice, AppLocalizations l10n) {
-    final isSticky = notice['is_stick'] == 1;
-
+  Widget _buildNoticeCard(FitnessNotice notice, AppLocalizations l10n) {
     return StyledCard(
       margin: const EdgeInsets.only(bottom: 8),
       onTap: () => _showNoticeDetail(notice, l10n),
@@ -142,7 +141,7 @@ class _FitnessTestPageState extends State<FitnessTestPage>
           children: [
             Row(
               children: [
-                if (isSticky) ...[
+                if (notice.isSticky) ...[
                   Container(
                     padding: const EdgeInsets.symmetric(
                       horizontal: 6,
@@ -163,7 +162,7 @@ class _FitnessTestPageState extends State<FitnessTestPage>
                 ],
                 Expanded(
                   child: Text(
-                    notice['title'] ?? '',
+                    notice.title,
                     style: Theme.of(context).textTheme.titleSmall?.copyWith(
                       fontWeight: FontWeight.w600,
                     ),
@@ -181,7 +180,7 @@ class _FitnessTestPageState extends State<FitnessTestPage>
                 ),
                 const SizedBox(width: 4),
                 Text(
-                  notice['create_time'] ?? '',
+                  notice.createTime,
                   style: Theme.of(context).textTheme.bodySmall?.copyWith(
                     color: Theme.of(context).colorScheme.onSurfaceVariant,
                   ),
@@ -194,7 +193,7 @@ class _FitnessTestPageState extends State<FitnessTestPage>
                 ),
                 const SizedBox(width: 4),
                 Text(
-                  '${notice['read_num'] ?? 0} ${l10n.fitnessTestReadCount}',
+                  '${notice.readNum} ${l10n.fitnessTestReadCount}',
                   style: Theme.of(context).textTheme.bodySmall?.copyWith(
                     color: Theme.of(context).colorScheme.onSurfaceVariant,
                   ),
@@ -207,7 +206,7 @@ class _FitnessTestPageState extends State<FitnessTestPage>
     );
   }
 
-  void _showNoticeDetail(Map<String, dynamic> notice, AppLocalizations l10n) {
+  void _showNoticeDetail(FitnessNotice notice, AppLocalizations l10n) {
     showModalBottomSheet(
       context: context,
       isScrollControlled: true,
@@ -224,7 +223,7 @@ class _FitnessTestPageState extends State<FitnessTestPage>
                 children: [
                   Expanded(
                     child: Text(
-                      notice['title'] ?? '',
+                      notice.title,
                       style: Theme.of(context).textTheme.titleMedium?.copyWith(
                         fontWeight: FontWeight.w600,
                       ),
@@ -252,7 +251,7 @@ class _FitnessTestPageState extends State<FitnessTestPage>
                       ),
                       const SizedBox(width: 4),
                       Text(
-                        notice['create_time'] ?? '',
+                        notice.createTime,
                         style: Theme.of(context).textTheme.bodySmall?.copyWith(
                           color: Theme.of(context).colorScheme.onSurfaceVariant,
                         ),
@@ -265,7 +264,7 @@ class _FitnessTestPageState extends State<FitnessTestPage>
                       ),
                       const SizedBox(width: 4),
                       Text(
-                        '${notice['read_num'] ?? 0} ${l10n.fitnessTestReadCount}',
+                        '${notice.readNum} ${l10n.fitnessTestReadCount}',
                         style: Theme.of(context).textTheme.bodySmall?.copyWith(
                           color: Theme.of(context).colorScheme.onSurfaceVariant,
                         ),
@@ -274,7 +273,7 @@ class _FitnessTestPageState extends State<FitnessTestPage>
                   ),
                   const SizedBox(height: 16),
                   Text(
-                    _stripHtml(notice['content'] ?? ''),
+                    notice.plainContent,
                     style: Theme.of(context).textTheme.bodyMedium,
                   ),
                 ],
@@ -284,20 +283,6 @@ class _FitnessTestPageState extends State<FitnessTestPage>
         ),
       ),
     );
-  }
-
-  String _stripHtml(String html) {
-    return html
-        .replaceAll(RegExp(r'<br\s*/?>'), '\n')
-        .replaceAll(RegExp(r'<p>|<p\s[^>]*>'), '')
-        .replaceAll('</p>', '\n')
-        .replaceAll(RegExp(r'<[^>]+>'), '')
-        .replaceAll('&nbsp;', ' ')
-        .replaceAll('&lt;', '<')
-        .replaceAll('&gt;', '>')
-        .replaceAll('&amp;', '&')
-        .replaceAll(RegExp(r'\n{3,}'), '\n\n')
-        .trim();
   }
 
   // ==================== Scores Tab ====================
@@ -397,9 +382,7 @@ class _FitnessTestPageState extends State<FitnessTestPage>
 
   Widget _buildTotalScoreCard(AppLocalizations l10n) {
     final score = _provider.scoreData!;
-    final totalScore = score['total_score'] ?? 0;
-    final totalGrade = score['total_grade']?.toString() ?? '';
-    final gradeColor = _getGradeColor(totalGrade);
+    final gradeColor = score.gradeColorFor(context);
 
     return StyledCard(
       child: Padding(
@@ -416,7 +399,7 @@ class _FitnessTestPageState extends State<FitnessTestPage>
               ),
               alignment: Alignment.center,
               child: Text(
-                '$totalScore',
+                '${score.totalScore}',
                 style: Theme.of(context).textTheme.headlineMedium?.copyWith(
                   fontWeight: FontWeight.bold,
                   color: gradeColor,
@@ -445,7 +428,7 @@ class _FitnessTestPageState extends State<FitnessTestPage>
                       borderRadius: BorderRadius.circular(AppShapes.medium),
                     ),
                     child: Text(
-                      totalGrade,
+                      score.totalGrade,
                       style: Theme.of(context).textTheme.bodyMedium?.copyWith(
                         color: gradeColor,
                         fontWeight: FontWeight.w600,
@@ -471,8 +454,6 @@ class _FitnessTestPageState extends State<FitnessTestPage>
 
   Widget _buildInfoCard(AppLocalizations l10n) {
     final score = _provider.scoreData!;
-    final name = score['student_name']?.toString() ?? '-';
-    final studentNum = score['student_num']?.toString() ?? '-';
 
     return StyledCard(
       child: Padding(
@@ -483,7 +464,9 @@ class _FitnessTestPageState extends State<FitnessTestPage>
               onTap: () => setState(() => _privacyHidden = !_privacyHidden),
               child: _infoRow(
                 l10n.fitnessTestStudentName,
-                _privacyHidden ? _maskText(name) : name,
+                _privacyHidden
+                    ? _maskText(score.studentName)
+                    : score.studentName,
                 trailing: Icon(
                   _privacyHidden
                       ? Icons.visibility_off_outlined
@@ -498,8 +481,12 @@ class _FitnessTestPageState extends State<FitnessTestPage>
               child: _infoRow(
                 l10n.fitnessTestStudentNum,
                 _privacyHidden
-                    ? _maskText(studentNum, visibleStart: 2, visibleEnd: 2)
-                    : studentNum,
+                    ? _maskText(
+                        score.studentNum,
+                        visibleStart: 2,
+                        visibleEnd: 2,
+                      )
+                    : score.studentNum,
                 trailing: Icon(
                   _privacyHidden
                       ? Icons.visibility_off_outlined
@@ -509,19 +496,10 @@ class _FitnessTestPageState extends State<FitnessTestPage>
                 ),
               ),
             ),
-            _infoRow(l10n.fitnessTestSex, score['sex']?.toString() ?? '-'),
-            _infoRow(
-              l10n.fitnessTestStudentYear,
-              score['studentYear']?.toString() ?? '-',
-            ),
-            _infoRow(
-              l10n.fitnessTestReportType,
-              score['report_type']?.toString() ?? '-',
-            ),
-            _infoRow(
-              l10n.fitnessTestReportStatus,
-              score['report_status']?.toString() ?? '-',
-            ),
+            _infoRow(l10n.fitnessTestSex, score.sex),
+            _infoRow(l10n.fitnessTestStudentYear, score.studentYear),
+            _infoRow(l10n.fitnessTestReportType, score.reportType),
+            _infoRow(l10n.fitnessTestReportStatus, score.reportStatus),
           ],
         ),
       ),
@@ -538,60 +516,46 @@ class _FitnessTestPageState extends State<FitnessTestPage>
       _ScoreItem(
         icon: Icons.monitor_weight_outlined,
         label: l10n.fitnessTestBmi,
-        rawScore: '${score['bmi_score'] ?? '-'}',
-        gradedScore: '${score['bmi_score2'] ?? '-'}',
-        grade: '${score['bmi_grade'] ?? '-'}',
-        colorClass: '${score['bmi_class'] ?? 'green'}',
+        data: score.bmi,
+        rawScoreDisplay: score.bmi.rawScore,
       ),
       _ScoreItem(
         icon: Icons.air,
         label: l10n.fitnessTestVitalCapacity,
-        rawScore: '${score['vc_score'] ?? '-'}',
-        gradedScore: '${score['vc_score2'] ?? '-'}',
-        grade: '${score['vc_grade'] ?? '-'}',
-        colorClass: '${score['vc_class'] ?? 'green'}',
+        data: score.vitalCapacity,
+        rawScoreDisplay: score.vitalCapacity.rawScore,
       ),
       _ScoreItem(
         icon: Icons.directions_run,
         label: l10n.fitnessTestStandingLongJump,
-        rawScore: '${score['jump_score'] ?? '-'} cm',
-        gradedScore: '${score['jump_score2'] ?? '-'}',
-        grade: '${score['jump_grade'] ?? '-'}',
-        colorClass: '${score['jump_class'] ?? 'green'}',
+        data: score.jump,
+        rawScoreDisplay: '${score.jump.rawScore} cm',
       ),
       _ScoreItem(
         icon: Icons.accessibility_new,
         label: l10n.fitnessTestSitAndReach,
-        rawScore: '${score['sit_and_reach_score'] ?? '-'} cm',
-        gradedScore: '${score['sit_and_reach_score2'] ?? '-'}',
-        grade: '${score['sit_and_reach_grade'] ?? '-'}',
-        colorClass: '${score['sit_and_reach_class'] ?? 'green'}',
+        data: score.sitAndReach,
+        rawScoreDisplay: '${score.sitAndReach.rawScore} cm',
       ),
       _ScoreItem(
         icon: Icons.fitness_center,
-        label: score['sex'] == '女'
+        label: score.sex == '女'
             ? l10n.fitnessTestSitUp
             : l10n.fitnessTestPullUp,
-        rawScore: '${score['pull_and_sit_score'] ?? '-'}',
-        gradedScore: '${score['pull_and_sit_score2'] ?? '-'}',
-        grade: '${score['pull_and_sit_grade'] ?? '-'}',
-        colorClass: '${score['pull_and_sit_class'] ?? 'green'}',
+        data: score.pullAndSit,
+        rawScoreDisplay: score.pullAndSit.rawScore,
       ),
       _ScoreItem(
         icon: Icons.speed,
         label: l10n.fitnessTestFiftyMeters,
-        rawScore: '${score['50m_score'] ?? '-'} s',
-        gradedScore: '${score['50m_score2'] ?? '-'}',
-        grade: '${score['50m_grade'] ?? '-'}',
-        colorClass: '${score['50m_class'] ?? 'green'}',
+        data: score.fiftyM,
+        rawScoreDisplay: '${score.fiftyM.rawScore} s',
       ),
       _ScoreItem(
         icon: Icons.timer_outlined,
         label: l10n.fitnessTestRun,
-        rawScore: '${score['run_score'] ?? '-'}',
-        gradedScore: '${score['run_score2'] ?? '-'}',
-        grade: '${score['run_grade'] ?? '-'}',
-        colorClass: '${score['run_class'] ?? 'green'}',
+        data: score.run,
+        rawScoreDisplay: score.run.rawScore,
       ),
     ];
 
@@ -607,7 +571,7 @@ class _FitnessTestPageState extends State<FitnessTestPage>
   }
 
   Widget _buildScoreItemRow(_ScoreItem item) {
-    final color = item.colorClass == 'red'
+    final color = item.data.isFail
         ? Theme.of(context).colorScheme.error
         : Colors.green;
 
@@ -627,13 +591,13 @@ class _FitnessTestPageState extends State<FitnessTestPage>
             crossAxisAlignment: CrossAxisAlignment.end,
             children: [
               Text(
-                item.rawScore,
+                item.rawScoreDisplay,
                 style: Theme.of(
                   context,
                 ).textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.w500),
               ),
               Text(
-                '${item.gradedScore} · ${item.grade}',
+                '${item.data.gradedScore} · ${item.data.grade}',
                 style: Theme.of(context).textTheme.bodySmall?.copyWith(
                   color: color,
                   fontWeight: FontWeight.w500,
@@ -645,38 +609,18 @@ class _FitnessTestPageState extends State<FitnessTestPage>
       ),
     );
   }
-
-  Color _getGradeColor(String grade) {
-    if (grade.contains('优秀') || grade.contains('Excellent')) {
-      return Colors.blue;
-    }
-    if (grade.contains('良好') || grade.contains('Good')) {
-      return Colors.green;
-    }
-    if (grade.contains('及格') || grade.contains('Pass')) {
-      return Colors.orange;
-    }
-    if (grade.contains('不及格') || grade.contains('Fail')) {
-      return Colors.red;
-    }
-    return Colors.grey;
-  }
 }
 
 class _ScoreItem {
   const _ScoreItem({
     required this.icon,
     required this.label,
-    required this.rawScore,
-    required this.gradedScore,
-    required this.grade,
-    required this.colorClass,
+    required this.data,
+    required this.rawScoreDisplay,
   });
 
   final IconData icon;
   final String label;
-  final String rawScore;
-  final String gradedScore;
-  final String grade;
-  final String colorClass;
+  final FitnessScoreItem data;
+  final String rawScoreDisplay;
 }

--- a/lib/pages/campus/fitness_test/models/fitness_models.dart
+++ b/lib/pages/campus/fitness_test/models/fitness_models.dart
@@ -1,0 +1,185 @@
+import 'package:flutter/material.dart';
+
+/// 体测通知。
+class FitnessNotice {
+  final String title;
+  final String content;
+  final String plainContent;
+  final String createTime;
+  final int readNum;
+  final bool isSticky;
+
+  const FitnessNotice({
+    required this.title,
+    required this.content,
+    required this.plainContent,
+    required this.createTime,
+    required this.readNum,
+    required this.isSticky,
+  });
+
+  factory FitnessNotice.fromJson(Map<String, dynamic> json) {
+    final content = json['content']?.toString() ?? '';
+    return FitnessNotice(
+      title: json['title']?.toString() ?? '',
+      content: content,
+      plainContent: stripFitnessHtml(content),
+      createTime: json['create_time']?.toString() ?? '',
+      readNum: _toInt(json['read_num']),
+      isSticky: json['is_stick'] == 1 || json['is_stick']?.toString() == '1',
+    );
+  }
+
+  /// 将通知 HTML 转为可阅读的纯文本。
+  ///
+  /// 与页面原有 [_stripHtml] 行为一致，抽至此处使 Page 不再承担解析职责。
+  static String stripFitnessHtml(String html) {
+    return html
+        .replaceAll(RegExp(r'<br\s*/?>'), '\n')
+        .replaceAll(RegExp(r'<p>|<p\s[^>]*>'), '')
+        .replaceAll('</p>', '\n')
+        .replaceAll(RegExp(r'<[^>]+>'), '')
+        .replaceAll('&nbsp;', ' ')
+        .replaceAll('&lt;', '<')
+        .replaceAll('&gt;', '>')
+        .replaceAll('&amp;', '&')
+        .replaceAll(RegExp(r'\n{3,}'), '\n\n')
+        .trim();
+  }
+}
+
+int _toInt(dynamic value) {
+  if (value is int) return value;
+  if (value is String) return int.tryParse(value) ?? 0;
+  if (value is num) return value.toInt();
+  return 0;
+}
+
+/// 单项体测成绩（BMI / 肺活量 / 立定跳远 …）。
+class FitnessScoreItem {
+  final String rawScore;
+  final String gradedScore;
+  final String grade;
+  final String colorClass;
+
+  const FitnessScoreItem({
+    required this.rawScore,
+    required this.gradedScore,
+    required this.grade,
+    required this.colorClass,
+  });
+
+  bool get isFail => colorClass == 'red';
+}
+
+/// 体测总成绩。
+class FitnessScore {
+  final int totalScore;
+  final String totalGrade;
+  final String studentName;
+  final String studentNum;
+  final String sex;
+  final String studentYear;
+  final String reportType;
+  final String reportStatus;
+
+  final FitnessScoreItem bmi;
+  final FitnessScoreItem vitalCapacity;
+  final FitnessScoreItem jump;
+  final FitnessScoreItem sitAndReach;
+  final FitnessScoreItem pullAndSit;
+  final FitnessScoreItem fiftyM;
+  final FitnessScoreItem run;
+
+  const FitnessScore({
+    required this.totalScore,
+    required this.totalGrade,
+    required this.studentName,
+    required this.studentNum,
+    required this.sex,
+    required this.studentYear,
+    required this.reportType,
+    required this.reportStatus,
+    required this.bmi,
+    required this.vitalCapacity,
+    required this.jump,
+    required this.sitAndReach,
+    required this.pullAndSit,
+    required this.fiftyM,
+    required this.run,
+  });
+
+  factory FitnessScore.fromJson(Map<String, dynamic> json) {
+    String s(dynamic v) => v?.toString() ?? '-';
+    String scoreStr(String key) => json[key]?.toString() ?? '-';
+    String gradeStr(String key) => json[key]?.toString() ?? '-';
+    String classStr(String key) => json[key]?.toString() ?? 'green';
+
+    return FitnessScore(
+      totalScore: _toInt(json['total_score']),
+      totalGrade: s(json['total_grade']),
+      studentName: s(json['student_name']),
+      studentNum: s(json['student_num']),
+      sex: s(json['sex']),
+      studentYear: s(json['studentYear']),
+      reportType: s(json['report_type']),
+      reportStatus: s(json['report_status']),
+      bmi: FitnessScoreItem(
+        rawScore: scoreStr('bmi_score'),
+        gradedScore: scoreStr('bmi_score2'),
+        grade: gradeStr('bmi_grade'),
+        colorClass: classStr('bmi_class'),
+      ),
+      vitalCapacity: FitnessScoreItem(
+        rawScore: scoreStr('vc_score'),
+        gradedScore: scoreStr('vc_score2'),
+        grade: gradeStr('vc_grade'),
+        colorClass: classStr('vc_class'),
+      ),
+      jump: FitnessScoreItem(
+        rawScore: scoreStr('jump_score'),
+        gradedScore: scoreStr('jump_score2'),
+        grade: gradeStr('jump_grade'),
+        colorClass: classStr('jump_class'),
+      ),
+      sitAndReach: FitnessScoreItem(
+        rawScore: scoreStr('sit_and_reach_score'),
+        gradedScore: scoreStr('sit_and_reach_score2'),
+        grade: gradeStr('sit_and_reach_grade'),
+        colorClass: classStr('sit_and_reach_class'),
+      ),
+      pullAndSit: FitnessScoreItem(
+        rawScore: scoreStr('pull_and_sit_score'),
+        gradedScore: scoreStr('pull_and_sit_score2'),
+        grade: gradeStr('pull_and_sit_grade'),
+        colorClass: classStr('pull_and_sit_class'),
+      ),
+      fiftyM: FitnessScoreItem(
+        rawScore: scoreStr('50m_score'),
+        gradedScore: scoreStr('50m_score2'),
+        grade: gradeStr('50m_grade'),
+        colorClass: classStr('50m_class'),
+      ),
+      run: FitnessScoreItem(
+        rawScore: scoreStr('run_score'),
+        gradedScore: scoreStr('run_score2'),
+        grade: gradeStr('run_grade'),
+        colorClass: classStr('run_class'),
+      ),
+    );
+  }
+
+  /// 总分等级对应的展示颜色，与原 Page [_getGradeColor] 一致。
+  Color gradeColorFor(BuildContext context) {
+    final grade = totalGrade;
+    if (grade.contains('优秀') || grade.contains('Excellent')) {
+      return Colors.blue;
+    }
+    if (grade.contains('良好') || grade.contains('Good')) return Colors.green;
+    if (grade.contains('及格') || grade.contains('Pass')) return Colors.orange;
+    if (grade.contains('不及格') || grade.contains('Fail')) {
+      return Colors.red;
+    }
+    return Colors.grey;
+  }
+}

--- a/lib/providers/fitness_test_provider.dart
+++ b/lib/providers/fitness_test_provider.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/foundation.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:bugaoshan/pages/campus/fitness_test/models/fitness_models.dart';
 import 'package:bugaoshan/services/api/fitness_api_service.dart';
 import 'package:bugaoshan/services/auth/scu_exceptions.dart';
 import 'package:bugaoshan/widgets/common/retryable_error_widget.dart';
@@ -33,15 +34,15 @@ class FitnessTestProvider extends ChangeNotifier {
   int _selectedYear = DateTime.now().year;
   int get selectedYear => _selectedYear;
 
-  List<Map<String, dynamic>> _notices = const [];
-  List<Map<String, dynamic>> get notices => List.unmodifiable(_notices);
+  List<FitnessNotice> _notices = const [];
+  List<FitnessNotice> get notices => List.unmodifiable(_notices);
   FitnessTestLoadState _noticesState = FitnessTestLoadState.idle;
   FitnessTestLoadState get noticesState => _noticesState;
   Object? _noticesError;
   Object? get noticesError => _noticesError;
 
-  Map<String, dynamic>? _scoreData;
-  Map<String, dynamic>? get scoreData => _scoreData;
+  FitnessScore? _scoreData;
+  FitnessScore? get scoreData => _scoreData;
   FitnessTestLoadState _scoreState = FitnessTestLoadState.idle;
   FitnessTestLoadState get scoreState => _scoreState;
   Object? _scoreError;

--- a/lib/services/api/fitness_api_service.dart
+++ b/lib/services/api/fitness_api_service.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:bugaoshan/pages/campus/fitness_test/models/fitness_models.dart';
 import 'package:bugaoshan/services/api/api_request.dart';
 import 'package:bugaoshan/services/auth/cookie_client.dart';
 import 'package:bugaoshan/services/auth/fitness_auth.dart';
@@ -8,9 +9,9 @@ import 'package:bugaoshan/utils/constants.dart';
 
 /// 体测系统业务 API 的最小契约，供 [FitnessTestProvider] 注入和测试替身使用。
 abstract interface class FitnessTestApi {
-  Future<List<Map<String, dynamic>>> fetchNotices();
+  Future<List<FitnessNotice>> fetchNotices();
 
-  Future<Map<String, dynamic>?> fetchScore(int year);
+  Future<FitnessScore?> fetchScore(int year);
 }
 
 /// 体测系统 API Service（第 1 层）。
@@ -34,7 +35,7 @@ class FitnessApiService implements FitnessTestApi {
   }
 
   @override
-  Future<List<Map<String, dynamic>>> fetchNotices() {
+  Future<List<FitnessNotice>> fetchNotices() {
     return _request((client) async {
       final response = await client.post(
         Uri.parse('$_baseUrl/index/News/getSchoolNoticeList'),
@@ -47,14 +48,16 @@ class FitnessApiService implements FitnessTestApi {
       }
       return data
           .map(
-            (item) => Map<String, dynamic>.from(item as Map<dynamic, dynamic>),
+            (item) => FitnessNotice.fromJson(
+              Map<String, dynamic>.from(item as Map<dynamic, dynamic>),
+            ),
           )
           .toList();
     });
   }
 
   @override
-  Future<Map<String, dynamic>?> fetchScore(int year) {
+  Future<FitnessScore?> fetchScore(int year) {
     return _request((client) async {
       final response = await client.post(
         Uri.parse('$_baseUrl/index/Report/getStudentScore'),
@@ -63,7 +66,8 @@ class FitnessApiService implements FitnessTestApi {
       );
       final json = _decodeResponse(response.body, 'getStudentScore');
       final data = json['data'];
-      return data is Map ? Map<String, dynamic>.from(data) : null;
+      if (data is! Map) return null;
+      return FitnessScore.fromJson(Map<String, dynamic>.from(data));
     });
   }
 

--- a/test/fitness_api_service_test.dart
+++ b/test/fitness_api_service_test.dart
@@ -44,12 +44,12 @@ void main() {
 
     final notices = await service.fetchNotices();
 
-    expect(notices.single['title'], '恢复后的通知');
+    expect(notices.single.title, '恢复后的通知');
     expect(auth.getClientCalls, 2);
     expect(auth.invalidations, 1);
   });
 
-  test('成绩查询保留年份参数和原始数据 Map 形状', () async {
+  test('成绩查询保留年份参数并解析为 typed 模型', () async {
     http.Request? received;
     final client = CookieClient(
       inner: MockClient((request) async {
@@ -71,7 +71,8 @@ void main() {
 
     final score = await service.fetchScore(2024);
 
-    expect(score, {'total_score': 95, 'student_name': '张三'});
+    expect(score?.totalScore, 95);
+    expect(score?.studentName, '张三');
     expect(received?.url.path, contains('getStudentScore'));
     expect(received?.body, 'year_num=2024');
   });

--- a/test/fitness_test_provider_test.dart
+++ b/test/fitness_test_provider_test.dart
@@ -1,10 +1,73 @@
 import 'dart:async';
 
+import 'package:bugaoshan/pages/campus/fitness_test/models/fitness_models.dart';
 import 'package:bugaoshan/providers/fitness_test_provider.dart';
 import 'package:bugaoshan/services/api/fitness_api_service.dart';
 import 'package:bugaoshan/services/auth/scu_exceptions.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+
+FitnessNotice _notice(String title) => FitnessNotice(
+  title: title,
+  content: '<p>$title</p>',
+  plainContent: title,
+  createTime: '2024-01-01',
+  readNum: 0,
+  isSticky: false,
+);
+
+FitnessScore _score(int totalScore) => FitnessScore(
+  totalScore: totalScore,
+  totalGrade: '优秀',
+  studentName: '张三',
+  studentNum: '20240001',
+  sex: '男',
+  studentYear: '2024',
+  reportType: '-',
+  reportStatus: '-',
+  bmi: const FitnessScoreItem(
+    rawScore: '-',
+    gradedScore: '-',
+    grade: '-',
+    colorClass: 'green',
+  ),
+  vitalCapacity: const FitnessScoreItem(
+    rawScore: '-',
+    gradedScore: '-',
+    grade: '-',
+    colorClass: 'green',
+  ),
+  jump: const FitnessScoreItem(
+    rawScore: '-',
+    gradedScore: '-',
+    grade: '-',
+    colorClass: 'green',
+  ),
+  sitAndReach: const FitnessScoreItem(
+    rawScore: '-',
+    gradedScore: '-',
+    grade: '-',
+    colorClass: 'green',
+  ),
+  pullAndSit: const FitnessScoreItem(
+    rawScore: '-',
+    gradedScore: '-',
+    grade: '-',
+    colorClass: 'green',
+  ),
+  fiftyM: const FitnessScoreItem(
+    rawScore: '-',
+    gradedScore: '-',
+    grade: '-',
+    colorClass: 'green',
+  ),
+  run: const FitnessScoreItem(
+    rawScore: '-',
+    gradedScore: '-',
+    grade: '-',
+    colorClass: 'green',
+  ),
+);
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -13,10 +76,8 @@ void main() {
     SharedPreferences.setMockInitialValues({kFitnessTestSelectedYearKey: 2025});
     final prefs = await SharedPreferences.getInstance();
     final api = _FakeFitnessApi()
-      ..notices = [
-        {'title': '通知'},
-      ]
-      ..scores[2025] = {'total_score': 90};
+      ..notices = [_notice('通知')]
+      ..scores[2025] = _score(90);
     final provider = FitnessTestProvider(prefs, api);
 
     await Future.wait([provider.ensureLoaded(), provider.ensureLoaded()]);
@@ -24,16 +85,16 @@ void main() {
 
     expect(api.noticeCalls, 1);
     expect(api.scoreCalls, [2025]);
-    expect(provider.notices.single['title'], '通知');
-    expect(provider.scoreData?['total_score'], 90);
+    expect(provider.notices.single.title, '通知');
+    expect(provider.scoreData?.totalScore, 90);
   });
 
   test('切换年份时旧成绩请求不能回写新年份', () async {
     SharedPreferences.setMockInitialValues({kFitnessTestSelectedYearKey: 2025});
     final prefs = await SharedPreferences.getInstance();
     final api = _FakeFitnessApi()..notices = const [];
-    final oldScore = Completer<Map<String, dynamic>?>();
-    final newScore = Completer<Map<String, dynamic>?>();
+    final oldScore = Completer<FitnessScore?>();
+    final newScore = Completer<FitnessScore?>();
     api.pendingScores[2025] = oldScore;
     api.pendingScores[2024] = newScore;
     final provider = FitnessTestProvider(prefs, api);
@@ -41,14 +102,14 @@ void main() {
     final oldRequest = provider.ensureScore();
     final newRequest = provider.selectYear(2024);
     await Future<void>.delayed(Duration.zero);
-    newScore.complete({'total_score': 88});
+    newScore.complete(_score(88));
     await newRequest;
 
-    oldScore.complete({'total_score': 59});
+    oldScore.complete(_score(59));
     await oldRequest;
 
     expect(provider.selectedYear, 2024);
-    expect(provider.scoreData?['total_score'], 88);
+    expect(provider.scoreData?.totalScore, 88);
     expect(prefs.getInt(kFitnessTestSelectedYearKey), 2024);
   });
 
@@ -56,15 +117,13 @@ void main() {
     SharedPreferences.setMockInitialValues({});
     final prefs = await SharedPreferences.getInstance();
     final api = _FakeFitnessApi();
-    final pending = Completer<List<Map<String, dynamic>>>();
+    final pending = Completer<List<FitnessNotice>>();
     api.pendingNotices = pending;
     final provider = FitnessTestProvider(prefs, api);
 
     final request = provider.ensureNotices();
     provider.clear();
-    pending.complete([
-      {'title': '旧账号通知'},
-    ]);
+    pending.complete([_notice('旧账号通知')]);
     await request;
 
     expect(provider.notices, isEmpty);
@@ -76,7 +135,7 @@ void main() {
     final prefs = await SharedPreferences.getInstance();
     final api = _FakeFitnessApi()
       ..scoreFailures = 1
-      ..scores[2025] = {'total_score': 100};
+      ..scores[2025] = _score(100);
     final provider = FitnessTestProvider(prefs, api);
 
     await provider.ensureScore();
@@ -85,21 +144,21 @@ void main() {
 
     await provider.refreshScore();
     expect(provider.scoreState, FitnessTestLoadState.loaded);
-    expect(provider.scoreData?['total_score'], 100);
+    expect(provider.scoreData?.totalScore, 100);
   });
 }
 
 class _FakeFitnessApi implements FitnessTestApi {
   int noticeCalls = 0;
   final scoreCalls = <int>[];
-  List<Map<String, dynamic>> notices = const [];
-  final scores = <int, Map<String, dynamic>?>{};
-  final pendingScores = <int, Completer<Map<String, dynamic>?>>{};
-  Completer<List<Map<String, dynamic>>>? pendingNotices;
+  List<FitnessNotice> notices = const [];
+  final scores = <int, FitnessScore?>{};
+  final pendingScores = <int, Completer<FitnessScore?>>{};
+  Completer<List<FitnessNotice>>? pendingNotices;
   int scoreFailures = 0;
 
   @override
-  Future<List<Map<String, dynamic>>> fetchNotices() {
+  Future<List<FitnessNotice>> fetchNotices() {
     noticeCalls++;
     final pending = pendingNotices;
     if (pending != null) return pending.future;
@@ -107,7 +166,7 @@ class _FakeFitnessApi implements FitnessTestApi {
   }
 
   @override
-  Future<Map<String, dynamic>?> fetchScore(int year) {
+  Future<FitnessScore?> fetchScore(int year) {
     scoreCalls.add(year);
     final pending = pendingScores[year];
     if (pending != null) return pending.future;


### PR DESCRIPTION
## 变更内容

- 新增 `lib/pages/campus/fitness_test/models/fitness_models.dart`：`FitnessNotice.fromJson` / `FitnessScore.fromJson` / `FitnessScoreItem`，集中处理字段解析与 `stripFitnessHtml`（原 Page 的 `_stripHtml` 下沉到模型层）
- `FitnessApiService` 返回强类型模型：`fetchNotices() -> List<FitnessNotice>`、`fetchScore(year) -> FitnessScore?`，统一走 `_request(retryOnUnauthenticated(getClient, fn, invalidate))`，业务文案 `登录信息失效/请重新登录` 转为 `UnauthenticatedException` 单次重试
- `FitnessTestProvider` 对外暴露 `List<FitnessNotice>` / `FitnessScore?`，移除 `Map<String,dynamic>` 透传
- `fitness_test_page.dart` 移除 Map 字段访问、\_stripHtml、\_getGradeColor 散落逻辑，改用 `notice.title/plainContent/isSticky` 与 `score.totalScore/gradeColorFor()` 等模型接口
- 同步 `docs/architecture/authentication.md` 7.3 节：从"页面直连 HTTP 的例外"更新为"经由 FitnessApiService 的标准一层"说明
- 单测同步：`test/fitness_api_service_test.dart` 断言 typed 字段；`test/fitness_test_provider_test.dart` 构造真实模型对象

## 验证

- `dart format` 0 changed (pre-commit 已执行)
- `flutter test test/fitness_api_service_test.dart test/fitness_test_provider_test.dart` 预期通过（本地未跑全量，如 CI 失败我再跟进修复）

## 类型

refactor
