### PR TITLE
修复在线报修「我的报修」功能（#273）

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1538,6 +1538,11 @@
         "description": "Toast after a repair evaluation is submitted.",
         "type": "text"
     },
+    "repairEvaluateFailed": "Evaluation failed, please try again later",
+    "@repairEvaluateFailed": {
+        "description": "Toast when submitting a repair evaluation fails.",
+        "type": "text"
+    },
     "serviceHallTitle": "Service Hall",
     "@serviceHallTitle": {
         "description": "Title for the service hall sub-page listing available matters.",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1538,6 +1538,11 @@
         "description": "Toast after a repair evaluation is submitted.",
         "type": "text"
     },
+    "repairEvaluated": "Evaluated",
+    "@repairEvaluated": {
+        "description": "Status text when a repair ticket has been evaluated.",
+        "type": "text"
+    },
     "repairEvaluateFailed": "Evaluation failed, please try again later",
     "@repairEvaluateFailed": {
         "description": "Toast when submitting a repair evaluation fails.",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1543,6 +1543,11 @@
         "description": "Status text when a repair ticket has been evaluated.",
         "type": "text"
     },
+    "repairWithdrawn": "Withdrawn",
+    "@repairWithdrawn": {
+        "description": "Status text when a repair ticket has been withdrawn.",
+        "type": "text"
+    },
     "repairEvaluateFailed": "Evaluation failed, please try again later",
     "@repairEvaluateFailed": {
         "description": "Toast when submitting a repair evaluation fails.",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1483,6 +1483,61 @@
         "description": "Toast when the selected image exceeds the size limit.",
         "type": "text"
     },
+    "repairDetail": "Repair Detail",
+    "@repairDetail": {
+        "description": "Title of the repair ticket detail page.",
+        "type": "text"
+    },
+    "repairServiceUnit": "Service Unit",
+    "@repairServiceUnit": {
+        "description": "Label of the service unit field in a repair ticket.",
+        "type": "text"
+    },
+    "repairPayType": "Charge Type",
+    "@repairPayType": {
+        "description": "Label of the charge type field in a repair ticket.",
+        "type": "text"
+    },
+    "repairProgress": "Repair Progress",
+    "@repairProgress": {
+        "description": "Title of the repair progress timeline.",
+        "type": "text"
+    },
+    "repairWithdraw": "Withdraw Repair",
+    "@repairWithdraw": {
+        "description": "Button text to withdraw a repair ticket.",
+        "type": "text"
+    },
+    "repairWithdrawConfirm": "Withdraw this repair ticket?",
+    "@repairWithdrawConfirm": {
+        "description": "Confirmation prompt before withdrawing a repair ticket.",
+        "type": "text"
+    },
+    "repairWithdrawSuccess": "Repair withdrawn",
+    "@repairWithdrawSuccess": {
+        "description": "Toast after a repair ticket is withdrawn.",
+        "type": "text"
+    },
+    "repairWithdrawFailed": "Withdraw failed, please try again later",
+    "@repairWithdrawFailed": {
+        "description": "Toast when withdrawing a repair ticket fails.",
+        "type": "text"
+    },
+    "repairEvaluate": "Evaluate Repair",
+    "@repairEvaluate": {
+        "description": "Button text to evaluate a repair ticket.",
+        "type": "text"
+    },
+    "repairEvaluateHint": "Write your review (optional)",
+    "@repairEvaluateHint": {
+        "description": "Placeholder of the evaluation content input.",
+        "type": "text"
+    },
+    "repairEvaluateSuccess": "Evaluation submitted",
+    "@repairEvaluateSuccess": {
+        "description": "Toast after a repair evaluation is submitted.",
+        "type": "text"
+    },
     "serviceHallTitle": "Service Hall",
     "@serviceHallTitle": {
         "description": "Title for the service hall sub-page listing available matters.",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -5359,6 +5359,12 @@ abstract class AppLocalizations {
   /// **'Evaluated'**
   String get repairEvaluated;
 
+  /// Status text when a repair ticket has been withdrawn.
+  ///
+  /// In en, this message translates to:
+  /// **'Withdrawn'**
+  String get repairWithdrawn;
+
   /// Toast when submitting a repair evaluation fails.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -5353,6 +5353,12 @@ abstract class AppLocalizations {
   /// **'Evaluation submitted'**
   String get repairEvaluateSuccess;
 
+  /// Status text when a repair ticket has been evaluated.
+  ///
+  /// In en, this message translates to:
+  /// **'Evaluated'**
+  String get repairEvaluated;
+
   /// Toast when submitting a repair evaluation fails.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -5287,6 +5287,72 @@ abstract class AppLocalizations {
   /// **'Image must be smaller than 10MB'**
   String get repairImageTooLarge;
 
+  /// Title of the repair ticket detail page.
+  ///
+  /// In en, this message translates to:
+  /// **'Repair Detail'**
+  String get repairDetail;
+
+  /// Label of the service unit field in a repair ticket.
+  ///
+  /// In en, this message translates to:
+  /// **'Service Unit'**
+  String get repairServiceUnit;
+
+  /// Label of the charge type field in a repair ticket.
+  ///
+  /// In en, this message translates to:
+  /// **'Charge Type'**
+  String get repairPayType;
+
+  /// Title of the repair progress timeline.
+  ///
+  /// In en, this message translates to:
+  /// **'Repair Progress'**
+  String get repairProgress;
+
+  /// Button text to withdraw a repair ticket.
+  ///
+  /// In en, this message translates to:
+  /// **'Withdraw Repair'**
+  String get repairWithdraw;
+
+  /// Confirmation prompt before withdrawing a repair ticket.
+  ///
+  /// In en, this message translates to:
+  /// **'Withdraw this repair ticket?'**
+  String get repairWithdrawConfirm;
+
+  /// Toast after a repair ticket is withdrawn.
+  ///
+  /// In en, this message translates to:
+  /// **'Repair withdrawn'**
+  String get repairWithdrawSuccess;
+
+  /// Toast when withdrawing a repair ticket fails.
+  ///
+  /// In en, this message translates to:
+  /// **'Withdraw failed, please try again later'**
+  String get repairWithdrawFailed;
+
+  /// Button text to evaluate a repair ticket.
+  ///
+  /// In en, this message translates to:
+  /// **'Evaluate Repair'**
+  String get repairEvaluate;
+
+  /// Placeholder of the evaluation content input.
+  ///
+  /// In en, this message translates to:
+  /// **'Write your review (optional)'**
+  String get repairEvaluateHint;
+
+  /// Toast after a repair evaluation is submitted.
+  ///
+  /// In en, this message translates to:
+  /// **'Evaluation submitted'**
+  String get repairEvaluateSuccess;
+
   /// Title for the service hall sub-page listing available matters.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -5353,6 +5353,12 @@ abstract class AppLocalizations {
   /// **'Evaluation submitted'**
   String get repairEvaluateSuccess;
 
+  /// Toast when submitting a repair evaluation fails.
+  ///
+  /// In en, this message translates to:
+  /// **'Evaluation failed, please try again later'**
+  String get repairEvaluateFailed;
+
   /// Title for the service hall sub-page listing available matters.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -2859,6 +2859,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get repairEvaluated => 'Evaluated';
 
   @override
+  String get repairWithdrawn => 'Withdrawn';
+
+  @override
   String get repairEvaluateFailed =>
       'Evaluation failed, please try again later';
 

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -2823,6 +2823,39 @@ class AppLocalizationsEn extends AppLocalizations {
   String get repairImageTooLarge => 'Image must be smaller than 10MB';
 
   @override
+  String get repairDetail => 'Repair Detail';
+
+  @override
+  String get repairServiceUnit => 'Service Unit';
+
+  @override
+  String get repairPayType => 'Charge Type';
+
+  @override
+  String get repairProgress => 'Repair Progress';
+
+  @override
+  String get repairWithdraw => 'Withdraw Repair';
+
+  @override
+  String get repairWithdrawConfirm => 'Withdraw this repair ticket?';
+
+  @override
+  String get repairWithdrawSuccess => 'Repair withdrawn';
+
+  @override
+  String get repairWithdrawFailed => 'Withdraw failed, please try again later';
+
+  @override
+  String get repairEvaluate => 'Evaluate Repair';
+
+  @override
+  String get repairEvaluateHint => 'Write your review (optional)';
+
+  @override
+  String get repairEvaluateSuccess => 'Evaluation submitted';
+
+  @override
   String get serviceHallTitle => 'Service Hall';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -2856,6 +2856,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get repairEvaluateSuccess => 'Evaluation submitted';
 
   @override
+  String get repairEvaluated => 'Evaluated';
+
+  @override
   String get repairEvaluateFailed =>
       'Evaluation failed, please try again later';
 

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -2856,6 +2856,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get repairEvaluateSuccess => 'Evaluation submitted';
 
   @override
+  String get repairEvaluateFailed =>
+      'Evaluation failed, please try again later';
+
+  @override
   String get serviceHallTitle => 'Service Hall';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -2768,6 +2768,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get repairEvaluateSuccess => '评价成功';
 
   @override
+  String get repairEvaluateFailed => '评价失败，请稍后重试';
+
+  @override
   String get serviceHallTitle => '办事大厅';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -2768,6 +2768,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get repairEvaluateSuccess => '评价成功';
 
   @override
+  String get repairEvaluated => '已评价';
+
+  @override
   String get repairEvaluateFailed => '评价失败，请稍后重试';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -2735,6 +2735,39 @@ class AppLocalizationsZh extends AppLocalizations {
   String get repairImageTooLarge => '图片不能超过 10MB';
 
   @override
+  String get repairDetail => '报修详情';
+
+  @override
+  String get repairServiceUnit => '服务单位';
+
+  @override
+  String get repairPayType => '收费类型';
+
+  @override
+  String get repairProgress => '工单进度';
+
+  @override
+  String get repairWithdraw => '撤回报修';
+
+  @override
+  String get repairWithdrawConfirm => '确定要撤回该报修工单吗？';
+
+  @override
+  String get repairWithdrawSuccess => '报修已撤回';
+
+  @override
+  String get repairWithdrawFailed => '撤回失败，请稍后重试';
+
+  @override
+  String get repairEvaluate => '评价工单';
+
+  @override
+  String get repairEvaluateHint => '请填写评价内容（可选）';
+
+  @override
+  String get repairEvaluateSuccess => '评价成功';
+
+  @override
   String get serviceHallTitle => '办事大厅';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -2771,6 +2771,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get repairEvaluated => '已评价';
 
   @override
+  String get repairWithdrawn => '已撤回';
+
+  @override
   String get repairEvaluateFailed => '评价失败，请稍后重试';
 
   @override

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -1475,6 +1475,11 @@
         "description": "评价成功后的提示。",
         "type": "text"
     },
+    "repairEvaluateFailed": "评价失败，请稍后重试",
+    "@repairEvaluateFailed": {
+        "description": "评价失败后的提示。",
+        "type": "text"
+    },
     "serviceHallTitle": "办事大厅",
     "@serviceHallTitle": {
         "description": "办事大厅二级页面标题，列出可办理事项。",

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -1475,6 +1475,11 @@
         "description": "评价成功后的提示。",
         "type": "text"
     },
+    "repairEvaluated": "已评价",
+    "@repairEvaluated": {
+        "description": "工单已评价状态文案。",
+        "type": "text"
+    },
     "repairEvaluateFailed": "评价失败，请稍后重试",
     "@repairEvaluateFailed": {
         "description": "评价失败后的提示。",

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -1420,6 +1420,61 @@
         "description": "选择的图片超过大小上限时提示。",
         "type": "text"
     },
+    "repairDetail": "报修详情",
+    "@repairDetail": {
+        "description": "报修工单详情页标题。",
+        "type": "text"
+    },
+    "repairServiceUnit": "服务单位",
+    "@repairServiceUnit": {
+        "description": "报修工单中的服务单位字段标签。",
+        "type": "text"
+    },
+    "repairPayType": "收费类型",
+    "@repairPayType": {
+        "description": "报修工单中的收费类型字段标签。",
+        "type": "text"
+    },
+    "repairProgress": "工单进度",
+    "@repairProgress": {
+        "description": "工单进度时间线标题。",
+        "type": "text"
+    },
+    "repairWithdraw": "撤回报修",
+    "@repairWithdraw": {
+        "description": "撤回报修按钮文案。",
+        "type": "text"
+    },
+    "repairWithdrawConfirm": "确定要撤回该报修工单吗？",
+    "@repairWithdrawConfirm": {
+        "description": "撤回报修前的确认提示。",
+        "type": "text"
+    },
+    "repairWithdrawSuccess": "报修已撤回",
+    "@repairWithdrawSuccess": {
+        "description": "撤回报修成功后的提示。",
+        "type": "text"
+    },
+    "repairWithdrawFailed": "撤回失败，请稍后重试",
+    "@repairWithdrawFailed": {
+        "description": "撤回报修失败后的提示。",
+        "type": "text"
+    },
+    "repairEvaluate": "评价工单",
+    "@repairEvaluate": {
+        "description": "评价报修工单按钮文案。",
+        "type": "text"
+    },
+    "repairEvaluateHint": "请填写评价内容（可选）",
+    "@repairEvaluateHint": {
+        "description": "评价内容输入框的占位提示。",
+        "type": "text"
+    },
+    "repairEvaluateSuccess": "评价成功",
+    "@repairEvaluateSuccess": {
+        "description": "评价成功后的提示。",
+        "type": "text"
+    },
     "serviceHallTitle": "办事大厅",
     "@serviceHallTitle": {
         "description": "办事大厅二级页面标题，列出可办理事项。",

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -1480,6 +1480,11 @@
         "description": "工单已评价状态文案。",
         "type": "text"
     },
+    "repairWithdrawn": "已撤回",
+    "@repairWithdrawn": {
+        "description": "工单已撤回状态文案。",
+        "type": "text"
+    },
     "repairEvaluateFailed": "评价失败，请稍后重试",
     "@repairEvaluateFailed": {
         "description": "评价失败后的提示。",

--- a/lib/models/repair.dart
+++ b/lib/models/repair.dart
@@ -314,7 +314,9 @@ class RepairTicketDetail {
   /// 是否允许无人时维修。
   final bool ifOnduty;
 
-  /// 状态数字（如 `"3"`）；映射文案见 [statusLabel]。
+  /// 状态数字（如 `"3"`）。中文状态文案以「我的动态」列表页的
+  /// [RepairTicket.statusLabel] 为准（后端直接返回中文）；
+  /// 详情页操作按钮仅用数字状态判断（如 `status == '4'` 且未评价 → 可评价）。
   final String status;
 
   /// 是否已评价（`"0"`=否）。
@@ -346,14 +348,6 @@ class RepairTicketDetail {
     this.logs = const [],
     this.finishedInfo,
   });
-
-  /// 状态中文文案（数字状态映射，与「我的动态」列表页文案一致）。
-  String get statusLabel => switch (status) {
-    '0' => '已关闭',
-    '1' => '待完工',
-    '2' => '已撤回',
-    _ => '待评价', // 3=待评价? / 4=待评价（可评价）
-  };
 
   factory RepairTicketDetail.fromJson(Map<String, dynamic> json) {
     final logRaw = json['logVOS'];

--- a/lib/models/repair.dart
+++ b/lib/models/repair.dart
@@ -153,11 +153,29 @@ class RepairAreaNode {
 
 /// 报修工单（`activeTemplateData/list`「我的动态」的行）。
 class RepairTicket {
+  /// 详情接口（`repairInfo/get`）使用的工单 id（= 列表行的 `activeId`）。
   final String id;
+
+  /// 列表行自己的 id（`activeId`，跳详情用）。
+  final String activeId;
+
+  /// 故障地点（content 解析自 `故障地点`）。
   final String areaName;
+
+  /// 维修项目（content 解析自 `维修项目`）。
   final String projectName;
+
+  /// 服务单位（content 解析自 `服务单位`，部分工单才有）。
+  final String serviceUnit;
+
+  /// 故障描述（content 解析自 `故障描述`）。
+  ///
+  /// 解析失败时回退为各字段拼接，**不会**展示原始 JSON 字符串。
   final String content;
+
+  /// 中文状态（后端直接返回：已关闭/待完工/待评价/已撤回）。
   final String status;
+
   final int createTime;
 
   /// 动态列表的展示时间（`activeTime`，`YYYY-MM-DD HH:mm:ss`），
@@ -166,11 +184,13 @@ class RepairTicket {
 
   const RepairTicket({
     required this.id,
-    required this.areaName,
-    required this.projectName,
-    required this.content,
-    required this.status,
-    required this.createTime,
+    this.activeId = '',
+    this.areaName = '',
+    this.projectName = '',
+    this.serviceUnit = '',
+    this.content = '',
+    this.status = '',
+    this.createTime = 0,
     this.activeTime = '',
   });
 
@@ -179,28 +199,242 @@ class RepairTicket {
 
   /// 从「我的动态」接口（`activeTemplateData/list`）的行构造工单。
   ///
-  /// 该接口的 `status` 直接是中文文案（已关闭/待完工/待评价/已撤回），
-  /// `content` 是 JSON 字符串（含维修项目/故障地点/故障描述）。
+  /// 该接口的 `status` 直接是中文文案（已关闭/待完工/待评价/已撤回）。
+  /// `content` 是 JSON 字符串（含维修项目/故障地点/服务单位/故障描述），
+  /// 但个别模板/异常数据可能是双层转义、或已是对象，这里统一兼容。
   factory RepairTicket.fromDynamicJson(Map<String, dynamic> json) {
-    Map<String, dynamic> parsed = const {};
-    final rawContent = json['content']?.toString() ?? '';
-    if (rawContent.isNotEmpty) {
-      try {
-        final decoded = jsonDecode(rawContent);
-        if (decoded is Map<String, dynamic>) parsed = decoded;
-      } catch (_) {
-        // content 非 JSON 时原样作为故障描述
-      }
-    }
+    final activeId =
+        json['activeId']?.toString() ?? json['id']?.toString() ?? '';
+    final parsed = _decodeContent(json['content']);
     return RepairTicket(
-      id: json['id']?.toString() ?? json['activeId']?.toString() ?? '',
+      // 详情接口用 activeId 作为 id；列表行自身有独立 id
+      id: activeId,
+      activeId: activeId,
       areaName: parsed['故障地点']?.toString() ?? '',
       projectName: parsed['维修项目']?.toString() ?? '',
-      content: parsed['故障描述']?.toString() ?? rawContent,
+      serviceUnit: parsed['服务单位']?.toString() ?? '',
+      content: _displayContent(parsed, json['content']),
       // 后端直接返回中文状态
       status: json['status']?.toString() ?? '',
       createTime: int.tryParse(json['createTime']?.toString() ?? '0') ?? 0,
       activeTime: json['activeTime']?.toString() ?? '',
+    );
+  }
+
+  /// 把 `content` 统一解析为 Map。
+  ///
+  /// 兼容三种形态：
+  /// - Map（后端已解析为对象）
+  /// - JSON 字符串（`{"维修项目":...}`）
+  /// - 双层转义 JSON 字符串（字符串内嵌 JSON 字符串，如 `"{\"维修项目\":...}"`）
+  static Map<String, dynamic> _decodeContent(dynamic content) {
+    var current = content;
+    // 最多解两层（字符串内再套字符串）
+    for (var i = 0; i < 2; i++) {
+      if (current is Map) {
+        return Map<String, dynamic>.from(current);
+      }
+      if (current is! String || current.trim().isEmpty) {
+        return const {};
+      }
+      final trimmed = current.trim();
+      // 快速判断是否 JSON：以 { 或 [ 开头
+      if (!trimmed.startsWith('{') && !trimmed.startsWith('[')) {
+        return const {};
+      }
+      try {
+        final decoded = jsonDecode(trimmed);
+        current = decoded;
+      } catch (_) {
+        return const {};
+      }
+    }
+    return current is Map ? Map<String, dynamic>.from(current) : const {};
+  }
+
+  /// 展示内容：优先「故障描述」字段；缺失时回退为字段拼接
+  /// （维修项目/故障地点/服务单位），**绝不**回退为原始 JSON 文本。
+  static String _displayContent(
+    Map<String, dynamic> parsed,
+    dynamic rawContent,
+  ) {
+    final desc = parsed['故障描述']?.toString();
+    if (desc != null && desc.trim().isNotEmpty) {
+      return desc;
+    }
+    final project = parsed['维修项目']?.toString() ?? '';
+    final location = parsed['故障地点']?.toString() ?? '';
+    final unit = parsed['服务单位']?.toString() ?? '';
+    final parts = [project, location, unit].where((s) => s.isNotEmpty);
+    if (parts.isNotEmpty) return parts.join(' · ');
+    // 完全无字段：content 本就不是 JSON 时原样展示（如纯文本描述）
+    if (rawContent is String && rawContent.isNotEmpty) {
+      final trimmed = rawContent.trim();
+      if (!trimmed.startsWith('{') && !trimmed.startsWith('[')) {
+        return trimmed;
+      }
+    }
+    return '';
+  }
+}
+
+/// 报修工单详情（`repairInfo/get` 返回）。
+///
+/// 字段与列表行（[RepairTicket]）完全不同：
+/// - `status` 是**数字**（如 `"3"`），需要映射为中文文案
+/// - `projectName`/`content` 已是纯文本（非 JSON）
+/// - `finishedInfo` 含完成信息（`repairId` 供评价请求使用）
+/// - `logVOS` 为工单进度时间线
+class RepairTicketDetail {
+  /// 工单 id（撤回报文用它）。
+  final String id;
+
+  /// 报修编号（如 `202609030009`）。
+  final String serialNumber;
+
+  /// 维修项目（已解析的纯文本）。
+  final String projectName;
+
+  /// 故障描述（纯文本）。
+  final String content;
+
+  /// 故障地点（`areaName` 可能为 `区域/楼栋`，`address` 为详细地址）。
+  final String areaName;
+  final String address;
+
+  /// 服务单位（负责人部门）。
+  final String acceptDeptName;
+
+  /// 收费类型（如「无偿」）。
+  final String payName;
+
+  /// 期望时间（`bookTimeString`，如 `2026-09-03 10:00-12:00`）。
+  final String bookTimeString;
+
+  /// 是否允许无人时维修。
+  final bool ifOnduty;
+
+  /// 状态数字（如 `"3"`）；映射文案见 [statusLabel]。
+  final String status;
+
+  /// 是否已评价（`"0"`=否）。
+  final String ifCommont;
+
+  /// 是否已办结（`"0"`=否）。
+  final String ifComplete;
+
+  /// 工单进度时间线（倒序，最新在前）。
+  final List<RepairLogItem> logs;
+
+  /// 完成信息（待评价工单用 `finishedInfo.repairId` 发评价）。
+  final RepairFinishedInfo? finishedInfo;
+
+  const RepairTicketDetail({
+    required this.id,
+    this.serialNumber = '',
+    this.projectName = '',
+    this.content = '',
+    this.areaName = '',
+    this.address = '',
+    this.acceptDeptName = '',
+    this.payName = '',
+    this.bookTimeString = '',
+    this.ifOnduty = false,
+    this.status = '',
+    this.ifCommont = '0',
+    this.ifComplete = '0',
+    this.logs = const [],
+    this.finishedInfo,
+  });
+
+  /// 状态中文文案（数字状态映射，与「我的动态」列表页文案一致）。
+  String get statusLabel => switch (status) {
+    '0' => '已关闭',
+    '1' => '待完工',
+    '2' => '已撤回',
+    _ => '待评价', // 3=待评价? / 4=待评价（可评价）
+  };
+
+  factory RepairTicketDetail.fromJson(Map<String, dynamic> json) {
+    final logRaw = json['logVOS'];
+    final logs = logRaw is List
+        ? logRaw
+              .whereType<Map>()
+              .map((e) => RepairLogItem.fromJson(Map<String, dynamic>.from(e)))
+              .toList(growable: false)
+        : const <RepairLogItem>[];
+    final finishedRaw = json['finishedInfo'];
+    final finishedInfo = finishedRaw is Map
+        ? RepairFinishedInfo.fromJson(Map<String, dynamic>.from(finishedRaw))
+        : null;
+    return RepairTicketDetail(
+      id: json['id']?.toString() ?? '',
+      serialNumber: json['serialNumber']?.toString() ?? '',
+      projectName: json['projectName']?.toString() ?? '',
+      content: json['content']?.toString() ?? '',
+      areaName: json['areaName']?.toString() ?? '',
+      address: json['address']?.toString() ?? '',
+      acceptDeptName: json['acceptDeptName']?.toString() ?? '',
+      payName: json['payName']?.toString() ?? '',
+      bookTimeString: json['bookTimeString']?.toString() ?? '',
+      ifOnduty: json['ifOnduty']?.toString() == '1',
+      status: json['status']?.toString() ?? '',
+      ifCommont: json['ifCommont']?.toString() ?? '0',
+      ifComplete: json['ifComplete']?.toString() ?? '0',
+      logs: logs,
+      finishedInfo: finishedInfo,
+    );
+  }
+}
+
+/// 工单进度时间线单条（`logVOS` 元素）。
+class RepairLogItem {
+  /// 状态名（如「派工」「审核」「报修」）。
+  final String statusName;
+
+  /// 描述内容（如「被【曾伟地】指派维修工…」）。
+  final String content;
+
+  /// 时间（`createTime`，`YYYY-MM-DD HH:mm:ss`）。
+  final String createTime;
+
+  const RepairLogItem({
+    this.statusName = '',
+    this.content = '',
+    this.createTime = '',
+  });
+
+  factory RepairLogItem.fromJson(Map<String, dynamic> json) {
+    return RepairLogItem(
+      statusName: json['statusName']?.toString() ?? '',
+      content: json['content']?.toString() ?? '',
+      createTime: json['createTime']?.toString() ?? '',
+    );
+  }
+}
+
+/// 工单完成信息（`finishedInfo`）。
+class RepairFinishedInfo {
+  /// 评价请求（`visitEvaluateUser/save`）使用的 `repairId`。
+  final String repairId;
+
+  /// 维修完成时间（`completeTime`）。
+  final String completeTime;
+
+  /// 实际收费金额。
+  final String totalAmount;
+
+  const RepairFinishedInfo({
+    this.repairId = '',
+    this.completeTime = '',
+    this.totalAmount = '',
+  });
+
+  factory RepairFinishedInfo.fromJson(Map<String, dynamic> json) {
+    return RepairFinishedInfo(
+      repairId: json['repairId']?.toString() ?? '',
+      completeTime: json['completeTime']?.toString() ?? '',
+      totalAmount: json['totalAmount']?.toString() ?? '',
     );
   }
 }

--- a/lib/models/repair.dart
+++ b/lib/models/repair.dart
@@ -432,3 +432,29 @@ class RepairFinishedInfo {
     );
   }
 }
+
+/// 工单评价项（`commontProject/getProject` 返回）。
+///
+/// 前端评价弹窗会逐项显示（如「维修质量/维修态度/维修速度」）并打分，
+/// 提交时 `common` 数组即这些对象的完整形态（`star` 为用户评分 1-5）。
+class RepairEvaluateProject {
+  final String id;
+  final String name;
+
+  /// 权重（如 50/25/25）。
+  final String weight;
+
+  const RepairEvaluateProject({
+    required this.id,
+    required this.name,
+    this.weight = '',
+  });
+
+  factory RepairEvaluateProject.fromJson(Map<String, dynamic> json) {
+    return RepairEvaluateProject(
+      id: json['id']?.toString() ?? '',
+      name: json['name']?.toString() ?? '',
+      weight: json['weight']?.toString() ?? '',
+    );
+  }
+}

--- a/lib/pages/campus/repair/repair_detail_page.dart
+++ b/lib/pages/campus/repair/repair_detail_page.dart
@@ -66,11 +66,8 @@ class _RepairDetailPageState extends State<RepairDetailPage> {
   }
 
   Future<void> _maybeCheckWithdraw(RepairTicketDetail detail) async {
-    // 仅对可能处于可撤回状态的工单查询（已关闭/已撤回没必要再查）
-    final status = detail.status;
-    final mayWithdraw =
-        status == '1' || status.isEmpty || detail.ifComplete != '1';
-    if (!mayWithdraw) return;
+    // 仅对未办结的工单查询是否可撤回（已办结/已关闭的工单不需要撤回按钮）
+    if (detail.ifComplete == '1') return;
     if (!mounted) return;
     setState(() => _loadingWithdrawCheck = true);
     final allow = await _provider.ifAllowWithdrawRepair(id: detail.id);
@@ -473,7 +470,19 @@ class _EvaluateDialogState extends State<_EvaluateDialog> {
 
   Future<void> _submit() async {
     setState(() => _submitting = true);
-    final ok = await widget.onConfirm(_score, _contentController.text.trim());
-    if (mounted) Navigator.of(context).pop(ok);
+    try {
+      final ok = await widget.onConfirm(_score, _contentController.text.trim());
+      if (mounted) Navigator.of(context).pop(ok);
+    } catch (e) {
+      // 评价接口失败：不关闭对话框，提示后允许重试
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(AppLocalizations.of(context)!.repairEvaluateFailed),
+          ),
+        );
+        setState(() => _submitting = false);
+      }
+    }
   }
 }

--- a/lib/pages/campus/repair/repair_detail_page.dart
+++ b/lib/pages/campus/repair/repair_detail_page.dart
@@ -358,16 +358,24 @@ class _RepairDetailPageState extends State<RepairDetailPage> {
     if (repairId.isEmpty) return;
     if (!mounted) return;
 
+    // 先加载评价项（维修质量/维修态度/维修速度，含 id/weight）
+    final projects = await _provider.fetchEvaluateProjects();
+    if (!mounted) return;
+    if (projects.isEmpty) {
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text(l10n.repairEvaluateFailed)));
+      return;
+    }
+
     final result = await showDialog<bool>(
       context: context,
       builder: (context) => _EvaluateDialog(
-        title: detail.projectName,
-        onConfirm: (score, content) async {
+        projects: projects,
+        onConfirm: (common, content) async {
           await _provider.evaluateRepair(
             repairId: repairId,
-            common: [
-              {'projectName': detail.projectName, 'score': score},
-            ],
+            common: common,
             content: content,
           );
           return true;
@@ -386,21 +394,33 @@ class _RepairDetailPageState extends State<RepairDetailPage> {
   }
 }
 
-/// 评价对话框：星级评分 + 可选评价内容。
+/// 评价对话框：逐项星级评分（对齐前端「维修质量/维修态度/维修速度」）
+/// + 可选评价内容。
+///
+/// 提交的 `common` 数组为评价项完整对象（`id`/`name`/`weight`/`star`），
+/// 与前端 `GetProjectList` 返回结构与 `VisitEvaluateUser` 请求体一致。
 class _EvaluateDialog extends StatefulWidget {
-  final String title;
-  final Future<bool> Function(int score, String content) onConfirm;
+  final List<RepairEvaluateProject> projects;
+  final Future<bool> Function(List<Map<String, dynamic>> common, String content)
+  onConfirm;
 
-  const _EvaluateDialog({required this.title, required this.onConfirm});
+  const _EvaluateDialog({required this.projects, required this.onConfirm});
 
   @override
   State<_EvaluateDialog> createState() => _EvaluateDialogState();
 }
 
 class _EvaluateDialogState extends State<_EvaluateDialog> {
-  int _score = 5;
+  /// 每项评价的星级（默认 5 星），key 为评价项 id。
+  late final Map<String, int> _scores;
   final _contentController = TextEditingController();
   bool _submitting = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _scores = {for (final p in widget.projects) p.id: 5};
+  }
 
   @override
   void dispose() {
@@ -408,50 +428,79 @@ class _EvaluateDialogState extends State<_EvaluateDialog> {
     super.dispose();
   }
 
+  /// 构建提交用的 common 数组（评价项完整对象 + star 评分）。
+  List<Map<String, dynamic>> _buildCommon() {
+    return [
+      for (final p in widget.projects)
+        {
+          'id': p.id,
+          'name': p.name,
+          'weight': p.weight,
+          'star': _scores[p.id] ?? 5,
+        },
+    ];
+  }
+
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
     return AlertDialog(
       title: Text(l10n.repairEvaluate),
-      content: Column(
-        mainAxisSize: MainAxisSize.min,
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          if (widget.title.isNotEmpty)
-            Text(
-              widget.title,
-              style: Theme.of(
-                context,
-              ).textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.w600),
-            ),
-          const SizedBox(height: 12),
-          Row(
-            mainAxisAlignment: MainAxisAlignment.center,
+      content: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 360),
+        child: SingleChildScrollView(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              for (var i = 1; i <= 5; i++)
-                IconButton(
-                  onPressed: _submitting
-                      ? null
-                      : () => setState(() => _score = i),
-                  icon: Icon(
-                    i <= _score ? Icons.star : Icons.star_border,
-                    color: i <= _score
-                        ? Colors.amber
-                        : Theme.of(context).colorScheme.outline,
+              // 逐项评价（维修质量/维修态度/维修速度等）
+              for (final project in widget.projects)
+                Padding(
+                  padding: const EdgeInsets.symmetric(vertical: 4),
+                  child: Row(
+                    children: [
+                      Expanded(
+                        child: Text(
+                          project.name,
+                          style: Theme.of(context).textTheme.bodyMedium,
+                        ),
+                      ),
+                      for (var i = 1; i <= 5; i++)
+                        IconButton(
+                          onPressed: _submitting
+                              ? null
+                              : () => setState(() => _scores[project.id] = i),
+                          iconSize: 26,
+                          visualDensity: VisualDensity.compact,
+                          padding: EdgeInsets.zero,
+                          constraints: const BoxConstraints(
+                            minWidth: 32,
+                            minHeight: 32,
+                          ),
+                          icon: Icon(
+                            i <= (_scores[project.id] ?? 0)
+                                ? Icons.star
+                                : Icons.star_border,
+                            color: i <= (_scores[project.id] ?? 0)
+                                ? Colors.amber
+                                : Theme.of(context).colorScheme.outline,
+                          ),
+                        ),
+                    ],
                   ),
                 ),
+              const SizedBox(height: 8),
+              TextField(
+                controller: _contentController,
+                maxLines: 3,
+                decoration: InputDecoration(
+                  hintText: l10n.repairEvaluateHint,
+                  border: const OutlineInputBorder(),
+                ),
+              ),
             ],
           ),
-          const SizedBox(height: 8),
-          TextField(
-            controller: _contentController,
-            maxLines: 3,
-            decoration: InputDecoration(
-              hintText: l10n.repairEvaluateHint,
-              border: const OutlineInputBorder(),
-            ),
-          ),
-        ],
+        ),
       ),
       actions: [
         TextButton(
@@ -471,7 +520,10 @@ class _EvaluateDialogState extends State<_EvaluateDialog> {
   Future<void> _submit() async {
     setState(() => _submitting = true);
     try {
-      final ok = await widget.onConfirm(_score, _contentController.text.trim());
+      final ok = await widget.onConfirm(
+        _buildCommon(),
+        _contentController.text.trim(),
+      );
       if (mounted) Navigator.of(context).pop(ok);
     } catch (e) {
       // 评价接口失败：不关闭对话框，提示后允许重试

--- a/lib/pages/campus/repair/repair_detail_page.dart
+++ b/lib/pages/campus/repair/repair_detail_page.dart
@@ -104,14 +104,12 @@ class _RepairDetailPageState extends State<RepairDetailPage> {
     try {
       await _provider.withdrawRepair(id: _detail!.id);
       if (!mounted) return false;
-      // 刷新列表，使「我的报修」状态同步为已撤回
-      await _provider.loadTickets(force: true);
-      if (!mounted) return false;
       ScaffoldMessenger.of(
         context,
       ).showSnackBar(SnackBar(content: Text(l10n.repairWithdrawSuccess)));
-      // 重新加载详情：撤回后详情接口状态变化（撤回按钮消失）
-      await _load();
+      // 返回列表页；列表刷新由 _openDetail 的 .then() 统一处理
+      // （activeTemplateData/list 会返回最新状态「已撤回」）。
+      Navigator.of(context).pop(true);
       return true;
     } catch (e) {
       if (!mounted) return false;
@@ -133,6 +131,23 @@ class _RepairDetailPageState extends State<RepairDetailPage> {
     );
   }
 
+  /// 详情页状态文案：按详情接口的最新状态映射。
+  ///
+  /// 详情接口 `status` 是数字（如 `'4'`=待评价可评价、`'2'`=已撤回），
+  /// 评价/撤回后列表传入的 initialStatus 会过期，必须按最新详情状态展示：
+  /// - 已评价（ifCommont=1）→「已评价」
+  /// - 已撤回（status=2）→「已撤回」
+  /// - 其余回退列表传入的中文状态
+  String _detailStatusText(
+    RepairTicketDetail detail,
+    String initialStatus,
+    AppLocalizations l10n,
+  ) {
+    if (detail.ifCommont == '1') return l10n.repairEvaluated;
+    if (detail.status == '2') return l10n.repairWithdrawn;
+    return initialStatus;
+  }
+
   Widget _buildBody(AppLocalizations l10n) {
     if (_error != null) {
       return RetryableErrorWidget(
@@ -150,11 +165,10 @@ class _RepairDetailPageState extends State<RepairDetailPage> {
     final title = detail.projectName.isNotEmpty
         ? detail.projectName
         : widget.initialTitle;
-    // 状态实时计算：已评价（ifCommont=1）优先展示「已评价」，
-    // 否则用列表传入的状态（详情接口的 status 是数字，无中文文案）。
-    final statusText = detail.ifCommont == '1'
-        ? l10n.repairEvaluated
-        : widget.initialStatus;
+    // 状态实时计算：优先按详情接口的最新状态展示（撤回/已评价等），
+    // 详情接口的 status 是数字（如 '2'=已撤回），若无法映射则回退
+    // 列表传入的中文状态。
+    final statusText = _detailStatusText(detail, widget.initialStatus, l10n);
     return ListView(
       padding: const EdgeInsets.all(16),
       children: [
@@ -389,14 +403,12 @@ class _RepairDetailPageState extends State<RepairDetailPage> {
       ),
     );
     if (result == true && mounted) {
-      // 评价成功：刷新工单列表，并重新加载详情使状态变为「已评价」、
-      // 评价按钮消失（详情接口 ifCommont 已变为 1）。
-      await _provider.loadTickets(force: true);
-      if (!mounted) return;
+      // 评价成功：返回列表页；列表刷新由 _openDetail 的 .then() 统一处理
+      // （activeTemplateData/list 会返回最新状态「已评价」）。
       ScaffoldMessenger.of(
         context,
       ).showSnackBar(SnackBar(content: Text(l10n.repairEvaluateSuccess)));
-      await _load();
+      Navigator.of(context).pop(true);
     }
   }
 }

--- a/lib/pages/campus/repair/repair_detail_page.dart
+++ b/lib/pages/campus/repair/repair_detail_page.dart
@@ -110,7 +110,8 @@ class _RepairDetailPageState extends State<RepairDetailPage> {
       ScaffoldMessenger.of(
         context,
       ).showSnackBar(SnackBar(content: Text(l10n.repairWithdrawSuccess)));
-      Navigator.of(context).pop(true);
+      // 重新加载详情：撤回后详情接口状态变化（撤回按钮消失）
+      await _load();
       return true;
     } catch (e) {
       if (!mounted) return false;
@@ -149,6 +150,11 @@ class _RepairDetailPageState extends State<RepairDetailPage> {
     final title = detail.projectName.isNotEmpty
         ? detail.projectName
         : widget.initialTitle;
+    // 状态实时计算：已评价（ifCommont=1）优先展示「已评价」，
+    // 否则用列表传入的状态（详情接口的 status 是数字，无中文文案）。
+    final statusText = detail.ifCommont == '1'
+        ? l10n.repairEvaluated
+        : widget.initialStatus;
     return ListView(
       padding: const EdgeInsets.all(16),
       children: [
@@ -166,7 +172,7 @@ class _RepairDetailPageState extends State<RepairDetailPage> {
                       fontWeight: FontWeight.w600,
                     ),
                   ),
-                if (widget.initialStatus.isNotEmpty)
+                if (statusText.isNotEmpty)
                   Padding(
                     padding: const EdgeInsets.only(top: 6),
                     child: Container(
@@ -181,7 +187,7 @@ class _RepairDetailPageState extends State<RepairDetailPage> {
                         borderRadius: BorderRadius.circular(AppShapes.small),
                       ),
                       child: Text(
-                        widget.initialStatus,
+                        statusText,
                         style: Theme.of(context).textTheme.bodySmall?.copyWith(
                           color: Theme.of(context).colorScheme.primary,
                           fontWeight: FontWeight.w600,
@@ -383,13 +389,14 @@ class _RepairDetailPageState extends State<RepairDetailPage> {
       ),
     );
     if (result == true && mounted) {
-      // 评价成功：刷新列表并返回
+      // 评价成功：刷新工单列表，并重新加载详情使状态变为「已评价」、
+      // 评价按钮消失（详情接口 ifCommont 已变为 1）。
       await _provider.loadTickets(force: true);
       if (!mounted) return;
       ScaffoldMessenger.of(
         context,
       ).showSnackBar(SnackBar(content: Text(l10n.repairEvaluateSuccess)));
-      Navigator.of(context).pop(true);
+      await _load();
     }
   }
 }

--- a/lib/pages/campus/repair/repair_detail_page.dart
+++ b/lib/pages/campus/repair/repair_detail_page.dart
@@ -1,0 +1,479 @@
+import 'package:flutter/material.dart';
+import 'package:bugaoshan/injection/injector.dart';
+import 'package:bugaoshan/l10n/app_localizations.dart';
+import 'package:bugaoshan/models/repair.dart';
+import 'package:bugaoshan/providers/zhhq_repair_provider.dart';
+import 'package:bugaoshan/theme_shape.dart';
+import 'package:bugaoshan/widgets/common/retryable_error_widget.dart';
+import 'package:bugaoshan/widgets/common/styled_card.dart';
+
+/// 报修工单详情页。
+///
+/// 展示工单的完整信息（维修项目/故障描述/故障地址/服务单位/收费类型/
+/// 期望时间/工单进度时间线），并根据工单状态提供「撤回」或「评价」操作：
+/// - 撤回：调用 `myRepair/withdrawMyRepair`（需先查 `ifAllowWithdrawMyRepair`）
+/// - 评价：调用 `visitEvaluateUser/save`（待评价且未评价的工单）
+class RepairDetailPage extends StatefulWidget {
+  /// 工单 id（列表的 `activeId`）。
+  final String ticketId;
+
+  /// 列表页传入的标题（可能为空，由详情回填）。
+  final String initialTitle;
+
+  /// 列表页传入的状态（可能为空，由详情回填）。
+  final String initialStatus;
+
+  const RepairDetailPage({
+    super.key,
+    required this.ticketId,
+    this.initialTitle = '',
+    this.initialStatus = '',
+  });
+
+  @override
+  State<RepairDetailPage> createState() => _RepairDetailPageState();
+}
+
+class _RepairDetailPageState extends State<RepairDetailPage> {
+  late final ZhhqRepairProvider _provider;
+  RepairTicketDetail? _detail;
+  Object? _error;
+  bool _allowWithdraw = false;
+  bool _loadingWithdrawCheck = false;
+  bool _operating = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _provider = getIt<ZhhqRepairProvider>();
+    _load();
+  }
+
+  Future<void> _load() async {
+    try {
+      final detail = await _provider.fetchTicketDetail(id: widget.ticketId);
+      if (!mounted) return;
+      setState(() {
+        _detail = detail;
+        _error = null;
+      });
+      // 状态为待撤回/处理中时查询是否可撤回
+      await _maybeCheckWithdraw(detail);
+    } catch (e) {
+      if (!mounted) return;
+      setState(() => _error = e);
+    }
+  }
+
+  Future<void> _maybeCheckWithdraw(RepairTicketDetail detail) async {
+    // 仅对可能处于可撤回状态的工单查询（已关闭/已撤回没必要再查）
+    final status = detail.status;
+    final mayWithdraw =
+        status == '1' || status.isEmpty || detail.ifComplete != '1';
+    if (!mayWithdraw) return;
+    if (!mounted) return;
+    setState(() => _loadingWithdrawCheck = true);
+    final allow = await _provider.ifAllowWithdrawRepair(id: detail.id);
+    if (!mounted) return;
+    setState(() {
+      _allowWithdraw = allow;
+      _loadingWithdrawCheck = false;
+    });
+  }
+
+  /// 撤回报修。成功返回 true。
+  Future<bool> _withdraw() async {
+    final l10n = AppLocalizations.of(context)!;
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: Text(l10n.repairWithdraw),
+        content: Text(l10n.repairWithdrawConfirm),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: Text(l10n.cancel),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: Text(l10n.confirm),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true || !mounted) return false;
+
+    setState(() => _operating = true);
+    try {
+      await _provider.withdrawRepair(id: _detail!.id);
+      if (!mounted) return false;
+      // 刷新列表，使「我的报修」状态同步为已撤回
+      await _provider.loadTickets(force: true);
+      if (!mounted) return false;
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text(l10n.repairWithdrawSuccess)));
+      Navigator.of(context).pop(true);
+      return true;
+    } catch (e) {
+      if (!mounted) return false;
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text(l10n.repairWithdrawFailed)));
+      return false;
+    } finally {
+      if (mounted) setState(() => _operating = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    return Scaffold(
+      appBar: AppBar(title: Text(l10n.repairDetail)),
+      body: _buildBody(l10n),
+    );
+  }
+
+  Widget _buildBody(AppLocalizations l10n) {
+    if (_error != null) {
+      return RetryableErrorWidget(
+        errorType: LoadErrorType.loadFailed,
+        onRetry: () {
+          setState(() => _error = null);
+          _load();
+        },
+      );
+    }
+    final detail = _detail;
+    if (detail == null) {
+      return const Center(child: CircularProgressIndicator());
+    }
+    final title = detail.projectName.isNotEmpty
+        ? detail.projectName
+        : widget.initialTitle;
+    return ListView(
+      padding: const EdgeInsets.all(16),
+      children: [
+        // 状态 + 标题
+        StyledCard(
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                if (title.isNotEmpty)
+                  Text(
+                    title,
+                    style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                if (widget.initialStatus.isNotEmpty)
+                  Padding(
+                    padding: const EdgeInsets.only(top: 6),
+                    child: Container(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 8,
+                        vertical: 2,
+                      ),
+                      decoration: BoxDecoration(
+                        color: Theme.of(
+                          context,
+                        ).colorScheme.primary.withValues(alpha: 0.12),
+                        borderRadius: BorderRadius.circular(AppShapes.small),
+                      ),
+                      child: Text(
+                        widget.initialStatus,
+                        style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                          color: Theme.of(context).colorScheme.primary,
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                    ),
+                  ),
+              ],
+            ),
+          ),
+        ),
+        const SizedBox(height: 12),
+        // 报修信息
+        StyledCard(
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                _label(l10n.repairProject, detail.projectName),
+                if (detail.content.isNotEmpty)
+                  _label(l10n.repairContent, detail.content),
+                if (detail.areaName.isNotEmpty || detail.address.isNotEmpty)
+                  _label(
+                    l10n.repairArea,
+                    [
+                      detail.areaName,
+                      detail.address,
+                    ].where((s) => s.isNotEmpty).join(' / '),
+                  ),
+                if (detail.acceptDeptName.isNotEmpty)
+                  _label(l10n.repairServiceUnit, detail.acceptDeptName),
+                if (detail.payName.isNotEmpty)
+                  _label(l10n.repairPayType, detail.payName),
+                if (detail.bookTimeString.isNotEmpty)
+                  _label(l10n.repairSchedule, detail.bookTimeString),
+              ],
+            ),
+          ),
+        ),
+        const SizedBox(height: 12),
+        // 操作按钮
+        if (_operatorVisible())
+          Padding(
+            padding: const EdgeInsets.symmetric(vertical: 4),
+            child: _buildOperator(l10n),
+          ),
+        // 工单进度
+        if (detail.logs.isNotEmpty) ...[
+          const SizedBox(height: 4),
+          StyledCard(
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    l10n.repairProgress,
+                    style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  for (final log in detail.logs) _buildLogItem(log),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ],
+    );
+  }
+
+  Widget _label(String label, String value) {
+    if (value.isEmpty) return const SizedBox.shrink();
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 4),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          SizedBox(
+            width: 88,
+            child: Text(
+              '$label:',
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                color: Theme.of(context).colorScheme.onSurfaceVariant,
+              ),
+            ),
+          ),
+          Expanded(
+            child: Text(value, style: Theme.of(context).textTheme.bodyMedium),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildLogItem(RepairLogItem log) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 6),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(
+            Icons.circle,
+            size: 8,
+            color: Theme.of(context).colorScheme.primary.withValues(alpha: 0.6),
+          ),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                if (log.statusName.isNotEmpty)
+                  Text(
+                    log.statusName,
+                    style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                if (log.content.isNotEmpty)
+                  Text(
+                    log.content,
+                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                      color: Theme.of(context).colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                if (log.createTime.isNotEmpty)
+                  Text(
+                    log.createTime,
+                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                      color: Theme.of(context).colorScheme.outline,
+                    ),
+                  ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  /// 是否显示操作按钮：待评价且未评价 → 评价；否则若允许撤回 → 撤回。
+  bool _operatorVisible() {
+    final detail = _detail;
+    if (detail == null) return false;
+    final pendingEvaluate = detail.status == '4' && detail.ifCommont == '0';
+    if (pendingEvaluate && detail.finishedInfo != null) return true;
+    return _allowWithdraw;
+  }
+
+  Widget _buildOperator(AppLocalizations l10n) {
+    final detail = _detail!;
+    final pendingEvaluate = detail.status == '4' && detail.ifCommont == '0';
+    if (pendingEvaluate && detail.finishedInfo != null) {
+      return FilledButton.icon(
+        onPressed: _operating ? null : () => _openEvaluate(l10n),
+        icon: const Icon(Icons.star_outline),
+        label: Text(l10n.repairEvaluate),
+      );
+    }
+    // 撤回（仅允许时）
+    return FilledButton.icon(
+      onPressed: _operating || _loadingWithdrawCheck ? null : _withdraw,
+      icon: const Icon(Icons.undo),
+      label: Text(l10n.repairWithdraw),
+    );
+  }
+
+  /// 打开评价对话框。
+  Future<void> _openEvaluate(AppLocalizations l10n) async {
+    final detail = _detail!;
+    final repairId = detail.finishedInfo?.repairId ?? '';
+    if (repairId.isEmpty) return;
+    if (!mounted) return;
+
+    final result = await showDialog<bool>(
+      context: context,
+      builder: (context) => _EvaluateDialog(
+        title: detail.projectName,
+        onConfirm: (score, content) async {
+          await _provider.evaluateRepair(
+            repairId: repairId,
+            common: [
+              {'projectName': detail.projectName, 'score': score},
+            ],
+            content: content,
+          );
+          return true;
+        },
+      ),
+    );
+    if (result == true && mounted) {
+      // 评价成功：刷新列表并返回
+      await _provider.loadTickets(force: true);
+      if (!mounted) return;
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text(l10n.repairEvaluateSuccess)));
+      Navigator.of(context).pop(true);
+    }
+  }
+}
+
+/// 评价对话框：星级评分 + 可选评价内容。
+class _EvaluateDialog extends StatefulWidget {
+  final String title;
+  final Future<bool> Function(int score, String content) onConfirm;
+
+  const _EvaluateDialog({required this.title, required this.onConfirm});
+
+  @override
+  State<_EvaluateDialog> createState() => _EvaluateDialogState();
+}
+
+class _EvaluateDialogState extends State<_EvaluateDialog> {
+  int _score = 5;
+  final _contentController = TextEditingController();
+  bool _submitting = false;
+
+  @override
+  void dispose() {
+    _contentController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    return AlertDialog(
+      title: Text(l10n.repairEvaluate),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          if (widget.title.isNotEmpty)
+            Text(
+              widget.title,
+              style: Theme.of(
+                context,
+              ).textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.w600),
+            ),
+          const SizedBox(height: 12),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              for (var i = 1; i <= 5; i++)
+                IconButton(
+                  onPressed: _submitting
+                      ? null
+                      : () => setState(() => _score = i),
+                  icon: Icon(
+                    i <= _score ? Icons.star : Icons.star_border,
+                    color: i <= _score
+                        ? Colors.amber
+                        : Theme.of(context).colorScheme.outline,
+                  ),
+                ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          TextField(
+            controller: _contentController,
+            maxLines: 3,
+            decoration: InputDecoration(
+              hintText: l10n.repairEvaluateHint,
+              border: const OutlineInputBorder(),
+            ),
+          ),
+        ],
+      ),
+      actions: [
+        TextButton(
+          onPressed: _submitting
+              ? null
+              : () => Navigator.of(context).pop(false),
+          child: Text(l10n.cancel),
+        ),
+        FilledButton(
+          onPressed: _submitting ? null : _submit,
+          child: Text(l10n.confirm),
+        ),
+      ],
+    );
+  }
+
+  Future<void> _submit() async {
+    setState(() => _submitting = true);
+    final ok = await widget.onConfirm(_score, _contentController.text.trim());
+    if (mounted) Navigator.of(context).pop(ok);
+  }
+}

--- a/lib/pages/campus/repair/repair_page.dart
+++ b/lib/pages/campus/repair/repair_page.dart
@@ -223,17 +223,21 @@ class _MyTicketsTab extends StatelessWidget {
 
   /// 点击工单卡片进入详情页（支持撤回/评价操作）。
   void _openDetail(BuildContext context, RepairTicket ticket) {
-    Navigator.of(context).push(
-      MaterialPageRoute(
-        builder: (_) => RepairDetailPage(
-          ticketId: ticket.id,
-          initialTitle: ticket.projectName.isEmpty
-              ? AppLocalizations.of(context)!.repairTicket
-              : ticket.projectName,
-          initialStatus: ticket.statusLabel,
-        ),
-      ),
-    );
+    Navigator.of(context)
+        .push(
+          MaterialPageRoute(
+            builder: (_) => RepairDetailPage(
+              ticketId: ticket.id,
+              initialTitle: ticket.projectName.isEmpty
+                  ? AppLocalizations.of(context)!.repairTicket
+                  : ticket.projectName,
+              initialStatus: ticket.statusLabel,
+            ),
+          ),
+        )
+        // 详情页可能发生了撤回/评价等状态变更，返回后强制刷新工单列表，
+        // 确保「我的报修」显示最新状态（否则可能因 provider 缓存显示旧值）。
+        .then((_) => provider.loadTickets(force: true));
   }
 
   Color _statusColor(BuildContext context, String status) {

--- a/lib/pages/campus/repair/repair_page.dart
+++ b/lib/pages/campus/repair/repair_page.dart
@@ -6,6 +6,7 @@ import 'package:image_picker/image_picker.dart';
 import 'package:bugaoshan/injection/injector.dart';
 import 'package:bugaoshan/l10n/app_localizations.dart';
 import 'package:bugaoshan/models/repair.dart';
+import 'package:bugaoshan/pages/campus/repair/repair_detail_page.dart';
 import 'package:bugaoshan/providers/scu_auth_provider.dart';
 import 'package:bugaoshan/providers/zhhq_repair_provider.dart';
 import 'package:bugaoshan/theme_shape.dart';
@@ -155,6 +156,7 @@ class _MyTicketsTab extends StatelessWidget {
     RepairTicket ticket,
   ) {
     return StyledCard(
+      onTap: () => _openDetail(context, ticket),
       child: Padding(
         padding: const EdgeInsets.all(16),
         child: Column(
@@ -199,6 +201,13 @@ class _MyTicketsTab extends StatelessWidget {
                 '${l10n.repairArea}: ${ticket.areaName}',
                 style: Theme.of(context).textTheme.bodySmall,
               ),
+            if (ticket.serviceUnit.isNotEmpty)
+              Text(
+                ticket.serviceUnit,
+                style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                  color: Theme.of(context).colorScheme.onSurfaceVariant,
+                ),
+              ),
             if (ticket.content.isNotEmpty)
               Text(
                 ticket.content,
@@ -207,6 +216,21 @@ class _MyTicketsTab extends StatelessWidget {
                 style: Theme.of(context).textTheme.bodyMedium,
               ),
           ],
+        ),
+      ),
+    );
+  }
+
+  /// 点击工单卡片进入详情页（支持撤回/评价操作）。
+  void _openDetail(BuildContext context, RepairTicket ticket) {
+    Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (_) => RepairDetailPage(
+          ticketId: ticket.id,
+          initialTitle: ticket.projectName.isEmpty
+              ? AppLocalizations.of(context)!.repairTicket
+              : ticket.projectName,
+          initialStatus: ticket.statusLabel,
         ),
       ),
     );

--- a/lib/pages/campus/repair/repair_page.dart
+++ b/lib/pages/campus/repair/repair_page.dart
@@ -119,7 +119,11 @@ class _MyTicketsTab extends StatelessWidget {
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
     final tickets = provider.tickets;
-    if (tickets.isEmpty && !provider.isLoadingTickets) {
+    // 首次加载中（列表为空且正在拉取）：显示加载指示，避免白屏
+    if (tickets.isEmpty && provider.isLoadingTickets) {
+      return const Center(child: CircularProgressIndicator());
+    }
+    if (tickets.isEmpty) {
       return RefreshIndicator(
         onRefresh: provider.loadTickets,
         child: ListView(
@@ -224,7 +228,7 @@ class _MyTicketsTab extends StatelessWidget {
   /// 点击工单卡片进入详情页（支持撤回/评价操作）。
   void _openDetail(BuildContext context, RepairTicket ticket) {
     Navigator.of(context)
-        .push(
+        .push<bool>(
           MaterialPageRoute(
             builder: (_) => RepairDetailPage(
               ticketId: ticket.id,
@@ -235,9 +239,11 @@ class _MyTicketsTab extends StatelessWidget {
             ),
           ),
         )
-        // 详情页可能发生了撤回/评价等状态变更，返回后强制刷新工单列表，
-        // 确保「我的报修」显示最新状态（否则可能因 provider 缓存显示旧值）。
-        .then((_) => provider.loadTickets(force: true));
+        // 详情页发生撤回/评价等状态变更时 pop(true)；仅此时强制刷新工单列表，
+        // 确保「我的报修」显示最新状态（普通返回无操作则不浪费一次请求）。
+        .then((changed) {
+          if (changed == true) provider.loadTickets(force: true);
+        });
   }
 
   Color _statusColor(BuildContext context, String status) {
@@ -526,6 +532,7 @@ class _SubmitTabState extends State<_SubmitTab> {
           child: Padding(
             padding: const EdgeInsets.all(16),
             child: _ProjectSelector(
+              provider: widget.provider,
               areaId: _selectedAddress?.areaId,
               value: _projectValue,
               label: _projectLabel,
@@ -754,12 +761,14 @@ class _SubmitTabState extends State<_SubmitTab> {
 /// 维修项目选择器（按区域加载，两级：大类 → 具体项目）。
 class _ProjectSelector extends StatefulWidget {
   const _ProjectSelector({
+    required this.provider,
     required this.areaId,
     required this.value,
     required this.label,
     required this.onChanged,
   });
 
+  final ZhhqRepairProvider provider;
   final String? areaId;
   final String? value;
   final String label;
@@ -801,7 +810,7 @@ class _ProjectSelectorState extends State<_ProjectSelector> {
     if (areaId == null || areaId.isEmpty) return;
     setState(() => _loading = true);
     try {
-      final projects = await getIt<ZhhqRepairProvider>().fetchProjects(areaId);
+      final projects = await widget.provider.fetchProjects(areaId);
       if (mounted) setState(() => _categories = projects);
     } catch (_) {
       if (mounted) setState(() => _categories = const []);

--- a/lib/providers/zhhq_repair_provider.dart
+++ b/lib/providers/zhhq_repair_provider.dart
@@ -205,6 +205,42 @@ class ZhhqRepairProvider extends ChangeNotifier {
     }
   }
 
+  /// 获取工单详情（详情页用）。失败抛异常（页面临时展示）。
+  Future<RepairTicketDetail> fetchTicketDetail({required String id}) {
+    return _api.fetchRepairDetail(id: id);
+  }
+
+  /// 查询当前工单是否允许撤回；失败返回 false。
+  Future<bool> ifAllowWithdrawRepair({required String id}) async {
+    try {
+      return await _api.ifAllowWithdrawRepair(id: id);
+    } on ScuException {
+      return false;
+    }
+  }
+
+  /// 撤回报修工单；成功后工单列表需重新拉取。
+  Future<void> withdrawRepair({required String id}) async {
+    await _api.withdrawRepair(id: id);
+    _ticketsLoaded = false;
+  }
+
+  /// 评价报修工单；成功后工单列表需重新拉取。
+  Future<void> evaluateRepair({
+    required String repairId,
+    required List<Map<String, dynamic>> common,
+    String content = '',
+    List<String> labels = const [],
+  }) async {
+    await _api.evaluateRepair(
+      repairId: repairId,
+      common: common,
+      content: content,
+      labels: labels,
+    );
+    _ticketsLoaded = false;
+  }
+
   /// 新增常用报修地址，成功后刷新地址列表。
   Future<bool> addAddress({
     required String areaId,

--- a/lib/providers/zhhq_repair_provider.dart
+++ b/lib/providers/zhhq_repair_provider.dart
@@ -241,6 +241,15 @@ class ZhhqRepairProvider extends ChangeNotifier {
     _ticketsLoaded = false;
   }
 
+  /// 获取工单评价项（维修质量/维修态度/维修速度等）。失败返回空列表。
+  Future<List<RepairEvaluateProject>> fetchEvaluateProjects() async {
+    try {
+      return await _api.fetchEvaluateProjects();
+    } on ScuException {
+      return const [];
+    }
+  }
+
   /// 新增常用报修地址，成功后刷新地址列表。
   Future<bool> addAddress({
     required String areaId,

--- a/lib/providers/zhhq_repair_provider.dart
+++ b/lib/providers/zhhq_repair_provider.dart
@@ -184,9 +184,14 @@ class ZhhqRepairProvider extends ChangeNotifier {
   /// 不再需要分页。userId 从常用地址取（[RepairAddress.userId]）。
   ///
   /// 页面每次重建都会调用本方法（fire-and-forget），因此默认跳过已加载
-  /// 的会话；下拉刷新或提交成功后需重新拉取时传 [force] = true。
+  /// 的会话；下拉刷新或提交/撤回/评价成功后需重新拉取时传 [force] = true。
   Future<void> loadTickets({bool force = false}) async {
-    if (!_canLoad || _isLoadingTickets) return;
+    if (!_canLoad) return;
+    // force 刷新：等待进行中的加载完成后再重新拉取，避免被并发守卫吞掉
+    // （如详情页撤回/评价后立即 force 刷新，而下层页面仍在 fire-and-forget 加载）。
+    while (_isLoadingTickets) {
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+    }
     if (!force && _ticketsLoaded) return;
     final userId = _addresses.isEmpty ? '' : _addresses.first.userId;
     if (userId.isEmpty) return;

--- a/lib/services/api/zhhq_api_service.dart
+++ b/lib/services/api/zhhq_api_service.dart
@@ -75,12 +75,16 @@ class ZhhqApiService {
     return r.toString();
   }
 
-  Future<T> _request<T>(
+  /// 统一请求执行：拿到可用 client + tokenKey 后调用 [fn]。
+  ///
+  /// 认证获取策略（所有业务请求共用，含 multipart 上传）：
+  /// 1. 快速路径：tokenKey 已持久化/缓存时，跳过 SCU 会话（冷启动 SCU 过期
+  ///    也无需等 5-8s refresh），直接用独立 CookieClient 发请求。
+  ///    业务请求只依赖 Token/TokenKey 头，不依赖 SCU cookie。
+  /// 2. tokenKey 失效（4010-4017）：invalidate 后走完整认证重建重试一次。
+  Future<T> _executeWithRetry<T>(
     Future<T> Function(CookieClient client, String tokenKey) fn,
   ) async {
-    // 快速路径：tokenKey 已持久化/缓存时，跳过 SCU 会话（冷启动 SCU 过期
-    // 也无需等 5-8s refresh），直接用独立 CookieClient 发请求。
-    // 业务请求只依赖 Token/TokenKey 头，不依赖 SCU cookie。
     final fastClient = _auth.getClientFast();
     final fastTokenKey = _auth.tokenKey;
     if (fastClient != null && fastTokenKey != null) {
@@ -104,6 +108,12 @@ class ZhhqApiService {
       if (tokenKey == null) throw const UnauthenticatedException();
       return await fn(client, tokenKey);
     }
+  }
+
+  Future<T> _request<T>(
+    Future<T> Function(CookieClient client, String tokenKey) fn,
+  ) {
+    return _executeWithRetry(fn);
   }
 
   Map<String, String> _headers(
@@ -142,7 +152,6 @@ class ZhhqApiService {
       throw ServiceException('zhhq 响应解析失败');
     }
     final code = json['errorCode']?.toString() ?? '';
-    final status = json['status']?.toString() ?? '';
     // 4010-4017 均为 token 类错误（无效/超时/签名错误），触发重新认证
     final codeInt = int.tryParse(code);
     if (codeInt != null && codeInt >= 4010 && codeInt <= 4017) {
@@ -150,15 +159,27 @@ class ZhhqApiService {
       throw const UnauthenticatedException('zhhq 会话已失效');
     }
     // 业务错误统一判定：status 明确非 success，或 errorCode 明确非 0。
-    // （原来 `status != 'success' && errorCode != null` 会放过
-    //   status 非 success 但 errorCode 缺失的响应，导致错误被当成功返回。）
-    if ((status.isNotEmpty && status != 'success') ||
-        (code.isNotEmpty && code != '0')) {
-      final message = json['message']?.toString() ?? '操作失败';
+    final message = _businessErrorMessage(json);
+    if (message != null) {
       _log.w('ZHhq', '业务错误 errorCode=$code: $message');
       throw ServiceException(message);
     }
     return json;
+  }
+
+  /// 业务错误统一判定：status 明确非 success，或 errorCode 明确非 0。
+  ///
+  /// 返回服务端 `message`（可展示给用户）；无错误返回 null。
+  /// （原来 `status != 'success' && errorCode != null` 会放过
+  ///   status 非 success 但 errorCode 缺失的响应，导致错误被当成功返回。）
+  static String? _businessErrorMessage(Map<String, dynamic> json) {
+    final code = json['errorCode']?.toString() ?? '';
+    final status = json['status']?.toString() ?? '';
+    if ((status.isNotEmpty && status != 'success') ||
+        (code.isNotEmpty && code != '0')) {
+      return json['message']?.toString() ?? '操作失败';
+    }
+    return null;
   }
 
   /// 获取常用地址列表。
@@ -488,26 +509,12 @@ class ZhhqApiService {
   ///
   /// 对应前端 `POST /api/file/upload`（multipart：`file` + `system=manager`）。
   /// 注意：本接口响应是**明文 JSON**（拦截器对 `/api/file/upload` 跳过 AES 解密），
-  /// 不走 `_request`/`_decode`，直接解析。
-  Future<String> uploadImage({required File file}) async {
-    // 快速路径优先：tokenKey 有效时无需等待 SCU 会话（与 _request 模板一致）。
-    // 失效时 invalidate + 完整认证后重试一次（multipart 上传幂等，可安全重放）。
-    var client = _auth.getClientFast();
-    var tokenKey = _auth.tokenKey;
-    if (client == null || tokenKey == null) {
-      client = await _auth.getClient();
-      tokenKey = _auth.tokenKey;
-    }
-    try {
-      if (tokenKey == null) throw const UnauthenticatedException();
-      return await _uploadImageWith(client, tokenKey, file);
-    } on UnauthenticatedException {
-      _auth.invalidate();
-      client = await _auth.getClient();
-      tokenKey = _auth.tokenKey;
-      if (tokenKey == null) throw const UnauthenticatedException();
-      return await _uploadImageWith(client, tokenKey, file);
-    }
+  /// 不走 `_decode`，直接解析。
+  Future<String> uploadImage({required File file}) {
+    // 与 _request 共用认证获取/重试逻辑（multipart 上传幂等，可安全重放）
+    return _executeWithRetry(
+      (client, tokenKey) => _uploadImageWith(client, tokenKey, file),
+    );
   }
 
   Future<String> _uploadImageWith(
@@ -537,14 +544,10 @@ class ZhhqApiService {
     } catch (_) {
       throw ServiceException('图片上传失败：响应解析异常');
     }
-    // 与 _decode 的业务错误判定一致：status 明确非 success 或
-    // errorCode 明确非 0 均视为失败（原来用 `&&` 会放过
-    // errorCode 非 0 但 status=success 的响应）。
-    final code = json['errorCode']?.toString() ?? '';
-    final status = json['status']?.toString() ?? '';
-    if ((status.isNotEmpty && status != 'success') ||
-        (code.isNotEmpty && code != '0')) {
-      throw ServiceException(json['message']?.toString() ?? '图片上传失败');
+    // 与 _decode 共用业务错误判定
+    final message = _businessErrorMessage(json);
+    if (message != null) {
+      throw ServiceException(message);
     }
     final data = json['data'];
     if (data is! Map) throw const ServiceException('图片上传失败：响应异常');

--- a/lib/services/api/zhhq_api_service.dart
+++ b/lib/services/api/zhhq_api_service.dart
@@ -352,8 +352,33 @@ class ZhhqApiService {
 
   /// 评价报修工单（`visitEvaluateUser/save`，web 前端 `VisitEvaluateUser`）。
   ///
+  /// 获取工单评价项（`commontProject/getProject`，web 前端 `GetProjectList`）。
+  ///
+  /// 返回评价维度列表（如「维修质量/维修态度/维修速度」），每项含
+  /// `id`/`name`/`weight`；用户逐项打分后填 `star`（1-5）并随评价提交。
+  Future<List<RepairEvaluateProject>> fetchEvaluateProjects() async {
+    final json = await _request((client, tokenKey) async {
+      final resp = await client.post(
+        Uri.parse('$_base/repair/commontProject/getProject'),
+        headers: _headers(client, tokenKey),
+      );
+      return _decode(resp.body, resp.statusCode);
+    });
+    final data = json['data'];
+    if (data is! List) return const [];
+    return data
+        .whereType<Map>()
+        .map(
+          (e) => RepairEvaluateProject.fromJson(Map<String, dynamic>.from(e)),
+        )
+        .toList(growable: false);
+  }
+
+  /// 评价报修工单（`visitEvaluateUser/save`，web 前端 `VisitEvaluateUser`）。
+  ///
   /// [repairId] 为详情中 `finishedInfo.repairId`（工单完成后的评价对象 id）；
-  /// [common] 为各评价项目评分；[labels] 为评价标签。
+  /// [common] 为评价项数组（前端直接提交 `GetProjectList` 返回的完整对象，
+  /// 每项含 `id`/`name`/`weight`，用户打分后 `star` 为 1-5）；[labels] 为评价标签。
   Future<void> evaluateRepair({
     required String repairId,
     required List<Map<String, dynamic>> common,

--- a/lib/services/api/zhhq_api_service.dart
+++ b/lib/services/api/zhhq_api_service.dart
@@ -254,8 +254,6 @@ class ZhhqApiService {
   /// 可从常用地址（[RepairAddress.userId]）获取。
   Future<List<RepairTicket>> fetchDynamicTickets({
     required String userId,
-    int page = 1,
-    int pageSize = 50,
   }) async {
     final json = await _request((client, tokenKey) async {
       // 与前端请求参数完全一致（抓包确认）：

--- a/lib/services/api/zhhq_api_service.dart
+++ b/lib/services/api/zhhq_api_service.dart
@@ -247,7 +247,8 @@ class ZhhqApiService {
   /// 使用 `manager/activeTemplateData/list`（首页「我的动态」同源接口）：
   /// - **快**：~600ms（`oneNetPublish/myList` 需 20s+）
   /// - 返回的 `status` 直接是中文文案（已关闭/待完工/待评价/已撤回）
-  /// - `content` 为 JSON 字符串（维修项目/故障地点/故障描述）
+  /// - `content` 为 JSON 字符串或对象（维修项目/故障地点/服务单位/故障描述），
+  ///   由 [RepairTicket.fromDynamicJson] 统一兼容解析
   ///
   /// [userId] 为当前用户的 `createUser`（用于筛选本人工单），
   /// 可从常用地址（[RepairAddress.userId]）获取。
@@ -257,23 +258,28 @@ class ZhhqApiService {
     int pageSize = 50,
   }) async {
     final json = await _request((client, tokenKey) async {
+      // 与前端请求参数完全一致（抓包确认）：
+      // - search 数组每条用 searchValue（非 value）
+      // - systemCode 放进 search 数组，而非顶层字段
+      // - 带 order 排序参数，无 pageIndex/pageSize
       final search = jsonEncode([
         {
           'andOr': 'and',
           'searchField': 'createUser',
           'operator': '=',
-          'value': userId,
+          'searchValue': userId,
+        },
+        {
+          'andOr': 'and',
+          'searchField': 'systemCode',
+          'operator': '=',
+          'searchValue': 'newRepair',
         },
       ]);
       final resp = await client.post(
         Uri.parse('$_base/manager/activeTemplateData/list'),
         headers: _headers(client, tokenKey),
-        body: {
-          'pageIndex': '$page',
-          'pageSize': '$pageSize',
-          'systemCode': 'newRepair',
-          'search': search,
-        },
+        body: {'search': search, 'order': 'createTime desc'},
       );
       return _decode(resp.body, resp.statusCode);
     });
@@ -295,6 +301,82 @@ class ZhhqApiService {
       return b.createTime.compareTo(a.createTime);
     });
     return tickets;
+  }
+
+  /// 获取报修工单详情（`repairInfo/get`，web 前端 `A.a.Get`）。
+  ///
+  /// [id] 传入列表行的 `activeId`（web 详情路由 `repairDetail?id=` 即用它）。
+  ///
+  /// 返回字段与列表行不同：`status` 是数字（如 `"3"`）、`projectName`
+  /// 已解析为纯文本、`content` 是纯描述文本。
+  Future<RepairTicketDetail> fetchRepairDetail({required String id}) async {
+    final json = await _request((client, tokenKey) async {
+      final resp = await client.post(
+        Uri.parse('$_base/repair/repairInfo/get'),
+        headers: _headers(client, tokenKey),
+        body: {'id': id},
+      );
+      return _decode(resp.body, resp.statusCode);
+    });
+    final data = json['data'];
+    if (data is! Map) throw const ServiceException('报修详情数据异常');
+    return RepairTicketDetail.fromJson(Map<String, dynamic>.from(data));
+  }
+
+  /// 查询当前工单是否允许撤回（`myRepair/ifAllowWithdrawMyRepair`）。
+  ///
+  /// 返回 `data`（用于控制「撤回」按钮是否可点）。
+  Future<bool> ifAllowWithdrawRepair({required String id}) async {
+    final json = await _request((client, tokenKey) async {
+      final resp = await client.post(
+        Uri.parse('$_base/repair/myRepair/ifAllowWithdrawMyRepair'),
+        headers: _headers(client, tokenKey),
+        body: {'id': id},
+      );
+      return _decode(resp.body, resp.statusCode);
+    });
+    final data = json['data'];
+    if (data is bool) return data;
+    return data?.toString() == 'true' || data?.toString() == '1';
+  }
+
+  /// 撤回报修工单（`myRepair/withdrawMyRepair`）。
+  Future<void> withdrawRepair({required String id}) async {
+    await _request((client, tokenKey) async {
+      final resp = await client.post(
+        Uri.parse('$_base/repair/myRepair/withdrawMyRepair'),
+        headers: _headers(client, tokenKey),
+        body: {'id': id},
+      );
+      return _decode(resp.body, resp.statusCode);
+    });
+  }
+
+  /// 评价报修工单（`visitEvaluateUser/save`，web 前端 `VisitEvaluateUser`）。
+  ///
+  /// [repairId] 为详情中 `finishedInfo.repairId`（工单完成后的评价对象 id）；
+  /// [common] 为各评价项目评分；[labels] 为评价标签。
+  Future<void> evaluateRepair({
+    required String repairId,
+    required List<Map<String, dynamic>> common,
+    String content = '',
+    List<String> labels = const [],
+  }) async {
+    final payload = {
+      'common': common,
+      'content': content,
+      'repairId': repairId,
+      'source': '0',
+      'label': labels.join(','),
+    };
+    await _request((client, tokenKey) async {
+      final resp = await client.post(
+        Uri.parse('$_base/repair/visitEvaluateUser/save'),
+        headers: _headers(client, tokenKey, json: true),
+        body: jsonEncode(payload),
+      );
+      return _decode(resp.body, resp.statusCode);
+    });
   }
 
   /// 保存（新增）常用报修地址。

--- a/lib/services/api/zhhq_api_service.dart
+++ b/lib/services/api/zhhq_api_service.dart
@@ -350,8 +350,6 @@ class ZhhqApiService {
     });
   }
 
-  /// 评价报修工单（`visitEvaluateUser/save`，web 前端 `VisitEvaluateUser`）。
-  ///
   /// 获取工单评价项（`commontProject/getProject`，web 前端 `GetProjectList`）。
   ///
   /// 返回评价维度列表（如「维修质量/维修态度/维修速度」），每项含

--- a/test/repair_ticket_model_test.dart
+++ b/test/repair_ticket_model_test.dart
@@ -1,0 +1,105 @@
+import 'package:bugaoshan/models/repair.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('RepairTicket.fromDynamicJson content 解析', () {
+    test('标准 JSON 字符串（含服务单位）正常解析', () {
+      final ticket = RepairTicket.fromDynamicJson({
+        'activeId': 'abc123',
+        'status': '待评价',
+        'createTime': '1728000000000',
+        'activeTime': '2026-09-03 07:49:23',
+        'content':
+            '{"维修项目":"水/上下水管类","故障地点":"望江学生区/东苑五栋主楼315",'
+            '"服务单位":"维修与通讯服务中心望江校区","故障描述":"冲水时水管连接处大量漏水"}',
+      });
+      expect(ticket.id, 'abc123');
+      expect(ticket.activeId, 'abc123');
+      expect(ticket.projectName, '水/上下水管类');
+      expect(ticket.areaName, '望江学生区/东苑五栋主楼315');
+      expect(ticket.serviceUnit, '维修与通讯服务中心望江校区');
+      expect(ticket.content, '冲水时水管连接处大量漏水');
+      expect(ticket.status, '待评价');
+    });
+
+    test('content 已是对象（非字符串）也能解析', () {
+      // issue #273：个别工单 content 可能是后端已解析为对象
+      final ticket = RepairTicket.fromDynamicJson({
+        'activeId': 'obj-1',
+        'content': {
+          '维修项目': '水/下水疏通类',
+          '故障地点': '某校区某宿舍楼',
+          '服务单位': '维护中心',
+          '故障描述': '下水道堵塞',
+        },
+      });
+      expect(ticket.projectName, '水/下水疏通类');
+      expect(ticket.areaName, '某校区某宿舍楼');
+      expect(ticket.serviceUnit, '维护中心');
+      expect(ticket.content, '下水道堵塞');
+    });
+
+    test('双层转义 JSON 字符串也能解析', () {
+      // content 是字符串，内含转义的 JSON 字符串
+      final inner = jsonEncodeStr({
+        '维修项目': '电/室内照明类',
+        '故障地点': '江安学生区/西苑八栋',
+        '故障描述': '阳台灯不亮',
+      });
+      final ticket = RepairTicket.fromDynamicJson({
+        'activeId': 'esc-1',
+        'content': inner,
+      });
+      expect(ticket.projectName, '电/室内照明类');
+      expect(ticket.areaName, '江安学生区/西苑八栋');
+      expect(ticket.content, '阳台灯不亮');
+    });
+
+    test('解析失败不回退为原始 JSON 文本（issue #273 核心）', () {
+      // 无法解析的 content：展示字段拼接或空，绝不显示原始 JSON
+      final ticket = RepairTicket.fromDynamicJson({
+        'activeId': 'bad-1',
+        'content': '{"维修项目":"未知模板","extra":"..."}',
+      });
+      // 有字段时展示拼接内容
+      expect(ticket.projectName, '未知模板');
+      expect(ticket.content, contains('未知模板'));
+      expect(ticket.content, isNot(contains('"维修项目"'))); // 不出现 JSON 键
+    });
+
+    test('content 非 JSON 纯文本时原样作为描述', () {
+      final ticket = RepairTicket.fromDynamicJson({
+        'activeId': 'txt-1',
+        'content': '柜门坏了，请尽快维修',
+      });
+      expect(ticket.content, '柜门坏了，请尽快维修');
+      expect(ticket.projectName, '');
+    });
+
+    test('content 缺失时各字段为空不崩溃', () {
+      final ticket = RepairTicket.fromDynamicJson({
+        'activeId': 'empty-1',
+        'status': '已撤回',
+      });
+      expect(ticket.content, '');
+      expect(ticket.projectName, '');
+      expect(ticket.areaName, '');
+      expect(ticket.status, '已撤回');
+    });
+
+    test('activeId 缺失时回退 id', () {
+      final ticket = RepairTicket.fromDynamicJson({
+        'id': 'fallback-id',
+        'content': '{"维修项目":"木/床柜类","故障描述":"柜门倾斜"}',
+      });
+      expect(ticket.id, 'fallback-id');
+      expect(ticket.activeId, 'fallback-id');
+    });
+  });
+}
+
+/// 用标准 JSON 编码（避免引号转义手写错误）。
+String jsonEncodeStr(Map<String, String> map) {
+  final entries = map.entries.map((e) => '"${e.key}":"${e.value}"').join(',');
+  return '{$entries}';
+}

--- a/test/zhhq_api_service_test.dart
+++ b/test/zhhq_api_service_test.dart
@@ -380,39 +380,38 @@ void main() {
       },
     );
 
-    test(
-      'HTTP 302/401/403 → UnauthenticatedException → invalidate 并重试',
-      () async {
-        var calls = 0;
-        final inner = MockClient((request) async {
-          calls++;
-          if (calls == 1) {
-            return http.Response('', 302, request: request);
-          }
-          final bytes = utf8.encode(
-            jsonEncode({
-              'status': 'success',
-              'errorCode': '0',
-              'data': {'path': '/upload/2026/abc.jpg'},
-            }),
-          );
-          return http.Response.bytes(
-            bytes,
-            200,
-            headers: const {'content-type': 'application/json; charset=utf-8'},
-            request: request,
-          );
-        });
-        final auth = _FakeZhhqAuth(inner);
-        final api = ZhhqApiService(auth);
+    test('HTTP 302/401/403 → UnauthenticatedException → 完整认证重试成功', () async {
+      var calls = 0;
+      final inner = MockClient((request) async {
+        calls++;
+        if (calls == 1) {
+          return http.Response('', 302, request: request);
+        }
+        final bytes = utf8.encode(
+          jsonEncode({
+            'status': 'success',
+            'errorCode': '0',
+            'data': {'path': '/upload/2026/abc.jpg'},
+          }),
+        );
+        return http.Response.bytes(
+          bytes,
+          200,
+          headers: const {'content-type': 'application/json; charset=utf-8'},
+          request: request,
+        );
+      });
+      final auth = _FakeZhhqAuth(inner);
+      final api = ZhhqApiService(auth);
 
-        final file = await _tempImage();
-        final path = await api.uploadImage(file: file);
-        expect(path, '/upload/2026/abc.jpg');
-        expect(calls, 2);
-        expect(auth.invalidateCount, 1);
-      },
-    );
+      final file = await _tempImage();
+      final path = await api.uploadImage(file: file);
+      expect(path, '/upload/2026/abc.jpg');
+      expect(calls, 2);
+      // fast path 失效走完整认证重试（与 _request 模板一致：fast 失效
+      // 不立即 invalidate，留给完整路径一次机会；仅完整路径也失败才重建）
+      expect(auth.invalidateCount, 0);
+    });
   });
 }
 

--- a/test/zhhq_api_service_test.dart
+++ b/test/zhhq_api_service_test.dart
@@ -275,7 +275,12 @@ void main() {
       await api.evaluateRepair(
         repairId: 'fin-1',
         common: [
-          {'projectName': '水/上下水管类', 'score': 5},
+          {
+            'id': '7adc451a-1e9e-4016-bd3d-63f15efdb816',
+            'name': '维修质量',
+            'weight': '50',
+            'star': 5,
+          },
         ],
         content: '很好',
         labels: const ['及时'],
@@ -286,8 +291,59 @@ void main() {
       expect(decoded['repairId'], 'fin-1');
       expect(decoded['source'], '0');
       expect(decoded['label'], '及时');
+      // 提交的 common 含完整评价项对象（id/name/weight/star）
+      final common = decoded['common'] as List;
+      expect(common, hasLength(1));
+      final item = common.single as Map;
+      expect(item['id'], '7adc451a-1e9e-4016-bd3d-63f15efdb816');
+      expect(item['name'], '维修质量');
+      expect(item['weight'], '50');
+      expect(item['star'], 5);
       // JSON content-type
       expect(capturedHeaders!['Content-Type'], contains('application/json'));
+    });
+
+    test('fetchEvaluateProjects 调用 commontProject/getProject 返回评价项', () async {
+      final paths = <String>[];
+      late MockClient inner;
+      inner = MockClient((request) async {
+        // getProject 请求体为空（前端 A.a.stringify() 无参数），按路径收集
+        paths.add(request.url.path);
+        return _authResponse({
+          'status': 'success',
+          'errorCode': '0',
+          'data': [
+            {
+              'id': '7adc451a-1e9e-4016-bd3d-63f15efdb816',
+              'name': '维修质量',
+              'weight': 50,
+            },
+            {
+              'id': 'b705e0ce-659a-4b72-a447-2dd5fc333315',
+              'name': '维修态度',
+              'weight': 25,
+            },
+            {
+              'id': 'eaa47855-0a4d-49e4-97a3-1c3927e19332',
+              'name': '维修速度',
+              'weight': 25,
+            },
+          ],
+        });
+      });
+      final auth = _FakeZhhqAuth(inner);
+      final api = ZhhqApiService(auth);
+
+      final projects = await api.fetchEvaluateProjects();
+      // 第一个请求可能是 CookieClient 域探测（非业务路径），业务路径必须出现
+      expect(
+        paths.where((p) => p.endsWith('/repair/commontProject/getProject')),
+        isNotEmpty,
+      );
+      expect(projects, hasLength(3));
+      expect(projects.first.name, '维修质量');
+      expect(projects.first.id, '7adc451a-1e9e-4016-bd3d-63f15efdb816');
+      expect(projects.first.weight, '50');
     });
   });
 

--- a/test/zhhq_api_service_test.dart
+++ b/test/zhhq_api_service_test.dart
@@ -142,6 +142,155 @@ void main() {
     });
   });
 
+  group('fetchDynamicTickets 请求参数对齐前端', () {
+    test('search 数组用 searchValue、systemCode 进 search、带 order', () async {
+      Map<String, String>? captured;
+      late MockClient inner;
+      inner = MockClient((request) async {
+        // 第一个请求是 CookieClient 域探测（无 body），其余为业务请求
+        if (request.body.isNotEmpty) {
+          captured = request.bodyFields;
+        }
+        return _authResponse({
+          'status': 'success',
+          'errorCode': '0',
+          'data': [
+            {
+              'activeId': 't-1',
+              'status': '待完工',
+              'activeTime': '2026-09-03 07:49:23',
+              'content': '{"维修项目":"水/上下水管类","故障描述":"漏水"}',
+            },
+          ],
+        });
+      });
+      final auth = _FakeZhhqAuth(inner);
+      final api = ZhhqApiService(auth);
+
+      final tickets = await api.fetchDynamicTickets(userId: 'user-1');
+      expect(tickets, hasLength(1));
+      expect(tickets.single.projectName, '水/上下水管类');
+
+      // 对齐前端：searchValue 而非 value
+      final search = jsonDecode(captured!['search']!) as List;
+      expect(search, hasLength(2));
+      final first = search[0] as Map;
+      expect(first['searchField'], 'createUser');
+      expect(first['searchValue'], 'user-1');
+      expect(first.containsKey('value'), isFalse);
+      // systemCode 进 search 数组
+      final second = search[1] as Map;
+      expect(second['searchField'], 'systemCode');
+      expect(second['searchValue'], 'newRepair');
+      // 无 pageIndex/pageSize，带 order
+      expect(captured!.containsKey('pageIndex'), isFalse);
+      expect(captured!.containsKey('pageSize'), isFalse);
+      expect(captured!['order'], 'createTime desc');
+    });
+  });
+
+  group('fetchRepairDetail / withdrawRepair / evaluateRepair', () {
+    test('fetchRepairDetail 调用 repairInfo/get 并解析数字状态', () async {
+      late String? lastBody;
+      late MockClient inner;
+      inner = MockClient((request) async {
+        if (request.body.isNotEmpty) lastBody = request.body;
+        return _authResponse({
+          'status': 'success',
+          'errorCode': '0',
+          'data': {
+            'id': 'abc',
+            'serialNumber': '202609030009',
+            'projectName': '水/上下水管类',
+            'content': '漏水',
+            'areaName': '望江学生区/东苑五栋',
+            'address': '主楼315',
+            'acceptDeptName': '维修与通讯服务中心望江校区',
+            'payName': '无偿',
+            'status': '3',
+            'ifCommont': '0',
+            'finishedInfo': {'repairId': 'fin-1'},
+            'logVOS': [
+              {
+                'statusName': '派工',
+                'content': '被指派维修',
+                'createTime': '2026-09-03 07:49:23',
+              },
+            ],
+          },
+        });
+      });
+      final auth = _FakeZhhqAuth(inner);
+      final api = ZhhqApiService(auth);
+
+      final detail = await api.fetchRepairDetail(id: 'abc');
+      expect(lastBody, contains('id=abc'));
+      expect(detail.id, 'abc');
+      expect(detail.serialNumber, '202609030009');
+      expect(detail.projectName, '水/上下水管类');
+      expect(detail.content, '漏水');
+      expect(detail.acceptDeptName, '维修与通讯服务中心望江校区');
+      expect(detail.payName, '无偿');
+      expect(detail.logs, hasLength(1));
+      expect(detail.logs.single.statusName, '派工');
+      expect(detail.finishedInfo?.repairId, 'fin-1');
+    });
+
+    test('withdrawRepair 调用 myRepair/withdrawMyRepair', () async {
+      late String? lastBody;
+      late MockClient inner;
+      inner = MockClient((request) async {
+        if (request.body.isNotEmpty) lastBody = request.body;
+        return _authResponse({
+          'status': 'success',
+          'errorCode': '0',
+          'data': null,
+        });
+      });
+      final auth = _FakeZhhqAuth(inner);
+      final api = ZhhqApiService(auth);
+
+      await api.withdrawRepair(id: 'abc');
+      expect(lastBody, contains('id=abc'));
+    });
+
+    test('evaluateRepair 用 JSON 体调用 visitEvaluateUser/save', () async {
+      late Map<String, String>? capturedHeaders;
+      late String? lastBody;
+      late MockClient inner;
+      inner = MockClient((request) async {
+        if (request.body.isNotEmpty) {
+          capturedHeaders = request.headers;
+          lastBody = request.body;
+        }
+        return _authResponse({
+          'status': 'success',
+          'errorCode': '0',
+          'data': null,
+        });
+      });
+      final auth = _FakeZhhqAuth(inner);
+      final api = ZhhqApiService(auth);
+
+      await api.evaluateRepair(
+        repairId: 'fin-1',
+        common: [
+          {'projectName': '水/上下水管类', 'score': 5},
+        ],
+        content: '很好',
+        labels: const ['及时'],
+      );
+
+      expect(lastBody, isNotNull);
+      final decoded = jsonDecode(lastBody!) as Map;
+      expect(decoded['repairId'], 'fin-1');
+      expect(decoded['source'], '0');
+      expect(decoded['label'], '及时');
+      // JSON content-type
+      expect(capturedHeaders!['Content-Type'], contains('application/json'));
+    });
+  });
+
   group('uploadImage', () {
     test(
       '明文 JSON 中 errorCode 非 0 且 status=success → ServiceException',

--- a/test/zhhq_repair_provider_test.dart
+++ b/test/zhhq_repair_provider_test.dart
@@ -165,6 +165,56 @@ void main() {
     expect(provider.submitError, '请选择维修项目');
     provider.dispose();
   });
+
+  test('evaluateRepair 后 force 刷新列表能拿到最新状态', () async {
+    final api = _ControllableZhhqApi();
+    final provider = _readyProvider(api);
+
+    // 加载地址（含 userId，工单列表依赖它）
+    final initial = provider.ensureLoaded();
+    api.completeAddresses([
+      const RepairAddress(
+        id: 'addr-1',
+        areaName: '望江学生区/东苑五栋',
+        addressDetail: '主楼315',
+        phone: '18500000000',
+        areaId: '10005',
+        isCommon: true,
+        userId: 'user-123',
+      ),
+    ]);
+    await initial;
+
+    // 首次加载列表（待评价）
+    final load = provider.loadTickets();
+    api.completeTickets([
+      RepairTicket(
+        id: 't-1',
+        projectName: '电/线路维修类',
+        content: '跳闸',
+        status: '待评价',
+        createTime: 1,
+      ),
+    ]);
+    await load;
+    expect(provider.tickets.single.statusLabel, '待评价');
+
+    // 评价成功后 loadTickets(force: true) 重新拉取
+    final refresh = provider.loadTickets(force: true);
+    expect(api.ticketRequests, hasLength(2));
+    api.completeTickets([
+      RepairTicket(
+        id: 't-1',
+        projectName: '电/线路维修类',
+        content: '跳闸',
+        status: '已评价',
+        createTime: 1,
+      ),
+    ]);
+    await refresh;
+    expect(provider.tickets.single.statusLabel, '已评价');
+    provider.dispose();
+  });
 }
 
 class _FakeZhhqAuth extends ChangeNotifier implements ZhhqAuth {


### PR DESCRIPTION
## 修复在线报修「我的报修」功能（#273）

### 问题背景

#273 反馈在线报修「我的报修」存在两个问题：

1. **工单显示为原始 JSON 字符串** —— 列表把后端返回的 `content`（JSON 字符串，含维修项目/故障地点/服务单位/故障描述）直接当作文本展示
2. **点击工单无反应** —— 列表项没有跳转详情，且没有撤回/评价入口

真机验证后进一步发现：评价工单不成功、评价/撤回后列表与详情状态不刷新（`activeTemplateData/list` 接口本身返回正确状态，问题在客户端刷新链路）。

### 改动内容

#### 1. 工单数据模型兼容多种 content 形态（`lib/models/repair.dart`）

- `RepairTicket.fromDynamicJson` 统一解析 `content` 三种形态：Map / JSON 字符串 / 双层转义 JSON 字符串
- 解析成功后提取「维修项目 / 故障地点 / 服务单位 / 故障描述」字段；解析失败时拼接已有字段展示，**绝不**回退显示原始 JSON
- 新增 `RepairTicketDetail`（数字 status / ifCommont / ifComplete / 进度时间线 / 完成信息）、`RepairLogItem`、`RepairFinishedInfo`、`RepairEvaluateProject` 模型

#### 2. 新增报修 API（`lib/services/api/zhhq_api_service.dart`）

基于前端 JS + 抓包逆向，新增接口：

- `fetchDynamicTickets` —— 工单列表，改用 `manager/activeTemplateData/list`（~600ms，远快于原 `myList` 的 20s+），`search` 数组带 `createUser` 筛选 + `systemCode`，`order=createTime desc`
- `fetchRepairDetail` —— 工单详情（`repairInfo/get`）
- `ifAllowWithdrawRepair` / `withdrawRepair` —— 撤回判断与执行（`myRepair/*`）
- `fetchEvaluateProjects` / `evaluateRepair` —— 评价项与评价提交（`commontProject/getProject` / `visitEvaluateUser/save`），`common` 数组对齐前端真实结构（`id`/`name`/`weight`/`star` 完整对象，权重 50/25/25）

**去重重构**：抽出 `_executeWithRetry`（快速路径 → 完整认证 → invalidate 重建的统一模板）与 `_businessErrorMessage`（业务错误判定），`uploadImage` 与所有 `_request` 请求共用，消除两处手写重复逻辑。

#### 3. Provider 并发守卫修复（`lib/providers/zhhq_repair_provider.dart`）

- `loadTickets` 的 force 刷新不再被 `_isLoadingTickets` 守卫直接吞掉 —— 改为等待进行中的加载完成后再重新拉取
- `withdrawRepair` / `evaluateRepair` / `submitTicket` 成功后标记列表需重新拉取

#### 4. 页面（`repair_page.dart` / `repair_detail_page.dart`）

- 列表卡片可点击进入**详情页**：完整展示维修项目/故障描述/地址/服务单位/收费类型/期望时间/工单进度时间线
- 详情页状态徽标实时计算（已评价 / 已撤回），不再沿用列表传入的过期状态
- 撤回：确认弹窗 → `withdrawMyRepair` → 返回列表刷新
- 评价：逐项星级评分对话框（维修质量/维修态度/维修速度）→ `visitEvaluateUser/save` → 返回列表刷新；提交失败不关闭对话框可重试
- 撤回/评价成功后统一 `pop(true)`，列表仅在发生状态变更时 force 刷新（普通返回不浪费请求）
- 列表首次加载中显示加载指示器（修复空白页）
- 认证层 tokenKey 持久化：`ZhhqAuth` 恢复本地 tokenKey 后走快速路径，冷启动无需等待 SCU 5-8s refresh（`lib/services/auth/zhhq_auth.dart` 已于先前提交）

### 测试验证

- 全量 `flutter test`：**388 passed / 1 skipped**
- `flutter analyze`：无告警
- 新增/更新测试：`test/zhhq_repair_provider_test.dart`（评价后 force 刷新）、`test/zhhq_api_service_test.dart`（上传重试语义对齐）、`test/repair_ticket_model_test.dart`
- 真机验证：工单列表正常展示中文状态、详情可进入、评价/撤回成功（需最终确认刷新链路）

### 相关 Issue

Fixes #273