### PR TITLE
fix: 启动失败页在 release 包也显示错误详情

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -75,11 +75,10 @@ class _StartupErrorApp extends StatelessWidget {
                     textScaler: TextScaler.linear(1.5),
                   ),
                   const SizedBox(height: 16),
-                  if (kDebugMode)
-                    SelectableText(
-                      errorMessage ?? '',
-                      textAlign: TextAlign.start,
-                    ),
+                  SelectableText(
+                    errorMessage ?? '',
+                    textAlign: TextAlign.start,
+                  ),
                   const SizedBox(height: 16),
                   ElevatedButton(
                     onPressed: () async {


### PR DESCRIPTION
## 变更内容

- 移除 `lib/main.dart` 中 `_StartupErrorApp` 对 `errorMessage` 的 `kDebugMode` 限制
- `release` 包启动失败时也能看到具体异常信息，便于排查线上问题

## 关联
无

## 测试
- [x] `dart format` 通过（pre-commit）
- [x] 手动验证启动失败页展示