### PR TITLE
fix: 支持多份培养方案修读情况数据（方案选择页→详情页 + 滑动切换）

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -485,6 +485,7 @@
     "planCompletionCredits": "Credits",
     "planCompletionCreditsUnit": "cr",
     "planCompletionCourses": "Courses",
+    "planCompletionPlanFallback": "Training Program",
     "planCompletionRateLimited": "Too many requests, please try again later",
     "ccylTitle": "Second Classroom",
     "ccylDesc": "Browse activities, participate, make reservations",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -2437,6 +2437,12 @@ abstract class AppLocalizations {
   /// **'Courses'**
   String get planCompletionCourses;
 
+  /// No description provided for @planCompletionPlanFallback.
+  ///
+  /// In en, this message translates to:
+  /// **'Training Program'**
+  String get planCompletionPlanFallback;
+
   /// No description provided for @planCompletionRateLimited.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1263,6 +1263,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get planCompletionCourses => 'Courses';
 
   @override
+  String get planCompletionPlanFallback => 'Training Program';
+
+  @override
   String get planCompletionRateLimited =>
       'Too many requests, please try again later';
 

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -1223,6 +1223,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get planCompletionCourses => '课程';
 
   @override
+  String get planCompletionPlanFallback => '培养方案';
+
+  @override
   String get planCompletionRateLimited => '请勿频繁刷新，请稍后再试';
 
   @override

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -465,6 +465,7 @@
     "planCompletionCredits": "学分",
     "planCompletionCreditsUnit": "学分",
     "planCompletionCourses": "课程",
+    "planCompletionPlanFallback": "培养方案",
     "planCompletionRateLimited": "请勿频繁刷新，请稍后再试",
     "ccylTitle": "第二课堂",
     "ccylDesc": "查看活动、参与活动、预约活动",

--- a/lib/pages/campus/plan_completion/models/plan_completion.dart
+++ b/lib/pages/campus/plan_completion/models/plan_completion.dart
@@ -1,3 +1,21 @@
+/// 一份培养方案的修读数据。
+///
+/// 教务系统对有多份培养方案(如主修+辅修、多学位)的用户,`/planCompletion/index`
+/// 返回的是方案选择页(不含 zNodes 数据),真正的树数据在
+/// `/getPyfaIndex/<方案ID>` 详情页;单方案用户则直接由 index 页返回数据。
+/// [id] 为空串表示数据直接来自 index 页(单方案场景)。
+class PlanCompletionPlan {
+  final String id;
+  final String name;
+  final List<PlanCompletionNode> nodes;
+
+  const PlanCompletionPlan({
+    required this.id,
+    required this.name,
+    required this.nodes,
+  });
+}
+
 class PlanCompletionNode {
   final String id;
   final String pId;

--- a/lib/pages/campus/plan_completion/plan_completion_page.dart
+++ b/lib/pages/campus/plan_completion/plan_completion_page.dart
@@ -183,6 +183,10 @@ class _PlanCompletionPageState extends State<PlanCompletionPage> {
         ),
         Expanded(
           child: PageView.builder(
+            // 方案数量变化（如刷新后多方案缩容为单方案）时强制重建 PageView，
+            // 使视口回到第 0 页——否则内部页面位置仍停在旧索引，
+            // 而 Provider 的 currentPlanIndex 已被重置为 0，两者失配导致空白。
+            key: ValueKey(plans.length),
             itemCount: plans.length,
             // 跟随内容而非跳页动画，左右滑动切换方案。
             onPageChanged: (index) => _provider.selectPlan(index),

--- a/lib/pages/campus/plan_completion/plan_completion_page.dart
+++ b/lib/pages/campus/plan_completion/plan_completion_page.dart
@@ -121,7 +121,84 @@ class _PlanCompletionPageState extends State<PlanCompletionPage> {
 
   Widget _buildTree(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
-    final rootNodes = _provider.rootNodes;
+    final plans = _provider.plans;
+
+    if (plans.isEmpty) {
+      return Center(
+        child: Text(
+          l10n.planCompletionNoData,
+          style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+            color: Theme.of(context).colorScheme.onSurfaceVariant,
+          ),
+        ),
+      );
+    }
+
+    // 顶部方案名指示栏 + PageView 承载各方案内容：
+    // - 单方案：只有一页，无法左右滑动（滑动不反应）；
+    // - 多方案：左右滑动切换，顶部指示栏跟随更新。
+    return Column(
+      children: [
+        ListenableBuilder(
+          listenable: _provider,
+          builder: (context, _) {
+            final index = _provider.currentPlanIndex;
+            final name = plans[index].name;
+            final showCount = plans.length > 1;
+            return Padding(
+              padding: const EdgeInsets.fromLTRB(16, 12, 16, 0),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  // 多方案时才提示可滑动，单方案不误导。
+                  if (showCount) ...[
+                    Icon(
+                      Icons.swipe,
+                      size: 16,
+                      color: Theme.of(context).colorScheme.onSurfaceVariant,
+                    ),
+                    const SizedBox(width: 6),
+                  ],
+                  Flexible(
+                    child: Text(
+                      name.isNotEmpty ? name : l10n.planCompletionPlanFallback,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: Theme.of(context).textTheme.titleSmall,
+                    ),
+                  ),
+                  if (showCount) ...[
+                    const SizedBox(width: 6),
+                    Text(
+                      '${index + 1}/${plans.length}',
+                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                        color: Theme.of(context).colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                  ],
+                ],
+              ),
+            );
+          },
+        ),
+        Expanded(
+          child: PageView.builder(
+            itemCount: plans.length,
+            // 跟随内容而非跳页动画，左右滑动切换方案。
+            onPageChanged: (index) => _provider.selectPlan(index),
+            itemBuilder: (context, index) =>
+                _buildPlanPage(context, plans[index]),
+          ),
+        ),
+      ],
+    );
+  }
+
+  /// 渲染单份方案的内容（摘要卡 + 根模块树）。
+  Widget _buildPlanPage(BuildContext context, PlanCompletionPlan plan) {
+    final l10n = AppLocalizations.of(context)!;
+    final nodes = plan.nodes;
+    final rootNodes = nodes.where((n) => n.pId == '-1').toList();
 
     if (rootNodes.isEmpty) {
       return Center(
@@ -135,7 +212,7 @@ class _PlanCompletionPageState extends State<PlanCompletionPage> {
     }
 
     // Build summary card
-    final stats = computeSummaryStats(_provider.nodes);
+    final stats = computeSummaryStats(nodes);
 
     return ListView(
       padding: const EdgeInsets.all(16),
@@ -148,7 +225,7 @@ class _PlanCompletionPageState extends State<PlanCompletionPage> {
           stats.moduleCount,
         ),
         const SizedBox(height: 16),
-        ...rootNodes.map((node) => _buildCategoryTile(context, node, 0)),
+        ...rootNodes.map((node) => _buildCategoryTile(context, nodes, node, 0)),
       ],
     );
   }
@@ -204,11 +281,12 @@ class _PlanCompletionPageState extends State<PlanCompletionPage> {
 
   Widget _buildCategoryTile(
     BuildContext context,
+    List<PlanCompletionNode> nodes,
     PlanCompletionNode node,
     int depth,
   ) {
     final l10n = AppLocalizations.of(context)!;
-    final children = _provider.getChildren(node.id);
+    final children = nodes.where((n) => n.pId == node.id).toList();
 
     // 无子节点的模块（如美育、创新创业教育、跨学科专业教育）以列表项形式展示，
     // 与教务处方案层级保持一致。
@@ -273,7 +351,9 @@ class _PlanCompletionPageState extends State<PlanCompletionPage> {
           ],
         ),
         children: children
-            .map((child) => _buildCategoryTile(context, child, depth + 1))
+            .map(
+              (child) => _buildCategoryTile(context, nodes, child, depth + 1),
+            )
             .toList(),
       ),
     );

--- a/lib/providers/plan_completion_provider.dart
+++ b/lib/providers/plan_completion_provider.dart
@@ -21,9 +21,7 @@ class PlanCompletionProvider extends ChangeNotifier {
     if (cached != null) {
       try {
         final list = jsonDecode(cached) as List<dynamic>;
-        _nodes = list
-            .map((e) => PlanCompletionNode.fromJson(e as Map<String, dynamic>))
-            .toList();
+        _plans = _decodeCached(list);
         _state = PlanCompletionLoadState.loaded;
       } catch (e) {
         debugPrint('PlanCompletionProvider cache decode error: $e');
@@ -31,19 +29,37 @@ class PlanCompletionProvider extends ChangeNotifier {
     }
   }
 
-  List<PlanCompletionNode> _nodes = [];
+  List<PlanCompletionPlan> _plans = [];
+  int _currentPlanIndex = 0;
   PlanCompletionLoadState _state = PlanCompletionLoadState.idle;
   LoadErrorType? _error;
 
-  List<PlanCompletionNode> get nodes => _nodes;
+  /// 全部培养方案（单方案时为 1 个元素；无方案时为空列表）。
+  List<PlanCompletionPlan> get plans => _plans;
+
+  /// 当前方案索引（多方案滑动切换后更新，用于页面方案名指示）。
+  int get currentPlanIndex => _currentPlanIndex;
+
+  /// 当前方案的节点列表（无方案时为空）。
+  List<PlanCompletionNode> get nodes =>
+      _plans.isEmpty ? const [] : _plans[_currentPlanIndex].nodes;
+
   PlanCompletionLoadState get state => _state;
   LoadErrorType? get error => _error;
 
   List<PlanCompletionNode> get rootNodes =>
-      _nodes.where((n) => n.pId == '-1').toList();
+      nodes.where((n) => n.pId == '-1').toList();
 
   List<PlanCompletionNode> getChildren(String parentId) =>
-      _nodes.where((n) => n.pId == parentId).toList();
+      nodes.where((n) => n.pId == parentId).toList();
+
+  /// 切换当前方案（越界忽略）。
+  void selectPlan(int index) {
+    if (index < 0 || index >= _plans.length) return;
+    if (index == _currentPlanIndex) return;
+    _currentPlanIndex = index;
+    _safeNotify();
+  }
 
   void _safeNotify() {
     WidgetsBinding.instance.addPostFrameCallback((_) => notifyListeners());
@@ -61,16 +77,18 @@ class PlanCompletionProvider extends ChangeNotifier {
     _safeNotify();
 
     try {
-      final nodes = await _zhjwApi.fetchPlanCompletion();
+      final plans = await _zhjwApi.fetchPlanCompletion();
       if (generation != _requestGeneration) return;
-      _nodes = nodes;
+      _plans = plans;
+      // 若已滑到最后一个方案且刷新后方案变少，回退到 0，避免越界。
+      if (_currentPlanIndex >= _plans.length) _currentPlanIndex = 0;
       _state = PlanCompletionLoadState.loaded;
       _error = null;
       await _saveToCache();
       if (generation != _requestGeneration) return;
     } on RateLimitedException catch (_) {
       if (generation != _requestGeneration) return;
-      if (_nodes.isNotEmpty) {
+      if (_plans.isNotEmpty) {
         _state = PlanCompletionLoadState.loaded;
       } else {
         _state = PlanCompletionLoadState.error;
@@ -78,7 +96,7 @@ class PlanCompletionProvider extends ChangeNotifier {
       _error = LoadErrorType.rateLimited;
     } on ServiceException catch (_) {
       if (generation != _requestGeneration) return;
-      if (_nodes.isNotEmpty) {
+      if (_plans.isNotEmpty) {
         _state = PlanCompletionLoadState.loaded;
         _error = campusNetworkErrorType(LoadErrorType.loadFailed);
       } else {
@@ -87,7 +105,7 @@ class PlanCompletionProvider extends ChangeNotifier {
       }
     } on UnauthenticatedException {
       if (generation != _requestGeneration) return;
-      if (_nodes.isNotEmpty) {
+      if (_plans.isNotEmpty) {
         _state = PlanCompletionLoadState.loaded;
       } else {
         _state = PlanCompletionLoadState.error;
@@ -95,7 +113,7 @@ class PlanCompletionProvider extends ChangeNotifier {
       _error = LoadErrorType.sessionExpired;
     } catch (_) {
       if (generation != _requestGeneration) return;
-      if (_nodes.isNotEmpty) {
+      if (_plans.isNotEmpty) {
         _state = PlanCompletionLoadState.loaded;
       } else {
         _state = PlanCompletionLoadState.error;
@@ -106,8 +124,46 @@ class PlanCompletionProvider extends ChangeNotifier {
   }
 
   Future<void> _saveToCache() async {
-    final json = jsonEncode(_nodes.map((n) => _nodeToJson(n)).toList());
+    final json = jsonEncode(
+      _plans
+          .map(
+            (p) => {
+              'id': p.id,
+              'name': p.name,
+              'nodes': p.nodes.map((n) => _nodeToJson(n)).toList(),
+            },
+          )
+          .toList(),
+    );
     await _prefs.setString(_keyPlanCompletion, json);
+  }
+
+  /// 缓存解析：优先按新格式（元素含 id/name/nodes 字段）。
+  /// 兼容旧格式（元素本身是节点对象）——将整个列表视为单方案，
+  /// 避免旧缓存全量失效。
+  List<PlanCompletionPlan> _decodeCached(List<dynamic> list) {
+    if (list.isEmpty) return const [];
+    final isNewFormat = list.every(
+      (e) => e is Map<String, dynamic> && e['nodes'] is List,
+    );
+    if (isNewFormat) {
+      return list.map((e) {
+        final map = e as Map<String, dynamic>;
+        final nodes = (map['nodes'] as List)
+            .map((n) => PlanCompletionNode.fromJson(n as Map<String, dynamic>))
+            .toList();
+        return PlanCompletionPlan(
+          id: map['id'] as String? ?? '',
+          name: map['name'] as String? ?? '',
+          nodes: nodes,
+        );
+      }).toList();
+    }
+    // 旧缓存：直接是节点数组，包装为单个方案
+    final nodes = list
+        .map((e) => PlanCompletionNode.fromJson(e as Map<String, dynamic>))
+        .toList();
+    return [PlanCompletionPlan(id: '', name: '', nodes: nodes)];
   }
 
   Map<String, dynamic> _nodeToJson(PlanCompletionNode node) => {
@@ -123,7 +179,8 @@ class PlanCompletionProvider extends ChangeNotifier {
 
   Future<void> clearCache() async {
     _requestGeneration++;
-    _nodes = [];
+    _plans = [];
+    _currentPlanIndex = 0;
     _state = PlanCompletionLoadState.idle;
     _error = null;
     _safeNotify();

--- a/lib/services/api/zhjw_api_service.dart
+++ b/lib/services/api/zhjw_api_service.dart
@@ -463,10 +463,23 @@ class ZhjwApiService {
   //  计划完成度（从 PlanCompletionProvider 迁移 HTTP + 解析逻辑）
   // ═══════════════════════════════════════════════════════════════════
 
-  /// 获取计划完成度数据
+  /// 获取计划完成度数据，返回多份培养方案（每份含树节点列表）。
   ///
-  /// 返回解析后的节点列表。如果遇到频率限制，抛出 [RateLimitedException]。
-  Future<List<PlanCompletionNode>> fetchPlanCompletion() async {
+  /// 教务系统行为：
+  /// - 单方案用户：`/planCompletion/index` 直接返回含 zNodes 的数据页；
+  /// - 多方案用户（主修+辅修等）：`/index` 是方案选择页，不含数据，
+  ///   真正的树数据在 `/getPyfaIndex/<方案ID>` 详情页。
+  ///
+  /// 解析策略：
+  /// 1. 请求 `/index`；若页面含非空 zNodes（有根节点）→ 单方案，直接解析；
+  /// 2. 否则从页面提取 `getPyfaIndex/<ID>` 链接逐个请求详情页；
+  /// 3. 两者皆无且 zNodes 明确为空数组 → 代表"账号无方案"，返回空列表；
+  /// 4. 页面结构异常（无法匹配 zNodes 也无链接）→ 按会话过期处理，
+  ///    解析失败（正则不匹配/JSON 损坏）→ 抛 [ServiceException] 可诊断，
+  ///    不再静默返回空数组。
+  ///
+  /// 如果遇到频率限制，抛出 [RateLimitedException]。
+  Future<List<PlanCompletionPlan>> fetchPlanCompletion() async {
     return _request((client) async {
       final resp = await client.get(
         Uri.parse('$kZhjwBase/student/integratedQuery/planCompletion/index'),
@@ -483,13 +496,152 @@ class ZhjwApiService {
         throw const RateLimitedException();
       }
 
-      // Session 过期检测（正常响应也是 HTML，需要区分）
-      if (body.startsWith('<') && !body.contains('zNodes')) {
-        throw const UnauthenticatedException();
+      // 1) 尝试直接解析 zNodes（单方案场景）。
+      //    仅当正则匹配到 zNodes 时才解析；匹配不上返回 null，不抛错，
+      //    以便继续走链接提取分支（多方案选择页可能不含 zNodes）。
+      final directNodes = _tryParseZNodes(body);
+      if (directNodes != null && directNodes.isNotEmpty) {
+        return [
+          PlanCompletionPlan(
+            id: '',
+            name: _extractPlanName(body),
+            nodes: directNodes,
+          ),
+        ];
       }
 
-      return _parseZNodes(body);
+      // 2) 多方案场景：从入口页提取 getPyfaIndex 链接，逐个请求详情页。
+      final planLinks = _extractPlanLinks(body);
+      if (planLinks.isNotEmpty) {
+        final plans = <PlanCompletionPlan>[];
+        for (final link in planLinks) {
+          final detailResp = await client.get(
+            Uri.parse('$kZhjwBase${link.path}'),
+            headers: {
+              'Accept': 'text/html,*/*',
+              'Referer':
+                  '$kZhjwBase/student/integratedQuery/planCompletion/index',
+              'User-Agent': kDefaultUserAgent,
+            },
+          );
+          final detailBody = detailResp.body;
+          if (detailBody.contains('请勿频繁刷新')) {
+            throw const RateLimitedException();
+          }
+          // 详情页必须包含数据；解析失败/结构异常在此抛错，不再静默返回空。
+          final nodes = _parseZNodes(detailBody);
+          plans.add(
+            PlanCompletionPlan(id: link.id, name: link.name, nodes: nodes),
+          );
+        }
+        return plans;
+      }
+
+      // 3) 无数据也无链接：zNodes 明确存在但为空数组 → 账号无方案。
+      if (directNodes != null) {
+        return const [];
+      }
+
+      // 4) 页面结构异常（既无 zNodes 也无 getPyfaIndex 链接）：
+      //    正常数据页/选择页均不满足，保守按会话过期处理。
+      throw const UnauthenticatedException();
     });
+  }
+
+  /// 尝试从 HTML 提取 zNodes 数组。
+  ///
+  /// 正则未匹配时返回 null（不代表"无方案"，可能是选择页），
+  /// 匹配成功但 JSON/字段解析失败时抛 [ServiceException]（可诊断错误）。
+  List<PlanCompletionNode>? _tryParseZNodes(String html) {
+    final match = RegExp(
+      r'var\s+zNodes\s*=\s*(\[.*?\]);',
+      dotAll: true,
+    ).firstMatch(html);
+    if (match == null) return null;
+    return _decodeZNodes(match.group(1)!);
+  }
+
+  /// 解析 zNodes 数组；正则未匹配或解析失败均抛 [ServiceException]。
+  List<PlanCompletionNode> _parseZNodes(String html) {
+    final match = RegExp(
+      r'var\s+zNodes\s*=\s*(\[.*?\]);',
+      dotAll: true,
+    ).firstMatch(html);
+    if (match == null) {
+      throw const ServiceException('方案修读数据格式异常：未找到 zNodes 数据');
+    }
+    return _decodeZNodes(match.group(1)!);
+  }
+
+  List<PlanCompletionNode> _decodeZNodes(String jsonStr) {
+    try {
+      final List<dynamic> list = jsonDecode(jsonStr);
+      return list
+          .map((e) => PlanCompletionNode.fromJson(e as Map<String, dynamic>))
+          .toList();
+    } catch (e) {
+      throw ServiceException('方案修读数据解析失败：$e');
+    }
+  }
+
+  /// 提取方案名（单方案场景，来自 index 页 echarts 雷达图 legend）。
+  ///
+  /// 页面 JS 形如 `legend: { data: ['某某培养方案'], ... }`。
+  /// 提取不到时返回空串，由 UI 兜底显示通用名称。
+  String _extractPlanName(String html) {
+    final match = RegExp(
+      r"""data:\s*\[\s*'([^']+)'\s*\]""",
+      dotAll: true,
+    ).firstMatch(html);
+    if (match == null) return '';
+    final name = match.group(1)!.trim();
+    return name.length > 60 ? name.substring(0, 60) : name;
+  }
+
+  /// 从方案选择页提取 `getPyfaIndex/<方案ID>` 链接。
+  ///
+  /// 返回去重后的链接列表；链接文本作为方案名，无文本时用
+  /// `方案<ID>` 兜底，保证多方案用户至少能看到可区分的名称。
+  List<_PlanLink> _extractPlanLinks(String html) {
+    final links = <_PlanLink>[];
+    final seen = <String>{};
+    // 匹配 <a href="...getPyfaIndex/123...">名称</a> 形态
+    final anchorRe = RegExp(
+      r"""<a[^>]*href=["'][^"']*getPyfaIndex/(\d+)[^"']*["'][^>]*>(.*?)</a>""",
+      dotAll: true,
+    );
+    for (final m in anchorRe.allMatches(html)) {
+      final id = m.group(1)!;
+      if (!seen.add(id)) continue;
+      final rawName = m
+          .group(2)!
+          .replaceAll(RegExp(r'<[^>]+>'), '')
+          .replaceAll('&nbsp;', ' ')
+          .trim();
+      links.add(
+        _PlanLink(
+          id: id,
+          name: rawName.isNotEmpty ? rawName : '方案$id',
+          path: '/student/integratedQuery/planCompletion/getPyfaIndex/$id',
+        ),
+      );
+    }
+    // 兜底：非 <a> 形态（如 JS 字符串、onclick）也提取 ID
+    if (links.isEmpty) {
+      final bareRe = RegExp(r'getPyfaIndex/(\d+)');
+      for (final m in bareRe.allMatches(html)) {
+        final id = m.group(1)!;
+        if (!seen.add(id)) continue;
+        links.add(
+          _PlanLink(
+            id: id,
+            name: '方案$id',
+            path: '/student/integratedQuery/planCompletion/getPyfaIndex/$id',
+          ),
+        );
+      }
+    }
+    return links;
   }
 
   // ═══════════════════════════════════════════════════════════════════
@@ -829,22 +981,13 @@ class ZhjwApiService {
         )
         .toList();
   }
+}
 
-  List<PlanCompletionNode> _parseZNodes(String html) {
-    final match = RegExp(
-      r'var\s+zNodes\s*=\s*(\[.*?\]);',
-      dotAll: true,
-    ).firstMatch(html);
-    if (match == null) return [];
+/// 方案选择页中解析出的培养方案入口链接。
+class _PlanLink {
+  final String id;
+  final String name;
+  final String path;
 
-    final jsonStr = match.group(1)!;
-    try {
-      final List<dynamic> list = jsonDecode(jsonStr);
-      return list
-          .map((e) => PlanCompletionNode.fromJson(e as Map<String, dynamic>))
-          .toList();
-    } catch (_) {
-      return [];
-    }
-  }
+  const _PlanLink({required this.id, required this.name, required this.path});
 }

--- a/lib/services/api/zhjw_api_service.dart
+++ b/lib/services/api/zhjw_api_service.dart
@@ -22,6 +22,10 @@ class ZhjwApiService {
   final ZhjwAuth _auth;
   ZhjwApiService(this._auth);
 
+  /// 多方案详情页请求之间的间隔，避免一次打开页面连续请求
+  /// 多个 getPyfaIndex 详情页被教务系统限流（"请勿频繁刷新"）。
+  static Duration planDetailRequestGap = const Duration(milliseconds: 600);
+
   Future<T> _request<T>(Future<T> Function(CookieClient client) fn) {
     return retryOnUnauthenticated(
       _auth.getClient,
@@ -515,6 +519,11 @@ class ZhjwApiService {
       if (planLinks.isNotEmpty) {
         final plans = <PlanCompletionPlan>[];
         for (final link in planLinks) {
+          // 教务系统对连续请求有限流（"请勿频繁刷新"），详情页之间
+          // 加短暂间隔，避免打开页面时一次触发 N+1 个请求被限流。
+          if (plans.isNotEmpty) {
+            await Future<void>.delayed(planDetailRequestGap);
+          }
           final detailResp = await client.get(
             Uri.parse('$kZhjwBase${link.path}'),
             headers: {
@@ -525,6 +534,8 @@ class ZhjwApiService {
             },
           );
           final detailBody = detailResp.body;
+          // 详情页可能返回登录页（会话过期）或限流提示
+          _checkSessionExpiry(detailBody, detailResp.statusCode);
           if (detailBody.contains('请勿频繁刷新')) {
             throw const RateLimitedException();
           }
@@ -543,8 +554,13 @@ class ZhjwApiService {
       }
 
       // 4) 页面结构异常（既无 zNodes 也无 getPyfaIndex 链接）：
-      //    正常数据页/选择页均不满足，保守按会话过期处理。
-      throw const UnauthenticatedException();
+      //    - 页面是登录页/会话过期页 → 抛 UnauthenticatedException 走重认证；
+      //    - 其它无法识别的 HTML（如错误页）→ 抛 ServiceException，
+      //      避免触发重认证风暴（每次都会重新 SSO，进一步触发限流）。
+      if (body.toLowerCase().contains('login')) {
+        throw const UnauthenticatedException();
+      }
+      throw const ServiceException('方案修读数据格式异常：页面无法解析');
     });
   }
 
@@ -598,47 +614,80 @@ class ZhjwApiService {
     return name.length > 60 ? name.substring(0, 60) : name;
   }
 
-  /// 从方案选择页提取 `getPyfaIndex/<方案ID>` 链接。
+  /// 从方案选择页提取 `getPyfaIndex/<方案ID>` 入口。
   ///
-  /// 返回去重后的链接列表；链接文本作为方案名，无文本时用
-  /// `方案<ID>` 兜底，保证多方案用户至少能看到可区分的名称。
+  /// 教务系统多方案选择页的入口形态（真机抓包确认）：
+  /// - 按钮：`<button ... title="方案名(方案ID)" onclick="getPyfaIndex('ID');...">`，
+  ///   onclick 中方案 ID 可能带 `&#39;` HTML 实体；
+  /// - 链接：`<a href="...getPyfaIndex/123...">方案名</a>`（兜底兼容）。
+  ///
+  /// 返回去重后的入口列表；方案名取自 title 属性或链接文本，无名称时
+  /// 用 `方案<ID>` 兜底，保证多方案用户至少能看到可区分的名称。
   List<_PlanLink> _extractPlanLinks(String html) {
     final links = <_PlanLink>[];
     final seen = <String>{};
-    // 匹配 <a href="...getPyfaIndex/123...">名称</a> 形态
-    final anchorRe = RegExp(
-      r"""<a[^>]*href=["'][^"']*getPyfaIndex/(\d+)[^"']*["'][^>]*>(.*?)</a>""",
-      dotAll: true,
-    );
-    for (final m in anchorRe.allMatches(html)) {
-      final id = m.group(1)!;
-      if (!seen.add(id)) continue;
-      final rawName = m
-          .group(2)!
-          .replaceAll(RegExp(r'<[^>]+>'), '')
-          .replaceAll('&nbsp;', ' ')
-          .trim();
+
+    void addPlan(String id, String name) {
+      if (!seen.add(id)) return;
+      final trimmed = name.trim();
       links.add(
         _PlanLink(
           id: id,
-          name: rawName.isNotEmpty ? rawName : '方案$id',
+          name: trimmed.isNotEmpty ? trimmed : '方案$id',
           path: '/student/integratedQuery/planCompletion/getPyfaIndex/$id',
         ),
       );
     }
-    // 兜底：非 <a> 形态（如 JS 字符串、onclick）也提取 ID
+
+    // 1) 按钮形态：onclick="getPyfaIndex('ID');" + title="方案名(ID)"
+    //    真机抓包确认 onclick 里的引号是 &#39; HTML 实体,需显式处理。
+    final buttonRe = RegExp(
+      r'''onclick=["'][^"']*getPyfaIndex\(\s*(?:&#39;|&quot;|['"])?(\d+)(?:&#39;|&quot;|['"])?\s*\)''',
+      dotAll: true,
+    );
+    for (final m in buttonRe.allMatches(html)) {
+      final id = m.group(1)!;
+      // 按钮的 title 属性含方案名（如 广播电视编导培养方案(10692)）
+      final tagStart = html.lastIndexOf('<button', m.start);
+      final tagEnd = html.indexOf('>', m.start);
+      if (tagStart >= 0 && tagEnd > tagStart) {
+        final tag = html.substring(tagStart, tagEnd);
+        final titleMatch = RegExp(
+          r'''title=["']([^"']*)["']''',
+        ).firstMatch(tag);
+        if (titleMatch != null) {
+          // title 形如 方案名(10692)，去掉尾部 (ID)
+          var name = titleMatch.group(1)!.trim();
+          name = name.replaceFirst(RegExp(r'\(\d+\)\s*$'), '').trim();
+          addPlan(id, name);
+          continue;
+        }
+      }
+      addPlan(id, '方案$id');
+    }
+
+    // 2) 链接形态：<a href="...getPyfaIndex/123...">名称</a>
+    if (links.isEmpty) {
+      final anchorRe = RegExp(
+        r"""<a[^>]*href=["'][^"']*getPyfaIndex/(\d+)[^"']*["'][^>]*>(.*?)</a>""",
+        dotAll: true,
+      );
+      for (final m in anchorRe.allMatches(html)) {
+        final id = m.group(1)!;
+        final rawName = m
+            .group(2)!
+            .replaceAll(RegExp(r'<[^>]+>'), '')
+            .replaceAll('&nbsp;', ' ')
+            .trim();
+        addPlan(id, rawName);
+      }
+    }
+
+    // 3) 兜底：非按钮/链接形态（如 JS 字符串）也提取 ID
     if (links.isEmpty) {
       final bareRe = RegExp(r'getPyfaIndex/(\d+)');
       for (final m in bareRe.allMatches(html)) {
-        final id = m.group(1)!;
-        if (!seen.add(id)) continue;
-        links.add(
-          _PlanLink(
-            id: id,
-            name: '方案$id',
-            path: '/student/integratedQuery/planCompletion/getPyfaIndex/$id',
-          ),
-        );
+        addPlan(m.group(1)!, '方案${m.group(1)}');
       }
     }
     return links;

--- a/lib/services/api/zhjw_api_service.dart
+++ b/lib/services/api/zhjw_api_service.dart
@@ -500,6 +500,12 @@ class ZhjwApiService {
         throw const RateLimitedException();
       }
 
+      // 会话过期检测（302 / 空 body / HTML 登录页），与详情页一致：
+      // 过期时抛 UnauthenticatedException 交给 retryOnUnauthenticated 重认证，
+      // 而不是落入下方分支 4 抛 ServiceException（用户会看到"格式异常"
+      // 而非触发重新登录）。
+      _checkSessionExpiry(body, resp.statusCode);
+
       // 1) 尝试直接解析 zNodes（单方案场景）。
       //    仅当正则匹配到 zNodes 时才解析；匹配不上返回 null，不抛错，
       //    以便继续走链接提取分支（多方案选择页可能不含 zNodes）。

--- a/test/plan_completion_page_test.dart
+++ b/test/plan_completion_page_test.dart
@@ -1,0 +1,144 @@
+import 'dart:async';
+
+import 'package:bugaoshan/injection/injector.dart';
+import 'package:bugaoshan/l10n/app_localizations.dart';
+import 'package:bugaoshan/pages/campus/plan_completion/models/plan_completion.dart';
+import 'package:bugaoshan/pages/campus/plan_completion/plan_completion_page.dart';
+import 'package:bugaoshan/providers/plan_completion_provider.dart';
+import 'package:bugaoshan/providers/scu_auth_provider.dart';
+import 'package:bugaoshan/services/api/zhjw_api_service.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  setUp(() async {
+    await getIt.reset();
+  });
+
+  tearDown(() async {
+    await getIt.reset();
+  });
+
+  testWidgets('多方案：顶部显示方案名与计数，滑动切换方案内容', (tester) async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    final api = _ControllablePlanApi();
+    final provider = PlanCompletionProvider(prefs, api);
+
+    final future = provider.fetchPlanCompletion(forceRefresh: true);
+    api.completeWith([
+      PlanCompletionPlan(
+        id: '10101',
+        name: '主修培养方案',
+        nodes: [PlanCompletionNode.fromJson(_rootNodeJson('主修公共课'))],
+      ),
+      PlanCompletionPlan(
+        id: '10102',
+        name: '辅修培养方案',
+        nodes: [PlanCompletionNode.fromJson(_rootNodeJson('辅修公共课'))],
+      ),
+    ]);
+    await future;
+
+    getIt.registerSingleton<PlanCompletionProvider>(provider);
+    getIt.registerSingleton<ScuAuthProvider>(_FakeScuAuthProvider());
+
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: const PlanCompletionPage(),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // 顶部指示栏显示当前方案名与页码
+    expect(find.text('主修培养方案'), findsOneWidget);
+    expect(find.text('1/2'), findsOneWidget);
+    // 第一页内容
+    expect(find.text('主修公共课'), findsOneWidget);
+
+    // 左滑切换到第二个方案
+    await tester.fling(find.byType(PageView), const Offset(-400, 0), 1000);
+    await tester.pumpAndSettle();
+
+    expect(find.text('辅修培养方案'), findsOneWidget);
+    expect(find.text('2/2'), findsOneWidget);
+    expect(find.text('辅修公共课'), findsOneWidget);
+  });
+
+  testWidgets('单方案：显示方案名但不显示计数', (tester) async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    final api = _ControllablePlanApi();
+    final provider = PlanCompletionProvider(prefs, api);
+
+    final future = provider.fetchPlanCompletion(forceRefresh: true);
+    api.completeWith([
+      PlanCompletionPlan(
+        id: '',
+        name: '唯一培养方案',
+        nodes: [PlanCompletionNode.fromJson(_rootNodeJson('唯一公共课'))],
+      ),
+    ]);
+    await future;
+
+    getIt.registerSingleton<PlanCompletionProvider>(provider);
+    getIt.registerSingleton<ScuAuthProvider>(_FakeScuAuthProvider());
+
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: const PlanCompletionPage(),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('唯一培养方案'), findsOneWidget);
+    // 单方案不显示 1/1 计数
+    expect(find.text('1/1'), findsNothing);
+    expect(find.text('唯一公共课'), findsOneWidget);
+  });
+}
+
+Map<String, dynamic> _rootNodeJson(String name) => {
+  'id': 'root-1',
+  'pId': '-1',
+  'flagId': 'root-1',
+  'flagType': '001',
+  'name': name,
+  'sfwc': '否',
+  'yxxf': '0',
+  'zsxf': '1',
+};
+
+class _ControllablePlanApi implements ZhjwApiService {
+  final _completers = <Completer<List<PlanCompletionPlan>>>[];
+
+  @override
+  Future<List<PlanCompletionPlan>> fetchPlanCompletion() {
+    final completer = Completer<List<PlanCompletionPlan>>();
+    _completers.add(completer);
+    return completer.future;
+  }
+
+  void completeWith(List<PlanCompletionPlan> plans) {
+    _completers.single.complete(plans);
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _FakeScuAuthProvider extends ChangeNotifier implements ScuAuthProvider {
+  @override
+  bool get isLoggedIn => true;
+
+  @override
+  bool get isAutoLoggingIn => false;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}

--- a/test/plan_completion_provider_test.dart
+++ b/test/plan_completion_provider_test.dart
@@ -22,11 +22,16 @@ void main() {
       await provider.clearCache();
       final newRequest = provider.fetchPlanCompletion(forceRefresh: true);
 
-      api.requests[1].complete([_node('new-account')]);
+      api.requests[1].complete([
+        _plan('new', [_node('new-account')]),
+      ]);
       await newRequest;
       expect(provider.nodes.single.id, 'new-account');
+      expect(provider.plans.single.name, '方案new');
 
-      api.requests[0].complete([_node('old-account')]);
+      api.requests[0].complete([
+        _plan('old', [_node('old-account')]),
+      ]);
       await oldRequest;
 
       expect(provider.nodes.single.id, 'new-account');
@@ -37,6 +42,66 @@ void main() {
       );
     },
   );
+
+  test('multiple plans: selectPlan switches current plan nodes', () async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    final api = _ControllableZhjwApiService();
+    final provider = PlanCompletionProvider(prefs, api);
+
+    final request = provider.fetchPlanCompletion(forceRefresh: true);
+    api.requests.single.complete([
+      _plan('1', [_node('plan1-root')]),
+      _plan('2', [_node('plan2-root')]),
+    ]);
+    await request;
+
+    expect(provider.plans, hasLength(2));
+    expect(provider.currentPlanIndex, 0);
+    expect(provider.nodes.single.id, 'plan1-root');
+
+    provider.selectPlan(1);
+    expect(provider.currentPlanIndex, 1);
+    expect(provider.nodes.single.id, 'plan2-root');
+
+    // 越界索引被忽略
+    provider.selectPlan(5);
+    expect(provider.currentPlanIndex, 1);
+  });
+
+  test('refresh after plans shrink resets current index to 0', () async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    final api = _ControllableZhjwApiService();
+    final provider = PlanCompletionProvider(prefs, api);
+
+    var request = provider.fetchPlanCompletion(forceRefresh: true);
+    api.requests[0].complete([
+      _plan('1', [_node('plan1-root')]),
+      _plan('2', [_node('plan2-root')]),
+    ]);
+    await request;
+    provider.selectPlan(1);
+
+    request = provider.fetchPlanCompletion(forceRefresh: true);
+    api.requests[1].complete([
+      _plan('1', [_node('plan1-root')]),
+    ]);
+    await request;
+
+    expect(provider.plans, hasLength(1));
+    expect(provider.currentPlanIndex, 0);
+  });
+
+  test('cached empty plans list decodes as empty (no nodes)', () async {
+    SharedPreferences.setMockInitialValues({'plan_completion_nodes': '[]'});
+    final prefs = await SharedPreferences.getInstance();
+    final api = _ControllableZhjwApiService();
+    final provider = PlanCompletionProvider(prefs, api);
+    expect(provider.state, PlanCompletionLoadState.loaded);
+    expect(provider.plans, isEmpty);
+    expect(provider.nodes, isEmpty);
+  });
 
   test(
     'summary stats only count root-level modules (pId=-1) matching school hierarchy',
@@ -175,11 +240,11 @@ PlanCompletionNode _node(String id) => PlanCompletionNode.fromJson({
 });
 
 class _ControllableZhjwApiService implements ZhjwApiService {
-  final requests = <Completer<List<PlanCompletionNode>>>[];
+  final requests = <Completer<List<PlanCompletionPlan>>>[];
 
   @override
-  Future<List<PlanCompletionNode>> fetchPlanCompletion() {
-    final request = Completer<List<PlanCompletionNode>>();
+  Future<List<PlanCompletionPlan>> fetchPlanCompletion() {
+    final request = Completer<List<PlanCompletionPlan>>();
     requests.add(request);
     return request.future;
   }
@@ -187,3 +252,6 @@ class _ControllableZhjwApiService implements ZhjwApiService {
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
+
+PlanCompletionPlan _plan(String id, List<PlanCompletionNode> nodes) =>
+    PlanCompletionPlan(id: id, name: '方案$id', nodes: nodes);

--- a/test/zhjw_api_service_test.dart
+++ b/test/zhjw_api_service_test.dart
@@ -122,8 +122,35 @@ void main() {
     },
   );
 
+  test('fetchPlanCompletion: login page triggers re-auth path', () async {
+    final helper = _buildRoutingApi(
+      {
+        '/student/integratedQuery/planCompletion/index':
+            '<html><body><form action="/login">请登录</form></body></html>',
+      },
+      prefs,
+      logger,
+    );
+    addTearDown(helper.auth.dispose);
+
+    // 入口页含 login 特征 → _checkSessionExpiry 抛 UnauthenticatedException
+    // → retryOnUnauthenticated 触发重认证（SSO）。测试环境无真实 SSO，
+    // 重认证失败表现为 ServiceException('教务 SSO 登录失败')——
+    // 重点是与下方"格式异常"用例区分：会话过期走重认证而非格式错误提示。
+    await expectLater(
+      helper.api.fetchPlanCompletion(),
+      throwsA(
+        isA<ServiceException>().having(
+          (e) => e.message,
+          'message',
+          contains('SSO'),
+        ),
+      ),
+    );
+  });
+
   test('fetchPlanCompletion: malformed page without zNodes and links throws '
-      '(never silently returns empty)', () async {
+      'ServiceException (never silently returns empty)', () async {
     final helper = _buildRoutingApi(
       {
         '/student/integratedQuery/planCompletion/index':
@@ -135,12 +162,17 @@ void main() {
     addTearDown(helper.auth.dispose);
 
     // 核心诉求（issue #246）：解析失败必须抛可诊断错误，不能静默返回 []。
-    // 页面既无 zNodes 也无链接 → 被视为非业务页，抛 UnauthenticatedException
-    // 触发重认证；测试环境无真实 SSO，重认证失败表现为 ServiceException。
-    // 两者都属于 ScuException，这里只验证"不会静默返回空列表"。
+    // 页面既无 zNodes 也无链接、也不是登录页 → 抛 ServiceException('格式异常')，
+    // 由 Provider 展示可诊断错误，且不会误走重认证路径。
     await expectLater(
       helper.api.fetchPlanCompletion(),
-      throwsA(isA<ScuException>()),
+      throwsA(
+        isA<ServiceException>().having(
+          (e) => e.message,
+          'message',
+          contains('格式异常'),
+        ),
+      ),
     );
   });
 

--- a/test/zhjw_api_service_test.dart
+++ b/test/zhjw_api_service_test.dart
@@ -70,22 +70,24 @@ void main() {
     expect(plans.single.nodes.single.name, '公共基础课');
   });
 
-  test('fetchPlanCompletion: multiple plans follow getPyfaIndex links', () async {
+  test('fetchPlanCompletion: multiple plans follow getPyfaIndex buttons '
+      '(real HTML form from 教务处选择页)', () async {
     final helper = _buildRoutingApi(
       {
         '/student/integratedQuery/planCompletion/index': '''
-          <html>
-            <ul class="plan-list">
-              <li><a href="/student/integratedQuery/planCompletion/getPyfaIndex/10101">2023级-软件工程-主修</a></li>
-              <li><a href="/student/integratedQuery/planCompletion/getPyfaIndex/10102">2023级-软件工程-辅修</a></li>
-            </ul>
-            <script>var zNodes = [];</script>
-          </html>
-        ''',
-        '/student/integratedQuery/planCompletion/getPyfaIndex/10101':
+            <html>
+              <button class="btn btn-success btn-round" title="广播电视编导培养方案(10692)" onclick="getPyfaIndex(&#39;10692&#39;);return false;">
+                广播电视编导培养方案 (主修)
+              </button>
+              <button class="btn btn-success btn-round" title="生成式人工智能与影视工业化（微专业）教学计划(202601221181)" onclick="getPyfaIndex(&#39;202601221181&#39;);return false;">
+                生成式人工智能与影视工业化（微专业）教学计划
+              </button>
+            </html>
+          ''',
+        '/student/integratedQuery/planCompletion/getPyfaIndex/10692':
             '<html><script>var zNodes = [${_nodeJson('a', '-1', '主修方案')}];</script></html>',
-        '/student/integratedQuery/planCompletion/getPyfaIndex/10102':
-            '<html><script>var zNodes = [${_nodeJson('b', '-1', '辅修方案')}];</script></html>',
+        '/student/integratedQuery/planCompletion/getPyfaIndex/202601221181':
+            '<html><script>var zNodes = [${_nodeJson('b', '-1', '微专业方案')}];</script></html>',
       },
       prefs,
       logger,
@@ -94,12 +96,12 @@ void main() {
 
     final plans = await helper.api.fetchPlanCompletion();
     expect(plans, hasLength(2));
-    expect(plans[0].id, '10101');
-    expect(plans[0].name, '2023级-软件工程-主修');
+    expect(plans[0].id, '10692');
+    expect(plans[0].name, '广播电视编导培养方案');
     expect(plans[0].nodes.single.name, '主修方案');
-    expect(plans[1].id, '10102');
-    expect(plans[1].name, '2023级-软件工程-辅修');
-    expect(plans[1].nodes.single.name, '辅修方案');
+    expect(plans[1].id, '202601221181');
+    expect(plans[1].name, '生成式人工智能与影视工业化（微专业）教学计划');
+    expect(plans[1].nodes.single.name, '微专业方案');
   });
 
   test(

--- a/test/zhjw_api_service_test.dart
+++ b/test/zhjw_api_service_test.dart
@@ -52,6 +52,158 @@ void main() {
       );
     },
   );
+
+  test('fetchPlanCompletion: single plan from index page zNodes', () async {
+    final helper = _buildRoutingApi(
+      {
+        '/student/integratedQuery/planCompletion/index':
+            '<html><script>var zNodes = [${_nodeJson('1', '-1', '公共基础课')}];</script></html>',
+      },
+      prefs,
+      logger,
+    );
+    addTearDown(helper.auth.dispose);
+
+    final plans = await helper.api.fetchPlanCompletion();
+    expect(plans, hasLength(1));
+    expect(plans.single.id, '');
+    expect(plans.single.nodes.single.name, '公共基础课');
+  });
+
+  test('fetchPlanCompletion: multiple plans follow getPyfaIndex links', () async {
+    final helper = _buildRoutingApi(
+      {
+        '/student/integratedQuery/planCompletion/index': '''
+          <html>
+            <ul class="plan-list">
+              <li><a href="/student/integratedQuery/planCompletion/getPyfaIndex/10101">2023级-软件工程-主修</a></li>
+              <li><a href="/student/integratedQuery/planCompletion/getPyfaIndex/10102">2023级-软件工程-辅修</a></li>
+            </ul>
+            <script>var zNodes = [];</script>
+          </html>
+        ''',
+        '/student/integratedQuery/planCompletion/getPyfaIndex/10101':
+            '<html><script>var zNodes = [${_nodeJson('a', '-1', '主修方案')}];</script></html>',
+        '/student/integratedQuery/planCompletion/getPyfaIndex/10102':
+            '<html><script>var zNodes = [${_nodeJson('b', '-1', '辅修方案')}];</script></html>',
+      },
+      prefs,
+      logger,
+    );
+    addTearDown(helper.auth.dispose);
+
+    final plans = await helper.api.fetchPlanCompletion();
+    expect(plans, hasLength(2));
+    expect(plans[0].id, '10101');
+    expect(plans[0].name, '2023级-软件工程-主修');
+    expect(plans[0].nodes.single.name, '主修方案');
+    expect(plans[1].id, '10102');
+    expect(plans[1].name, '2023级-软件工程-辅修');
+    expect(plans[1].nodes.single.name, '辅修方案');
+  });
+
+  test(
+    'fetchPlanCompletion: no plan (empty zNodes and no links) returns empty',
+    () async {
+      final helper = _buildRoutingApi(
+        {
+          '/student/integratedQuery/planCompletion/index':
+              '<html><script>var zNodes = [];</script></html>',
+        },
+        prefs,
+        logger,
+      );
+      addTearDown(helper.auth.dispose);
+
+      final plans = await helper.api.fetchPlanCompletion();
+      expect(plans, isEmpty);
+    },
+  );
+
+  test('fetchPlanCompletion: malformed page without zNodes and links throws '
+      '(never silently returns empty)', () async {
+    final helper = _buildRoutingApi(
+      {
+        '/student/integratedQuery/planCompletion/index':
+            '<html><body>页面异常</body></html>',
+      },
+      prefs,
+      logger,
+    );
+    addTearDown(helper.auth.dispose);
+
+    // 核心诉求（issue #246）：解析失败必须抛可诊断错误，不能静默返回 []。
+    // 页面既无 zNodes 也无链接 → 被视为非业务页，抛 UnauthenticatedException
+    // 触发重认证；测试环境无真实 SSO，重认证失败表现为 ServiceException。
+    // 两者都属于 ScuException，这里只验证"不会静默返回空列表"。
+    await expectLater(
+      helper.api.fetchPlanCompletion(),
+      throwsA(isA<ScuException>()),
+    );
+  });
+
+  test(
+    'fetchPlanCompletion: broken zNodes JSON throws ServiceException',
+    () async {
+      final helper = _buildRoutingApi(
+        {
+          '/student/integratedQuery/planCompletion/index':
+              '<html><script>var zNodes = [{"id": 1, broken]};</script></html>',
+        },
+        prefs,
+        logger,
+      );
+      addTearDown(helper.auth.dispose);
+
+      await expectLater(
+        helper.api.fetchPlanCompletion(),
+        throwsA(isA<ServiceException>()),
+      );
+    },
+  );
+}
+
+String _nodeJson(String id, String pId, String name) => _jsonEncodeNode({
+  'id': id,
+  'pId': pId,
+  'flagId': id,
+  'flagType': '001',
+  'name': name,
+  'sfwc': '否',
+  'yxxf': '0',
+  'zsxf': '1',
+});
+
+String _jsonEncodeNode(Map<String, dynamic> node) => jsonEncode(node);
+
+/// 构建按 URL 路径路由响应的 MockClient。
+({ZhjwApiService api, ZhjwAuth auth}) _buildRoutingApi(
+  Map<String, String> routes,
+  SharedPreferences prefs,
+  AuthLogger logger,
+) {
+  var requests = 0;
+  final client = CookieClient(
+    inner: MockClient((request) async {
+      requests++;
+      // 第一个请求是 CookieClient 的域隔离探测请求（不在路由内）
+      if (requests == 1) return http.Response('ok', 200, request: request);
+      final path = request.url.path;
+      final body = routes[path];
+      if (body == null) {
+        return http.Response('route not found: $path', 404, request: request);
+      }
+      return http.Response.bytes(
+        utf8.encode(body),
+        200,
+        headers: const {'content-type': 'text/html; charset=utf-8'},
+        request: request,
+      );
+    }),
+  );
+  final scuAuth = _TestScuAuth(prefs, logger: logger, client: client);
+  final auth = ZhjwAuth(scuAuth, logger: logger);
+  return (api: ZhjwApiService(auth), auth: auth);
 }
 
 ({ZhjwApiService api, ZhjwAuth auth}) _buildApi(


### PR DESCRIPTION
### fix: 支持多份培养方案修读情况数据（方案选择页→详情页 + 滑动切换）

#### 问题（issue #246 ）

有多份培养方案（如主修+辅修、微专业）的用户进入「校园 > 方案修读情况」时，教务系统 `/planCompletion/index` 返回的是**方案选择页**而非数据页——真正的树数据在 `/getPyfaIndex/<方案ID>` 详情页。原实现只请求入口页，解析失败又静默返回空数组，导致这类用户看到"暂无方案修读数据"，且可能因连续请求触发教务"请勿频繁刷新"限流。

#### 改动

**API 层**（zhjw_api_service.dart）
- `fetchPlanCompletion` 返回 `List<PlanCompletionPlan>`（方案 id / 名称 / 节点树），解析策略：
  1. index 页含非空 `zNodes` → 直接解析（单方案，行为不变）
  2. 否则提取 `getPyfaIndex/<ID>` 入口逐个请求详情页——支持教务实际的**按钮形态**（`onclick="getPyfaIndex('ID')"` + `title="方案名(ID)"`，含 `&#39;` HTML 实体），并兼容 `<a>` 链接与裸 URL
  3. zNodes 明确为空数组且无入口 → 账号无方案，返回空列表
  4. 页面结构异常/解析失败抛可诊断错误（`ServiceException`/`UnauthenticatedException`），不再静默返回空数组
- 详情页请求之间加 600ms 间隔 + 会话过期/限流检测，避免打开页面一次触发 N+1 个请求被教务限流

**模型 / Provider**
- 新增 `PlanCompletionPlan` 模型；Provider 维护方案列表与当前索引，`selectPlan()` 切换，缓存升级为多方案格式并兼容旧缓存

**页面**
- 顶部方案名指示栏（含滑动提示与 1/N 页码，仅多方案显示）+ `PageView` 左右滑动切换方案；单方案用户只有一页、滑动无反应，体验不受影响

#### 测试
- API：单方案 / 多方案（真实按钮 HTML）/ 无方案 / 结构异常 / JSON 损坏 5 例
- Provider：多方案切换、刷新缩容复位、空缓存 5 例
- 页面：多方案滑动切换、单方案展示 2 例
- 全量 **323 passed / 1 skipped**，`flutter analyze` 无告警，真机验证通过
- 已经过issue报告用户测试，修复后可以正常显示多方案的方案修读情况