### PR TITLE
chore(review): 移除未使用的直接依赖 pub_semver（降级为传递依赖）

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1083,7 +1083,7 @@ packages:
     source: hosted
     version: "5.0.5"
   pub_semver:
-    dependency: "direct dev"
+    dependency: transitive
     description:
       name: pub_semver
       sha256: "5bfcf68ca79ef689f8990d1160781b4bad40a3bd5e5218ad4076ddb7f4081585"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -59,7 +59,6 @@ dev_dependencies:
   flutter_driver:
     sdk: flutter
   flutter_lints: ^6.0.0
-  pub_semver: ^2.1.4
   build_runner: any
   injectable_generator: any
   json_serializable: any


### PR DESCRIPTION
## 变更内容

从 `dev_dependencies` 中移除未直接使用的 `pub_semver` 依赖，将其降级为传递依赖。

## 原因

项目代码中没有任何 `package:pub_semver` 的 import，该依赖此前被显式声明为直接 dev 依赖但从未直接使用。实际引用方是依赖树中的 `build_runner` 等工具，因此移除后 `pub_semver` 仍会作为传递依赖自动引入，功能不受影响。

## 验证

- [x] `flutter pub get` 解析成功（`pub_semver` 作为传递依赖继续存在，版本 2.2.0）
- [x] `flutter analyze` 无警告无错误
- [x] 全项目搜索确认无 `import 'package:pub_semver'` 引用

## 影响范围

仅涉及依赖声明（`pubspec.yaml` / `pubspec.lock`），无代码逻辑变更。