### PR TITLE
fix: 移除 MainActivity 的 taskAffinity 空配置，避免小组件入口 Activity 重建

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -20,7 +20,6 @@
             android:name=".MainActivity"
             android:exported="true"
             android:launchMode="singleTop"
-            android:taskAffinity=""
             android:theme="@style/LaunchTheme"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
             android:hardwareAccelerated="true"


### PR DESCRIPTION
## 背景

Issue #239 根因分析：`MainActivity` 配置了 `android:taskAffinity=""`（空字符串）+ `launchMode="singleTop"`，而桌面课表小组件入口（CourseGlanceWidget）使用 `FLAG_ACTIVITY_NEW_TASK | FLAG_ACTIVITY_CLEAR_TOP` 启动 MainActivity。空 taskAffinity 使 MainActivity 进入独立命名的 task，`CLEAR_TOP` 跨 task 不生效，导致 Activity 重建：

- FlutterEngine 重新创建（无引擎缓存覆写，存在旧 engine 泄漏/双 engine 竞态）
- `configureFlutterEngine` 内 `WidgetUpdateWorker.enqueuePeriodic` 与 `WidgetAlarmManager.registerMidnightAlarm` 重复入队
- 任务切换器可能出现重复实例

> 说明：重构后 Sentry / ErrorFeedbackCoordinator 已移除，"异常反馈弹窗"症状虽消失，但 Activity 重建的根因配置仍保留，属"隐患还在、症状没了"。

## 改动

删除 AndroidManifest.xml 中 MainActivity 的 `android:taskAffinity=""` 一行，回归默认（应用包名）亲和性。全库已验证无任何代码依赖空 taskAffinity 行为（无 finishAndRemoveTask / FLAG_ACTIVITY_CLEAR_TASK / noHistory / excludeFromRecents 等配套逻辑）。

## 影响

- 小组件点击时 `CLEAR_TOP` 正确复用已存在实例（走 onNewIntent），Activity 不再重建
- BatteryOptimizationHandler / ApkInstaller 中的 `NEW_TASK` 是启动系统页面，与本 Activity affinity 无关，不受影响

Ref #239