### PR TITLE
fix: 处理 PR #268 review 意见(ICS 坐标守卫/匹配边界/解析健壮性)

### DIFF
--- a/lib/pages/course/import/jwxt_parser.dart
+++ b/lib/pages/course/import/jwxt_parser.dart
@@ -70,13 +70,13 @@ void validateImportedSchedule(ScheduleConfig config, List<Course> courses) {
                     tpMap['jxlm'] ??
                     tpMap['building'] ??
                     '')
-                as String;
+                .toString();
         final String room =
             (tpMap['classroomName'] ??
                     tpMap['jasm'] ??
                     tpMap['classroom'] ??
                     '')
-                as String;
+                .toString();
         var location = '$building$room'.trim();
         if (location.isEmpty) {
           location =
@@ -85,7 +85,7 @@ void validateImportedSchedule(ScheduleConfig config, List<Course> courses) {
                       tpMap['place'] ??
                       tpMap['skdd'] ??
                       '')
-                  as String;
+                  .toString();
           location = location.trim();
         }
         final String campusName = tpMap['campusName'] as String? ?? '';

--- a/lib/services/api/academic_calendar_service.dart
+++ b/lib/services/api/academic_calendar_service.dart
@@ -311,9 +311,12 @@ class AcademicCalendarService {
       );
       buffer.writeln('SUMMARY:${_escapeIcsText(event.title)}');
       buffer.writeln('LOCATION:${_escapeIcsText(event.location)}');
-      if (event.structuredLocation != null) {
+      final structuredLocation = event.structuredLocation;
+      if (structuredLocation != null &&
+          structuredLocation.latitude != null &&
+          structuredLocation.longitude != null) {
         buffer.writeln(
-          'GEO:${event.structuredLocation!.latitude};${event.structuredLocation!.longitude}',
+          'GEO:${structuredLocation.latitude};${structuredLocation.longitude}',
         );
       }
       buffer.writeln('DESCRIPTION:${_escapeIcsText(event.description)}');

--- a/lib/services/ics_service.dart
+++ b/lib/services/ics_service.dart
@@ -202,6 +202,10 @@ class IcsService {
     buffer.writeln('SUMMARY:${_escapeIcsText(event.title)}');
     buffer.writeln('LOCATION:${_escapeIcsText(event.location)}');
     final structuredLocation = event.structuredLocation;
+    // 注意：当前 CalendarLocationMapper.resolve() 的所有返回路径都未产出
+    // latitude/longitude 坐标（见 calendar_event_utils.dart），因此 GEO 与
+    // X-APPLE-STRUCTURED-LOCATION 行暂不会输出。此块保留，等待坐标数据源
+    // 接入后即可启用；若确认不再需要坐标请删除本块。
     if (structuredLocation != null &&
         structuredLocation.latitude != null &&
         structuredLocation.longitude != null) {

--- a/lib/utils/calendar_event_utils.dart
+++ b/lib/utils/calendar_event_utils.dart
@@ -467,22 +467,20 @@ class CalendarLocationMapper {
     }
 
     // 2. 尝试匹配高精度建筑（OSM 坐标 + 标准建筑全称）
+    //    最长 pattern 优先：避免短 pattern（如"一教"）截胡长 pattern
+    //    （如"一教A101"应命中"第一教学楼A座"而非无座版），不依赖表项顺序。
     _BuildingGeoReference? matchedBuilding;
     if (location.isNotEmpty) {
-      if (explicitCampus != null) {
-        for (final building in _buildingLocations) {
-          if (building.campusName == explicitCampus.fullName &&
-              building.matches(location)) {
-            matchedBuilding = building;
-            break;
-          }
+      var bestLength = 0;
+      for (final building in _buildingLocations) {
+        if (explicitCampus != null &&
+            building.campusName != explicitCampus.fullName) {
+          continue;
         }
-      } else {
-        for (final building in _buildingLocations) {
-          if (building.matches(location)) {
-            matchedBuilding = building;
-            break;
-          }
+        final length = building.longestMatchLength(location);
+        if (length > bestLength) {
+          bestLength = length;
+          matchedBuilding = building;
         }
       }
     }
@@ -756,11 +754,6 @@ class _CampusGeoReference {
     required this.keywords,
     this.buildingKeywords = const [],
   });
-
-  bool matches(String text) {
-    return keywords.any((keyword) => text.contains(keyword)) ||
-        buildingKeywords.any((building) => text.contains(building));
-  }
 }
 
 class _BuildingGeoReference {
@@ -776,7 +769,26 @@ class _BuildingGeoReference {
     this.redirectNote,
   });
 
-  bool matches(String text) {
-    return matchPatterns.any((pattern) => text.contains(pattern));
+  /// 返回命中的最高匹配得分（0 表示未命中）。
+  ///
+  /// 以"最长 pattern 优先"取代布尔 contains，使 `一教A101` 稳定命中
+  /// `第一教学楼A座`（pattern `一教A`）而非被 `一教` 截胡命中无座版，
+  /// 匹配结果不再依赖 `_buildingLocations` 表项顺序。
+  ///
+  /// 以字母结尾的 pattern 表示带座号（如 `一教A` / `基础教学楼B`），
+  /// 额外 +1 权重：`第一教学楼A座` 输入下 `第一教学楼A` 与 `第一教学楼`
+  /// 字长相同，权重确保带座号版本胜出，避免平局回退到表序。
+  int longestMatchLength(String text) {
+    var longest = 0;
+    for (final pattern in matchPatterns) {
+      if (pattern.isNotEmpty && text.contains(pattern)) {
+        final score =
+            pattern.length + (RegExp(r'[A-Za-z]$').hasMatch(pattern) ? 1 : 0);
+        if (score > longest) {
+          longest = score;
+        }
+      }
+    }
+    return longest;
   }
 }

--- a/test/academic_calendar_test.dart
+++ b/test/academic_calendar_test.dart
@@ -134,6 +134,13 @@ void main() {
       expect(payload.icsContent, contains('BEGIN:VCALENDAR'));
       expect(payload.icsContent, contains('SUMMARY:国庆节假期'));
       expect(payload.icsContent, contains('UID:acad-2026-2027学年秋季学期-国庆节假期-'));
+      // 回归：当前无坐标数据源（结构化位置恒 null），ICS 不得输出 GEO:null;null
+      // 或 X-APPLE 行；若未来接入坐标，此处立即捕获纬经度缺失的守卫遗漏。
+      expect(payload.icsContent, isNot(contains('GEO:null')));
+      expect(
+        payload.icsContent,
+        isNot(contains('X-APPLE-STRUCTURED-LOCATION')),
+      );
     });
   });
 }

--- a/test/calendar_event_utils_test.dart
+++ b/test/calendar_event_utils_test.dart
@@ -58,9 +58,19 @@ void main() {
       expect(yiJiaoLoc.title, '四川大学江安校区第一教学楼A座 · A101');
       expect(yiJiaoLoc.structuredLocation?.title, '四川大学江安校区第一教学楼A座 · A101');
 
+      // 回归：全称形式（第一教学楼A座）不得因子串冲突命中无座版。
+      final yiJiaoFull = CalendarLocationMapper.resolve('第一教学楼A座');
+      expect(yiJiaoFull.title, '四川大学江安校区第一教学楼A座');
+      expect(yiJiaoFull.structuredLocation?.title, '四川大学江安校区第一教学楼A座');
+
       final yiJiaoOnlyBuilding = CalendarLocationMapper.resolve('一教A座');
       expect(yiJiaoOnlyBuilding.title, '四川大学江安校区第一教学楼A座');
       expect(yiJiaoOnlyBuilding.structuredLocation?.title, '四川大学江安校区第一教学楼A座');
+
+      // 回归：无座号时仍应命中无座版。
+      final yiJiaoPlain = CalendarLocationMapper.resolve('第一教学楼');
+      expect(yiJiaoPlain.title, '四川大学江安校区第一教学楼');
+      expect(yiJiaoPlain.structuredLocation?.title, '四川大学江安校区第一教学楼');
 
       final wangJiangLoc = CalendarLocationMapper.resolve('基础教学楼B101');
       expect(wangJiangLoc.title, '四川大学望江校区基础教学楼B座 · B101');

--- a/test/ics_service_test.dart
+++ b/test/ics_service_test.dart
@@ -115,6 +115,8 @@ void main() {
       expect(ics, contains('SUMMARY:课序号 02 大学英语'));
       expect(ics, contains('UID:course-english_1@bugaoshan'));
       expect(ics, contains('LOCATION:四川大学华西校区第十教学楼 · 201'));
+      // 回归：无坐标（latitude/longitude 为 null）时不输出 GEO:null;null
+      expect(ics, isNot(contains('GEO:null')));
     });
 
     test('builds course calendar export payload in one place', () {

--- a/test/jwxt_parser_test.dart
+++ b/test/jwxt_parser_test.dart
@@ -99,5 +99,35 @@ void main() {
       final course = result.courses.first;
       expect(course.location, '第二基础实验大楼B501');
     });
+
+    test('tolerates non-String field values via toString fallback', () {
+      // 教务接口偶发数字型字段（如 classroomName 为 int），不应抛类型错误。
+      final mockData = {
+        'xkxx': [
+          {
+            'course4': {
+              'courseName': '程序设计',
+              'attendClassTeacher': '王老师',
+              'id': {'coureSequenceNumber': '04'},
+              'timeAndPlaceList': [
+                {
+                  'classDay': 2,
+                  'classSessions': 1,
+                  'continuingSession': 1,
+                  'teachingBuildingName': '第一教学楼',
+                  'classroomName': 101,
+                  'campusName': '江安校区',
+                  'classWeek': '1010',
+                },
+              ],
+            },
+          },
+        ],
+      };
+
+      final result = parseJwxtData(mockData, '默认课表');
+      expect(result.courses, hasLength(1));
+      expect(result.courses.first.location, '第一教学楼101');
+    });
   });
 }


### PR DESCRIPTION
## 🔧 处理 PR #268 review 意见(ICS 健壮性 & 匹配边界)

### 背景

PR #268(fix/calendar-location-export)合入后,review 提出 5 点跟进建议。经逐条核实,其中 4 点成立,已在本次全部处理(bug 均不阻碍 #268 合入,属防患层面)。

### 改动内容

**1. ICS GEO 行补 null 守卫** — `academic_calendar_service.dart`

校历 ICS 的 `GEO:` 行原先只有 `structuredLocation != null` 单层守卫,而 `structuredLocation.latitude/longitude` 是 `double?` 可空字段。已补齐与 `ics_service.dart` 一致的三重守卫(`structuredLocation` + `latitude` + `longitude`),避免未来接入坐标数据源时产出 `GEO:null;null` 坏 ICS。

**2. 标注 X-APPLE 死代码块** — `ics_service.dart`

`CalendarLocationMapper` 目前所有返回路径都不产出经纬度,`GEO:`/`X-APPLE-STRUCTURED-LOCATION` 行实际不会执行。保留代码(等待坐标数据源)但补充注释说明现状,避免误导。

**3. 建筑匹配改"最长 pattern 优先"** — `calendar_event_utils.dart`

原匹配是 `text.contains(pattern)` + 表项顺序优先,存在截胡问题:`一教A101` 可能命中无座版"第一教学楼"而非"第一教学楼A座"。改为**最长 pattern 优先**(带座号字母结尾的 pattern 额外 +1 权重,处理 `第一教学楼A座` 与 `第一教学楼` 同字长的平局),匹配结果不再依赖 `_buildingLocations` 表项排列顺序。

**4. 解析字段改 `toString()`** — `jwxt_parser.dart`

3 处无 null 兜底的 `as String` 强转改为 `.toString()`,兼容教务接口偶发的数值型字段(如 `classroomName: 101`),避免 `TypeError`。

**5. 补回归测试**(+4 用例)

| 用例 | 文件 | 覆盖 |
|---|---|---|
| ICS 不输出 `GEO:null` | `academic_calendar_test.dart` / `ics_service_test.dart` | 意见 1 防复发,未来接入坐标时立即捕获守卫遗漏 |
| 座号平局命中 A 座 / 无座命中无座版 | `calendar_event_utils_test.dart` | 意见 3 防复发 |
| 数值型教室字段兜底 | `jwxt_parser_test.dart` | 意见 4 防复发 |

### 附带清理

删除 `_CampusGeoReference.matches` 死方法(全库 0 调用,配合意见 3 的重构顺带移除)。

### 验证

| 检查 | 结果 |
|---|---|
| `flutter analyze` | ✅ No issues found |
| `flutter test`(全量) | ✅ +356,全部通过 |
| `dart format` | ✅ 无格式问题 |

### 统计

```
8 files changed, +93 −25
```

纯健壮性/可读性改进,无行为变更(#3 的匹配结果理论上更准确,已在测试中验证)。