### PR TITLE
ci: bundle WebView2Loader.dll into Windows release artifact

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -38,6 +38,32 @@ jobs:
             --dart-define=GIT_COMMIT_DATE=${{ steps.setup.outputs.GIT_COMMIT_DATE }}
         shell: bash
 
+      - name: Bundle WebView2Loader.dll
+        shell: pwsh
+        run: |
+          # flutter_inappwebview_windows 的 prebuilt DLL 静态导入 WebView2Loader.dll，
+          # 但 prebuilt 模式下不会链接 Microsoft.Web.WebView2 的 NuGet targets，
+          # 构建产物里不会自动带上该加载器。这里从官方 NuGet 包取回并放入 Release 目录，
+          # 确保最终 windows-release.zip 包含此依赖。
+          $version = "1.0.3650.58"  # 与插件 CMakeLists.txt 中的 WEBVIEW_VERSION 保持一致
+          $releaseDir = "build\windows\x64\runner\Release"
+          $tmp = Join-Path $env:RUNNER_TEMP "webview2"
+          $zip = Join-Path $env:RUNNER_TEMP "webview2.zip"
+
+          Invoke-WebRequest -Uri "https://www.nuget.org/api/v2/package/Microsoft.Web.WebView2/$version" -OutFile $zip
+          Expand-Archive $zip -DestinationPath $tmp -Force
+
+          $loader = Get-ChildItem $tmp -Recurse -Filter "WebView2Loader.dll" |
+            Where-Object { $_.FullName -match "runtimes[\\/]win-x64[\\/]native" } |
+            Select-Object -First 1
+          if (-not $loader) { throw "WebView2Loader.dll (win-x64) not found in Microsoft.Web.WebView2 $version" }
+
+          Copy-Item $loader.FullName (Join-Path $releaseDir "WebView2Loader.dll") -Force
+          if (-not (Test-Path (Join-Path $releaseDir "WebView2Loader.dll"))) {
+            throw "WebView2Loader.dll was not staged into $releaseDir"
+          }
+          Get-Item (Join-Path $releaseDir "WebView2Loader.dll") | Select-Object FullName, Length
+
       - name: Archive Windows Release
         run: Compress-Archive -Path build\windows\x64\runner\Release\* -DestinationPath
           windows-release.zip

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -45,7 +45,24 @@ jobs:
           # 但 prebuilt 模式下不会链接 Microsoft.Web.WebView2 的 NuGet targets，
           # 构建产物里不会自动带上该加载器。这里从官方 NuGet 包取回并放入 Release 目录，
           # 确保最终 windows-release.zip 包含此依赖。
-          $version = "1.0.3650.58"  # 与插件 CMakeLists.txt 中的 WEBVIEW_VERSION 保持一致
+          # 版本不硬编码：从插件 CMakeLists.txt 解析 WEBVIEW_VERSION，随插件升级自动跟随。
+          $cmake = "windows\flutter\ephemeral\.plugin_symlinks\flutter_inappwebview_windows\windows\CMakeLists.txt"
+          if (-not (Test-Path $cmake)) {
+            # 兜底：从 pub cache 的 git 依赖缓存中搜索（避免 Flutter 版本间目录结构差异）
+            $stale = Get-ChildItem "$env:LOCALAPPDATA\Pub\Cache\git\cache" -Recurse -Filter "CMakeLists.txt" -ErrorAction SilentlyContinue |
+              Where-Object { $_.FullName -match "flutter_inappwebview_windows[\\/]windows[\\/]CMakeLists.txt$" } |
+              Select-Object -First 1
+            if ($stale) { $cmake = $stale.FullName }
+          }
+          if (-not (Test-Path $cmake)) {
+            throw "flutter_inappwebview_windows CMakeLists.txt not found: $cmake"
+          }
+          $versionMatch = Select-String -Path $cmake -Pattern 'set\(WEBVIEW_VERSION\s+"([^"]+)"\)'
+          if (-not $versionMatch) {
+            throw "Unable to parse WEBVIEW_VERSION from $cmake"
+          }
+          $version = $versionMatch.Matches[0].Groups[1].Value
+          Write-Host "Parsed WEBVIEW_VERSION = $version (from $cmake)"
           $releaseDir = "build\windows\x64\runner\Release"
           $tmp = Join-Path $env:RUNNER_TEMP "webview2"
           $zip = Join-Path $env:RUNNER_TEMP "webview2.zip"


### PR DESCRIPTION
## 背景

Windows 版发布包缺少 `WebView2Loader.dll`，运行时 WebView 相关功能（通知页、登录页等）会加载失败。

## 根因

项目使用 fork 版 `flutter_inappwebview_windows`（prebuilt DLL 模式）：

- CI 构建走插件仓库内预编译的 `flutter_inappwebview_windows_plugin.dll`（`windows/prebuilt/x64/Release/`），跳过原生编译；
- 该模式不链接 `Microsoft.Web.WebView2` 的 NuGet targets（负责自动复制 `WebView2Loader.dll` 的机制）；
- 而 prebuilt DLL 的 PE 导入表**静态导入** `WebView2Loader.dll`（非延迟加载），运行时必须随包分发。

结果：`flutter build windows --release` 产出的 Release 目录里没有 `WebView2Loader.dll`，`Compress-Archive Release\*` 打出的 zip 自然也不含该依赖。

## 修改内容

仅修改 `.github/workflows/build-windows.yml`（不涉及源码构建逻辑）：

- 新增 `Bundle WebView2Loader.dll` 步骤（在 `Build Windows` 之后、`Archive` 之前）：
  - 从 nuget.org 下载官方 `Microsoft.Web.WebView2` 包（版本 `1.0.3650.58`，与插件 CMakeLists 的 `WEBVIEW_VERSION` 一致）；
  - 解压取出 `runtimes/win-x64/native/WebView2Loader.dll` 并复制到 `build\windows\x64\runner\Release\`；
  - 复制后断言文件存在，失败即构建失败，避免静默发布缺依赖的包。

## 验证

- [x] 触发 Windows 构建后，确认 `windows-release.zip` 内含 `WebView2Loader.dll`
- [ ] 解压发布 zip 运行 `Bugaoshan.exe`，WebView 页面可正常加载

## 备注

- 只改了 CI 打包逻辑，本地/源码构建不受影响；
- `WebView2Loader.dll` 版本与插件构建所用 NuGet 包版本保持一致，避免 ABI 不匹配。