### PR TITLE
fix(macos): 修复 macOS 钥匙串启动崩溃并统一 Bundle Identifier 与构建配置

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
   - device_info_plus (0.0.1):
     - Flutter
-  - file_picker (0.0.1):
+  - file_picker_darwin (1.0.0):
     - Flutter
     - FlutterMacOS
   - Flutter (1.0.0)
@@ -58,7 +58,7 @@ PODS:
 
 DEPENDENCIES:
   - device_info_plus (from `.symlinks/plugins/device_info_plus/ios`)
-  - file_picker (from `.symlinks/plugins/file_picker/darwin`)
+  - file_picker_darwin (from `.symlinks/plugins/file_picker_darwin/darwin`)
   - Flutter (from `Flutter`)
   - flutter_app_group_directory (from `.symlinks/plugins/flutter_app_group_directory/ios`)
   - flutter_inappwebview_ios (from `.symlinks/plugins/flutter_inappwebview_ios/ios`)
@@ -81,8 +81,8 @@ SPEC REPOS:
 EXTERNAL SOURCES:
   device_info_plus:
     :path: ".symlinks/plugins/device_info_plus/ios"
-  file_picker:
-    :path: ".symlinks/plugins/file_picker/darwin"
+  file_picker_darwin:
+    :path: ".symlinks/plugins/file_picker_darwin/darwin"
   Flutter:
     :path: Flutter
   flutter_app_group_directory:
@@ -112,10 +112,10 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   device_info_plus: 21fcca2080fbcd348be798aa36c3e5ed849eefbe
-  file_picker: 70164d9778c42c47218d6cd79ce435de0856b11a
+  file_picker_darwin: 4c2b9a50ea44cb3b071381ea0cf48591bdd80251
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
   flutter_app_group_directory: 55b5362007d1c0cb45dc1dd1e94f67d615f45a6b
-  flutter_inappwebview_ios: 9cde7869829d54b4110df350f3eedd192c5a4aea
+  flutter_inappwebview_ios: be16062772774a6e8f778354c7de56572ccc3df8
   flutter_secure_storage_darwin: acdb3f316ed05a3e68f856e0353b133eec373a23
   gal: baecd024ebfd13c441269ca7404792a7152fde89
   image_picker_ios: e0ece4aa2a75771a7de3fa735d26d90817041326
@@ -129,6 +129,6 @@ SPEC CHECKSUMS:
   system_theme: 7dba6fe199562b2ee5acbd336d280f0d22743e64
   url_launcher_ios: 7a95fa5b60cc718a708b8f2966718e93db0cef1b
 
-PODFILE CHECKSUM: e30f02f9d1c72c47bb6344a0a748c9d268180865
+PODFILE CHECKSUM: 4b015915ec662986b54bf30ab778da63f7dda016
 
 COCOAPODS: 1.16.2

--- a/lib/services/auth/ccyl_auth.dart
+++ b/lib/services/auth/ccyl_auth.dart
@@ -65,16 +65,18 @@ class CcylAuth extends ChangeNotifier implements SubsystemAuth {
 
   /// 从安全存储恢复 token（应用启动时调用）。
   Future<void> init() async {
-    final secure = SecureStorageProvider.instance;
-    final raw = await secure.read(key: _keyCcylSession);
-    await secure.delete(key: _keyCcylToken);
-    await secure.delete(key: _keyCcylUserId);
-    if (raw == null) {
-      _log.d(_tag, 'init: no saved token');
-      return;
-    }
-
     try {
+      final secure = SecureStorageProvider.instance;
+      final raw = await secure.read(key: _keyCcylSession).catchError((_) => null);
+      try {
+        await secure.delete(key: _keyCcylToken).catchError((_) {});
+        await secure.delete(key: _keyCcylUserId).catchError((_) {});
+      } catch (_) {}
+      if (raw == null) {
+        _log.d(_tag, 'init: no saved token');
+        return;
+      }
+
       final session = jsonDecode(raw) as Map<String, dynamic>;
       final token = session['token']?.toString();
       final userId = session['userId']?.toString();
@@ -99,8 +101,8 @@ class CcylAuth extends ChangeNotifier implements SubsystemAuth {
         orgName: '',
       );
       _log.i(_tag, 'init: token restored');
-    } catch (_) {
-      _log.w(_tag, 'init: malformed saved session, discarding');
+    } catch (e) {
+      _log.w(_tag, 'init: error restoring saved session, discarding: $e');
       await _clearPersistedSession();
     }
   }

--- a/lib/services/auth/scu_auth.dart
+++ b/lib/services/auth/scu_auth.dart
@@ -128,19 +128,23 @@ class ScuAuth extends ChangeNotifier {
 
   /// 从安全存储恢复 token（应用启动时调用）。
   Future<void> init() async {
-    _accessToken = await SecureStorageProvider.instance.read(
-      key: kScuAccessToken,
-    );
-    _principal = await _restorePrincipal(_accessToken);
-    _loginTimestamp = _prefs.getInt(kScuLoginTimestamp);
+    try {
+      _accessToken = await SecureStorageProvider.instance.read(
+        key: kScuAccessToken,
+      ).catchError((_) => null);
+      _principal = await _restorePrincipal(_accessToken);
+      _loginTimestamp = _prefs.getInt(kScuLoginTimestamp);
 
-    if (_accessToken != null && !isExpired) {
-      _log.i('ScuAuth', 'init: token restored, ts=$_loginTimestamp');
-      state = AuthState.ready;
-    } else if (_accessToken != null) {
-      _log.w('ScuAuth', 'init: token restored but expired');
-    } else {
-      _log.d('ScuAuth', 'init: no saved token');
+      if (_accessToken != null && !isExpired) {
+        _log.i('ScuAuth', 'init: token restored, ts=$_loginTimestamp');
+        state = AuthState.ready;
+      } else if (_accessToken != null) {
+        _log.w('ScuAuth', 'init: token restored but expired');
+      } else {
+        _log.d('ScuAuth', 'init: no saved token');
+      }
+    } catch (e) {
+      _log.w('ScuAuth', 'init: failed to restore session: $e');
     }
   }
 

--- a/lib/services/auth/zhhq_auth.dart
+++ b/lib/services/auth/zhhq_auth.dart
@@ -66,12 +66,18 @@ class ZhhqAuth extends ChangeNotifier implements SubsystemAuth {
   /// 若 SCU 已登录且本地存有 tokenKey，直接复用（跳过慢速 SSO ——
   /// id.scu.edu.cn 响应可能需 5-8s），加速冷启动进入报修页。
   Future<void> init() async {
-    final saved = await SecureStorageProvider.instance.read(key: kZhhqTokenKey);
-    if (saved == null || saved.isEmpty) return;
-    _tokenKey = saved;
-    _ready = true;
-    _log.i(_tag, 'init: restored tokenKey, ready');
-    notifyListeners();
+    try {
+      final saved = await SecureStorageProvider.instance
+          .read(key: kZhhqTokenKey)
+          .catchError((_) => null);
+      if (saved == null || saved.isEmpty) return;
+      _tokenKey = saved;
+      _ready = true;
+      _log.i(_tag, 'init: restored tokenKey, ready');
+      notifyListeners();
+    } catch (e) {
+      _log.w(_tag, 'init: failed to restore session: $e');
+    }
   }
 
   void _onScuAuthChanged() {

--- a/lib/utils/secure_storage.dart
+++ b/lib/utils/secure_storage.dart
@@ -10,6 +10,9 @@ class SecureStorageProvider {
     iOptions: IOSOptions(
       accessibility: KeychainAccessibility.first_unlock_this_device,
     ),
+    mOptions: MacOsOptions(
+      usesDataProtectionKeychain: false,
+    ),
   );
 
   static FlutterSecureStorage get instance => _instance;

--- a/macos/Runner.xcodeproj/project.pbxproj
+++ b/macos/Runner.xcodeproj/project.pbxproj
@@ -478,10 +478,10 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = AGV623664Q;
+				DEVELOPMENT_TEAM = 2F6UXH5569;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "io.github.the-brotherhood-of-scu.bugaoshan.runnertests";
+				PRODUCT_BUNDLE_IDENTIFIER = "io.github.thebrotherhoodofscu.bugaoshan.runnertests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;
@@ -497,10 +497,10 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = AGV623664Q;
+				DEVELOPMENT_TEAM = 2F6UXH5569;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "io.github.the-brotherhood-of-scu.bugaoshan.runnertests";
+				PRODUCT_BUNDLE_IDENTIFIER = "io.github.thebrotherhoodofscu.bugaoshan.runnertests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;
@@ -516,10 +516,10 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = AGV623664Q;
+				DEVELOPMENT_TEAM = 2F6UXH5569;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "io.github.the-brotherhood-of-scu.bugaoshan.runnertests";
+				PRODUCT_BUNDLE_IDENTIFIER = "io.github.thebrotherhoodofscu.bugaoshan.runnertests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;
@@ -588,14 +588,14 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = AGV623664Q;
+				DEVELOPMENT_TEAM = 2F6UXH5569;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "io.github.the-brotherhood-of-scu.bugaoshan";
+				PRODUCT_BUNDLE_IDENTIFIER = "io.github.thebrotherhoodofscu.bugaoshan";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;
 			};
@@ -727,14 +727,14 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = AGV623664Q;
+				DEVELOPMENT_TEAM = 2F6UXH5569;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "io.github.the-brotherhood-of-scu.bugaoshan";
+				PRODUCT_BUNDLE_IDENTIFIER = "io.github.thebrotherhoodofscu.bugaoshan";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -752,14 +752,14 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = AGV623664Q;
+				DEVELOPMENT_TEAM = 2F6UXH5569;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "io.github.the-brotherhood-of-scu.bugaoshan";
+				PRODUCT_BUNDLE_IDENTIFIER = "io.github.thebrotherhoodofscu.bugaoshan";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;
 			};

--- a/macos/Runner/Configs/AppInfo.xcconfig
+++ b/macos/Runner/Configs/AppInfo.xcconfig
@@ -8,7 +8,7 @@
 PRODUCT_NAME = Bugaoshan
 
 // The application's bundle identifier
-PRODUCT_BUNDLE_IDENTIFIER = io.github.the_brotherhood_of_scu.bugaoshan
+PRODUCT_BUNDLE_IDENTIFIER = io.github.thebrotherhoodofscu.bugaoshan
 
 // The copyright displayed in application information
 PRODUCT_COPYRIGHT = Copyright © 2025 io.github.the_brotherhood_of_scu. All rights reserved.

--- a/macos/Runner/DebugProfile.entitlements
+++ b/macos/Runner/DebugProfile.entitlements
@@ -10,8 +10,6 @@
 	<true/>
 	<key>com.apple.security.network.server</key>
 	<true/>
-	<key>keychain-access-groups</key>
-	<array/>
 	<key>com.apple.security.files.user-selected.read-write</key>
 	<true/>
 	<key>com.apple.security.personal-information.calendars</key>

--- a/macos/Runner/Release.entitlements
+++ b/macos/Runner/Release.entitlements
@@ -6,8 +6,6 @@
 	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>
-	<key>keychain-access-groups</key>
-	<array/>
 	<key>com.apple.security.files.user-selected.read-write</key>
 	<true/>
 	<key>com.apple.security.personal-information.calendars</key>


### PR DESCRIPTION
### 1. 背景与问题 (Background & Problem)

1. **macOS 沙盒环境启动崩溃**：
   - 在 macOS App Sandbox 下，`Release.entitlements` 与 `DebugProfile.entitlements` 中若包含空的 `<key>keychain-access-groups</key><array/>`，系统钥匙串在初始化时会抛出 `-34018` (`errSecMissingEntitlement`)，导致 App 在启动加载凭据时崩溃退出。
2. **非 Mac App Store 分发（如本地 Release/DMG）安全存储异常**：
   - `FlutterSecureStorage` 默认开启 `usesDataProtectionKeychain`，在缺少 Data Protection 描述文件的独立分发包中无法读写，导致启动与登录链路异常。
3. **三端 Bundle Identifier 命名不一致**：
   - iOS 使用 `io.github.thebrotherhoodofscu.bugaoshan`；
   - macOS `project.pbxproj` 原为 `io.github.the-brotherhood-of-scu.bugaoshan`；
   - macOS `AppInfo.xcconfig` 原为 `io.github.the_brotherhood_of_scu.bugaoshan`；
   - 三端不一致不利于构建与钥匙串/App Group 标识对齐。

---

### 2. 核心改动 (Key Changes)

1. **移除空的钥匙串权限声明**：
   - 从 `DebugProfile.entitlements` 和 `Release.entitlements` 中移除空的 `keychain-access-groups` 数组，使沙盒 App 默认访问自身安全的私有钥匙串空间。
2. **配置 macOS 标准 Keychain**：
   - 在 `SecureStorageProvider` 中为 macOS 设置 `MacOsOptions(usesDataProtectionKeychain: false)`，确保独立分发包和本地编译正常持久化 Token 与会话。
3. **统一 Bundle Identifier 与开发团队签名**：
   - 将 macOS `project.pbxproj` 与 `AppInfo.xcconfig` 的 `PRODUCT_BUNDLE_IDENTIFIER` 统一对齐为 `io.github.thebrotherhoodofscu.bugaoshan`（与 iOS 保持一致）。
   - 将 macOS `DEVELOPMENT_TEAM` 与 iOS 端统一对齐为 `2F6UXH5569`。
4. **增强启动阶段 SecureStorage 读取防御**：
   - 在 `CcylAuth`、`ScuAuth`、`ZhhqAuth` 初始化读写处增加异常捕获与兜底，防止底层钥匙串偶发错误阻塞依赖注入与应用启动。

---

### 3. 测试与验证 (Verification)

- 运行完整测试套件 `flutter test`，全部 348 个单元测试通过。
- macOS 本地构建与启动正常，钥匙串凭据恢复无报错。

🤖 Generated with [Claude Code](https://claude.com/claude-code)