### PR TITLE
refactor(review): 新增 AppLog 日志门面，业务错误日志统一接入 AuthLogger 缓冲与脱敏

### DIFF
--- a/lib/pages/auth/scu_login_page.dart
+++ b/lib/pages/auth/scu_login_page.dart
@@ -10,6 +10,7 @@ import 'package:bugaoshan/pages/auth/scu_login_header_image.dart';
 import 'package:bugaoshan/pages/auth/scu_login_input_field.dart';
 import 'package:bugaoshan/providers/scu_auth_provider.dart';
 import 'package:bugaoshan/services/auth/scu_auth.dart' show CaptchaResult;
+import 'package:bugaoshan/utils/app_log.dart';
 import 'package:bugaoshan/services/auth/scu_exceptions.dart';
 import 'package:bugaoshan/services/ocr_service.dart';
 import 'package:bugaoshan/theme_shape.dart';
@@ -43,7 +44,7 @@ class _ScuLoginPageState extends State<ScuLoginPage> {
   void initState() {
     super.initState();
     OcrService.init().catchError((e) {
-      debugPrint('OCR Init error: $e');
+      AppLog.e('ScuLoginPage', 'OCR Init error: $e');
     });
     _loadSaved();
     _loadCaptcha();
@@ -84,7 +85,7 @@ class _ScuLoginPageState extends State<ScuLoginPage> {
       try {
         imageBytes = _decodeBase64Image(captcha.captchaBase64);
       } catch (e) {
-        debugPrint('Captcha decode error: $e');
+        AppLog.e('ScuLoginPage', 'Captcha decode error: $e');
       }
 
       String? recognizedText;
@@ -92,7 +93,7 @@ class _ScuLoginPageState extends State<ScuLoginPage> {
         try {
           recognizedText = await OcrService.performOcr(imageBytes);
         } catch (e) {
-          debugPrint('OCR error: $e');
+          AppLog.e('ScuLoginPage', 'OCR error: $e');
         }
       }
 
@@ -111,7 +112,7 @@ class _ScuLoginPageState extends State<ScuLoginPage> {
         }
       });
     } catch (e) {
-      debugPrint('Captcha load error: $e');
+      AppLog.e('ScuLoginPage', 'Captcha load error: $e');
       if (!mounted) return;
       final l10n = AppLocalizations.of(context)!;
       setState(() => _errorMsg = l10n.captchaLoadFailed);
@@ -158,13 +159,13 @@ class _ScuLoginPageState extends State<ScuLoginPage> {
       if (!logicRootContext.mounted) return;
       Navigator.of(logicRootContext).pop(true);
     } on ScuLoginException catch (e) {
-      debugPrint('Login failed: ${e.message}');
+      AppLog.w('ScuLoginPage', 'Login failed: ${e.message}');
       if (!mounted) return;
       final l10n = AppLocalizations.of(context)!;
       setState(() => _errorMsg = _localizeLoginError(e, l10n));
       _loadCaptcha();
     } catch (e) {
-      debugPrint('Login network error: $e');
+      AppLog.e('ScuLoginPage', 'Login network error: $e');
       if (!mounted) return;
       final l10n = AppLocalizations.of(context)!;
       setState(() => _errorMsg = l10n.networkError);

--- a/lib/pages/campus/balance_query/widgets/balance_list.dart
+++ b/lib/pages/campus/balance_query/widgets/balance_list.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:bugaoshan/l10n/app_localizations.dart';
 import 'package:bugaoshan/providers/balance_query_provider.dart';
+import 'package:bugaoshan/utils/app_log.dart';
 import 'balance_card.dart';
 
 class BalanceList extends StatefulWidget {
@@ -78,7 +79,7 @@ class _BalanceListState extends State<BalanceList> {
         await widget.provider.refreshBalance(type);
       } catch (e) {
         failed = true;
-        debugPrint('Balance refresh error: $e');
+        AppLog.e('BalanceList', 'Refresh error: $e');
       }
     }
     if (!failed || !context.mounted) return;

--- a/lib/pages/campus/balance_query/widgets/bind_room_dialog.dart
+++ b/lib/pages/campus/balance_query/widgets/bind_room_dialog.dart
@@ -6,6 +6,7 @@ import 'package:bugaoshan/providers/balance_query_provider.dart';
 import 'package:bugaoshan/providers/scu_auth_provider.dart';
 import 'package:bugaoshan/services/api/balance_query_service.dart';
 import 'package:bugaoshan/providers/app_config_provider.dart';
+import 'package:bugaoshan/utils/app_log.dart';
 import 'package:bugaoshan/widgets/dialog/dialog.dart';
 
 class BindRoomDialog extends StatefulWidget {
@@ -143,7 +144,7 @@ class BindRoomDialogState extends State<BindRoomDialog> {
         });
       }
     } catch (e) {
-      debugPrint('Verify error: $e');
+      AppLog.e('BindRoomDialog', 'Verify error: $e');
       if (mounted) {
         setState(() {
           _isVerifying = false;

--- a/lib/pages/campus/ccyl/activities_tab.dart
+++ b/lib/pages/campus/ccyl/activities_tab.dart
@@ -7,6 +7,7 @@ import 'package:bugaoshan/pages/campus/ccyl/models/ccyl_models.dart';
 import 'package:bugaoshan/pages/campus/ccyl/activity_lib_detail_page.dart';
 import 'package:bugaoshan/widgets/common/retryable_error_widget.dart';
 import 'package:bugaoshan/widgets/common/styled_card.dart';
+import 'package:bugaoshan/utils/app_log.dart';
 
 class ActivitiesTab extends StatefulWidget {
   const ActivitiesTab({super.key});
@@ -74,7 +75,7 @@ class _ActivitiesTabState extends State<ActivitiesTab> {
         _hasMore = results.length >= 10;
       });
     } catch (e) {
-      debugPrint('Activities load error: $e');
+      AppLog.e('CcylActivitiesTab', 'Activities load error: $e');
       if (mounted) {
         setState(() {
           _error = campusNetworkErrorType(LoadErrorType.ccylActivityLoadFailed);

--- a/lib/pages/campus/ccyl/activity_detail_page.dart
+++ b/lib/pages/campus/ccyl/activity_detail_page.dart
@@ -8,6 +8,7 @@ import 'package:bugaoshan/widgets/common/icon_info_row.dart';
 import 'package:bugaoshan/widgets/common/image_viewer.dart';
 import 'package:bugaoshan/widgets/common/retryable_error_widget.dart';
 import 'package:bugaoshan/widgets/common/styled_card.dart';
+import 'package:bugaoshan/utils/app_log.dart';
 
 class ActivityDetailPage extends StatefulWidget {
   final String activityId;
@@ -52,7 +53,7 @@ class _ActivityDetailPageState extends State<ActivityDetailPage> {
         _loading = false;
       });
     } catch (e) {
-      debugPrint('Activity detail load error: $e');
+      AppLog.e('CcylActivityDetail', 'Detail load error: $e');
       if (!mounted) return;
       setState(() {
         _error = LoadErrorType.ccylActivityLoadFailed;
@@ -103,7 +104,7 @@ class _ActivityDetailPageState extends State<ActivityDetailPage> {
         selectedType.code ?? '',
       );
     } catch (e) {
-      debugPrint('Sign up error: $e');
+      AppLog.e('CcylActivityDetail', 'Sign up error: $e');
       if (!mounted) return;
       setState(() => _actionLoading = false);
       ScaffoldMessenger.of(context).showSnackBar(
@@ -133,7 +134,7 @@ class _ActivityDetailPageState extends State<ActivityDetailPage> {
       final provider = getIt<CcylProvider>();
       await provider.service.cancelSignUp(widget.activityId);
     } catch (e) {
-      debugPrint('Cancel sign up error: $e');
+      AppLog.e('CcylActivityDetail', 'Cancel sign up error: $e');
       if (!mounted) return;
       setState(() => _actionLoading = false);
       ScaffoldMessenger.of(context).showSnackBar(

--- a/lib/pages/campus/ccyl/activity_lib_detail_page.dart
+++ b/lib/pages/campus/ccyl/activity_lib_detail_page.dart
@@ -8,6 +8,7 @@ import 'package:bugaoshan/pages/campus/ccyl/activity_detail_page.dart';
 import 'package:bugaoshan/widgets/common/icon_info_row.dart';
 import 'package:bugaoshan/widgets/common/retryable_error_widget.dart';
 import 'package:bugaoshan/widgets/common/styled_card.dart';
+import 'package:bugaoshan/utils/app_log.dart';
 
 class ActivityLibDetailPage extends StatefulWidget {
   final String activityLibraryId;
@@ -52,7 +53,7 @@ class _ActivityLibDetailPageState extends State<ActivityLibDetailPage> {
         _loading = false;
       });
     } catch (e) {
-      debugPrint('Activity lib detail load error: $e');
+      AppLog.e('CcylActivityLibDetail', 'Detail load error: $e');
       if (!mounted) return;
       setState(() {
         _error = LoadErrorType.ccylActivityLoadFailed;
@@ -87,7 +88,7 @@ class _ActivityLibDetailPageState extends State<ActivityLibDetailPage> {
         ),
       );
     } catch (e) {
-      debugPrint('Subscription action error: $e');
+      AppLog.e('CcylActivityLibDetail', 'Subscription action error: $e');
       if (!mounted) return;
       setState(() => _actionLoading = false);
       ScaffoldMessenger.of(context).showSnackBar(

--- a/lib/pages/campus/ccyl/ccyl_bind_page.dart
+++ b/lib/pages/campus/ccyl/ccyl_bind_page.dart
@@ -4,6 +4,7 @@ import 'package:bugaoshan/l10n/app_localizations.dart';
 import 'package:bugaoshan/providers/ccyl_provider.dart';
 import 'package:bugaoshan/services/auth/ccyl_oauth_service.dart';
 import 'package:bugaoshan/services/auth/scu_auth.dart';
+import 'package:bugaoshan/utils/app_log.dart';
 import 'package:bugaoshan/widgets/common/retryable_error_widget.dart';
 
 class CcylBindPage extends StatefulWidget {
@@ -45,7 +46,7 @@ class _CcylBindPageState extends State<CcylBindPage> {
         Navigator.of(context).pop(true);
       }
     } catch (e) {
-      debugPrint('CCYL bind error: $e');
+      AppLog.e('CcylBindPage', 'Bind error: $e');
       if (mounted) {
         setState(() {
           _error = LoadErrorType.ccylBindFailed;

--- a/lib/pages/campus/ccyl/credit_list_page.dart
+++ b/lib/pages/campus/ccyl/credit_list_page.dart
@@ -6,6 +6,7 @@ import 'package:bugaoshan/pages/campus/ccyl/models/ccyl_models.dart';
 import 'package:bugaoshan/widgets/common/retryable_error_widget.dart';
 import 'package:bugaoshan/widgets/common/status_chip.dart';
 import 'package:bugaoshan/widgets/common/styled_card.dart';
+import 'package:bugaoshan/utils/app_log.dart';
 
 class CreditListPage extends StatefulWidget {
   const CreditListPage({super.key});
@@ -74,7 +75,7 @@ class _CreditListPageState extends State<CreditListPage> {
         _hasMore = results.length >= 10;
       });
     } catch (e) {
-      debugPrint('Credit list load error: $e');
+      AppLog.e('CcylCreditList', 'Load error: $e');
       if (mounted) {
         setState(() {
           _error = campusNetworkErrorType(LoadErrorType.ccylActivityLoadFailed);
@@ -178,7 +179,7 @@ class _CreditListPageState extends State<CreditListPage> {
         _selectedIds.clear();
       });
     } catch (e) {
-      debugPrint('Export error: $e');
+      AppLog.e('CcylCreditList', 'Export error: $e');
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(content: Text(e.toString()), backgroundColor: Colors.red),

--- a/lib/pages/campus/ccyl/my_activities_tab.dart
+++ b/lib/pages/campus/ccyl/my_activities_tab.dart
@@ -7,6 +7,7 @@ import 'package:bugaoshan/pages/campus/ccyl/models/ccyl_models.dart';
 import 'package:bugaoshan/pages/campus/ccyl/activity_detail_page.dart';
 import 'package:bugaoshan/widgets/common/retryable_error_widget.dart';
 import 'package:bugaoshan/widgets/common/styled_card.dart';
+import 'package:bugaoshan/utils/app_log.dart';
 
 class MyActivitiesTab extends StatefulWidget {
   const MyActivitiesTab({super.key});
@@ -69,7 +70,7 @@ class _MyActivitiesTabState extends State<MyActivitiesTab> {
         _hasMore = results.length >= 10;
       });
     } catch (e) {
-      debugPrint('My activities load error: $e');
+      AppLog.e('CcylMyActivities', 'Load error: $e');
       if (mounted) {
         setState(() {
           _error = campusNetworkErrorType(LoadErrorType.ccylActivityLoadFailed);

--- a/lib/pages/campus/ccyl/ordered_activities_tab.dart
+++ b/lib/pages/campus/ccyl/ordered_activities_tab.dart
@@ -7,6 +7,7 @@ import 'package:bugaoshan/pages/campus/ccyl/models/ccyl_models.dart';
 import 'package:bugaoshan/pages/campus/ccyl/activity_lib_detail_page.dart';
 import 'package:bugaoshan/widgets/common/retryable_error_widget.dart';
 import 'package:bugaoshan/widgets/common/styled_card.dart';
+import 'package:bugaoshan/utils/app_log.dart';
 
 class OrderedActivitiesTab extends StatefulWidget {
   const OrderedActivitiesTab({super.key});
@@ -71,7 +72,7 @@ class _OrderedActivitiesTabState extends State<OrderedActivitiesTab> {
         _hasMore = results.length >= 10;
       });
     } catch (e) {
-      debugPrint('Ordered activities load error: $e');
+      AppLog.e('CcylOrderedActivities', 'Load error: $e');
       if (mounted) {
         setState(() {
           _error = campusNetworkErrorType(LoadErrorType.ccylActivityLoadFailed);

--- a/lib/pages/campus/service_hall/service_form_page.dart
+++ b/lib/pages/campus/service_hall/service_form_page.dart
@@ -14,6 +14,7 @@ import 'package:bugaoshan/services/api/service_form_models.dart';
 import 'package:bugaoshan/services/api/service_plugin_models.dart';
 import 'package:bugaoshan/services/auth/scu_exceptions.dart';
 import 'package:bugaoshan/services/auth/service_auth.dart';
+import 'package:bugaoshan/utils/app_log.dart';
 import 'package:bugaoshan/utils/auth_logger.dart';
 import 'package:bugaoshan/widgets/common/login_required_widget.dart';
 import 'package:bugaoshan/widgets/common/service_region_picker.dart';
@@ -117,7 +118,7 @@ class _ServiceFormPageState extends State<ServiceFormPage> {
       // starterDepartId 已在 _fetchSchema 中先行请求）
       unawaited(_loadDataSources());
     } catch (e) {
-      debugPrint('Service form schema load failed: $e');
+      AppLog.e('ServiceFormPage', 'Schema load failed: $e');
     } finally {
       if (mounted) setState(() => _schemaLoading = false);
     }
@@ -169,7 +170,7 @@ class _ServiceFormPageState extends State<ServiceFormPage> {
         startData: startData,
       );
     } catch (e) {
-      debugPrint('Service live schema unavailable: $e');
+      AppLog.w('ServiceFormPage', 'Live schema unavailable: $e');
     }
     final fallback = widget.app.fallbackSchema;
     if (fallback != null) {
@@ -190,7 +191,7 @@ class _ServiceFormPageState extends State<ServiceFormPage> {
       if (!mounted || id == null) return;
       setState(() => _starterDepartId = id);
     } catch (e) {
-      debugPrint('Service starter depart id load skipped: $e');
+      AppLog.w('ServiceFormPage', 'Starter depart id load skipped: $e');
     }
   }
 
@@ -214,7 +215,7 @@ class _ServiceFormPageState extends State<ServiceFormPage> {
         if (d == null) continue;
         setState(() => controller.applyDataSourceValue(p, d['list']));
       } catch (e) {
-        debugPrint('Service dataSource ${p.key} load skipped: $e');
+        AppLog.w('ServiceFormPage', 'DataSource ${p.key} load skipped: $e');
       }
     }
   }
@@ -232,7 +233,10 @@ class _ServiceFormPageState extends State<ServiceFormPage> {
         data = await getIt<ServiceApiService>().fetchProvinces();
         if (data.isEmpty) throw StateError('empty provinces');
       } catch (e) {
-        debugPrint('Service region online load failed, fallback to asset: $e');
+        AppLog.w(
+          'ServiceFormPage',
+          'Region online load failed, fallback to asset: $e',
+        );
         final raw = await rootBundle.loadString('assets/region_data.json');
         data = jsonDecode(raw) as List;
       }
@@ -244,7 +248,7 @@ class _ServiceFormPageState extends State<ServiceFormPage> {
         });
       }
     } catch (e) {
-      debugPrint('Service region load skipped: $e');
+      AppLog.w('ServiceFormPage', 'Region load skipped: $e');
     } finally {
       if (mounted) setState(() => _regionsLoading = false);
     }
@@ -323,7 +327,7 @@ class _ServiceFormPageState extends State<ServiceFormPage> {
     } on UnauthenticatedException {
       if (mounted) _showSnack(l10n.loginRequired, isError: true);
     } catch (e) {
-      debugPrint('Service submit error: $e');
+      AppLog.e('ServiceFormPage', 'Submit error: $e');
       if (mounted) _showSnack(l10n.leaveSubmitFailed, isError: true);
     } finally {
       if (mounted) setState(() => _submitting = false);

--- a/lib/pages/course/import/import_schedule_page.dart
+++ b/lib/pages/course/import/import_schedule_page.dart
@@ -10,6 +10,7 @@ import 'package:bugaoshan/providers/scu_auth_provider.dart';
 import 'package:bugaoshan/services/api/academic_calendar_service.dart';
 import 'package:bugaoshan/services/api/zhjw_api_service.dart';
 import 'package:bugaoshan/services/auth/scu_exceptions.dart';
+import 'package:bugaoshan/utils/app_log.dart';
 import 'package:bugaoshan/widgets/dialog/dialog.dart';
 import 'package:bugaoshan/widgets/route/router_utils.dart';
 
@@ -193,7 +194,7 @@ class _ImportSchedulePageState extends State<ImportSchedulePage> {
         _showSuccessAndPop();
       }
     } catch (e) {
-      debugPrint('Import from share error: $e');
+      AppLog.e('ImportSchedulePage', 'Import from share error: $e');
       if (mounted) {
         showInfoDialog(title: l10n.importFailed, content: l10n.importFailedTip);
       }
@@ -232,7 +233,7 @@ class _ImportSchedulePageState extends State<ImportSchedulePage> {
       if (mounted) setState(() => _loading = false);
       return;
     } catch (e) {
-      debugPrint('Import online error: $e');
+      AppLog.e('ImportSchedulePage', 'Import online error: $e');
       if (mounted) {
         showInfoDialog(title: l10n.importFailed, content: l10n.importFailed);
         setState(() => _loading = false);
@@ -488,7 +489,7 @@ class _ImportSchedulePageState extends State<ImportSchedulePage> {
     } on ScuException catch (e) {
       if (mounted) showInfoDialog(title: l10n.importFailed, content: e.message);
     } catch (e) {
-      debugPrint('Import from jwxt error: $e');
+      AppLog.e('ImportSchedulePage', 'Import from jwxt error: $e');
       if (mounted) {
         showInfoDialog(title: l10n.importFailed, content: l10n.importFailed);
       }

--- a/lib/pages/course/main/course_page.dart
+++ b/lib/pages/course/main/course_page.dart
@@ -11,6 +11,7 @@ import 'course_page_top_bar.dart';
 import 'course_page_vacation_view.dart';
 import 'course_preview_data.dart';
 import '../management/schedule_management_page.dart';
+import 'package:bugaoshan/utils/app_log.dart';
 import 'package:bugaoshan/providers/app_config_provider.dart';
 import 'package:bugaoshan/providers/course_provider.dart';
 import 'package:bugaoshan/pages/course/widgets/course_grid.dart';
@@ -334,7 +335,7 @@ class _CoursePageState extends State<CoursePage> with WidgetsBindingObserver {
         courseProvider.switchSchedule(matchId);
       }
     } catch (e) {
-      debugPrint('CoursePage: failed to check next semester: $e');
+      AppLog.w('CoursePage', 'Failed to check next semester: $e');
     }
   }
 

--- a/lib/pages/course/main/course_page_controller.dart
+++ b/lib/pages/course/main/course_page_controller.dart
@@ -5,6 +5,7 @@ import 'package:bugaoshan/models/academic_calendar.dart';
 import 'package:bugaoshan/models/course.dart';
 import 'package:bugaoshan/services/api/academic_calendar_service.dart';
 import 'package:bugaoshan/theme_shape.dart';
+import 'package:bugaoshan/utils/app_log.dart';
 
 /// 课表页的页面级控制器（不进 GetIt —— 项目约定允许页面级非 DI 类；
 /// 且 demo/真实两个 CoursePage 实例共存，单例语义错误）。
@@ -185,7 +186,7 @@ class CoursePageController extends ChangeNotifier {
       _calendarNextSemesterLoaded = true;
       return next;
     } catch (e) {
-      debugPrint('CoursePageController: load calendar failed: $e');
+      AppLog.e('CoursePageController', 'Load calendar failed: $e');
       return null;
     } finally {
       if (!_disposed && gen == _calendarLoadGen) {

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -10,6 +10,7 @@ import 'package:bugaoshan/providers/app_config_provider.dart';
 import 'package:bugaoshan/providers/app_info_provider.dart';
 import 'package:bugaoshan/providers/scu_auth_provider.dart';
 import 'package:bugaoshan/providers/update_provider.dart';
+import 'package:bugaoshan/utils/app_log.dart';
 import 'package:bugaoshan/services/auth/auth_coordinator.dart';
 import 'package:bugaoshan/services/widget_update_service.dart';
 import 'package:bugaoshan/utils/constants.dart';
@@ -43,7 +44,7 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver {
       }
       await authProvider.autoLogin();
     } catch (e) {
-      debugPrint('Auto login attempt error: $e');
+      AppLog.w('HomePage', 'Auto login attempt error: $e');
     }
   }
 
@@ -61,7 +62,7 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver {
         appConfig.hasUpdateNotification.value = true;
       }
     } catch (e) {
-      debugPrint('HomePage._checkForUpdateInBackground error: $e');
+      AppLog.w('HomePage', 'CheckForUpdateInBackground error: $e');
     }
   }
 
@@ -83,7 +84,7 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver {
       try {
         await getIt<WidgetUpdateService>().updateWidgetData();
       } catch (e) {
-        debugPrint('Widget update failed: $e');
+        AppLog.e('HomePage', 'Widget update failed: $e');
       }
     }
   }

--- a/lib/pages/settings/add_widget/add_widget_page.dart
+++ b/lib/pages/settings/add_widget/add_widget_page.dart
@@ -7,6 +7,7 @@ import 'package:bugaoshan/l10n/app_localizations.dart';
 import 'package:bugaoshan/models/widget_appearance.dart';
 import 'package:bugaoshan/providers/app_config_provider.dart';
 import 'package:bugaoshan/services/widget_update_service.dart';
+import 'package:bugaoshan/utils/app_log.dart';
 import 'package:bugaoshan/widgets/common/styled_card.dart';
 import 'package:bugaoshan/models/widget_size.dart';
 import 'package:bugaoshan/theme_shape.dart';
@@ -131,7 +132,7 @@ class _AddWidgetContentState extends State<AddWidgetContent>
         try {
           await service.syncWidgetShowTomorrow(v);
         } catch (e, st) {
-          debugPrint('WidgetUpdate toggle failed: $e');
+          AppLog.e('AddWidgetPage', 'WidgetUpdate toggle failed: $e');
           debugPrint('$st');
         }
       },

--- a/lib/providers/balance_query_provider.dart
+++ b/lib/providers/balance_query_provider.dart
@@ -10,6 +10,7 @@ import 'package:bugaoshan/services/api/payapp_api_service.dart';
 import 'package:bugaoshan/services/auth/payapp_auth.dart';
 import 'package:bugaoshan/services/balance/balance_trend_calculator.dart';
 import 'package:bugaoshan/services/database_service.dart';
+import 'package:bugaoshan/utils/app_log.dart';
 import 'package:bugaoshan/utils/beijing_time.dart';
 
 const _keyBindingInfo = 'balance_query_binding';
@@ -205,18 +206,18 @@ class BalanceQueryProvider extends ChangeNotifier {
         try {
           await _loadBalanceFor(binding, kBalanceTypeElectric, force: true);
         } catch (e) {
-          debugPrint('Auto-sample electric failed: $e');
+          AppLog.w('BalanceQueryProvider', 'Auto-sample electric failed: $e');
         }
       }
       if (acRecords.isEmpty) {
         try {
           await _loadBalanceFor(binding, kBalanceTypeAc, force: true);
         } catch (e) {
-          debugPrint('Auto-sample AC failed: $e');
+          AppLog.w('BalanceQueryProvider', 'Auto-sample AC failed: $e');
         }
       }
     } catch (e) {
-      debugPrint('Auto-sample balance failed: $e');
+      AppLog.w('BalanceQueryProvider', 'Auto-sample balance failed: $e');
     } finally {
       _autoSampling = false;
     }
@@ -283,7 +284,10 @@ class BalanceQueryProvider extends ChangeNotifier {
             .map((e) => RoomBinding.fromJson(e as Map<String, dynamic>))
             .toList();
       } catch (e) {
-        debugPrint('Failed to load balance binding info: $e');
+        AppLog.w(
+          'BalanceQueryProvider',
+          'Failed to load balance binding info: $e',
+        );
       }
     }
     _currentIndex = _prefs.getInt(_keyCurrentRoomIndex) ?? 0;
@@ -324,7 +328,10 @@ class BalanceQueryProvider extends ChangeNotifier {
     try {
       await _db.deleteBalanceRecordsByRoom(roomKey);
     } catch (e) {
-      debugPrint('Failed to clean balance history for removed room: $e');
+      AppLog.w(
+        'BalanceQueryProvider',
+        'Failed to clean balance history for removed room: $e',
+      );
     }
     ensureCurrentBalances();
   }
@@ -661,7 +668,7 @@ class BalanceQueryProvider extends ChangeNotifier {
             key.roomKey == record.roomKey && key.balanceType == balanceType,
       );
     } catch (e) {
-      debugPrint('Failed to record balance history: $e');
+      AppLog.w('BalanceQueryProvider', 'Failed to record balance history: $e');
     }
   }
 

--- a/lib/providers/class_schedule_inquiry_provider.dart
+++ b/lib/providers/class_schedule_inquiry_provider.dart
@@ -2,6 +2,7 @@ import 'package:flutter/foundation.dart';
 import 'package:bugaoshan/pages/campus/models/class_schedule_inquiry_model.dart';
 import 'package:bugaoshan/services/api/zhjw_api_service.dart';
 import 'package:bugaoshan/services/auth/scu_exceptions.dart';
+import 'package:bugaoshan/utils/app_log.dart';
 import 'package:bugaoshan/widgets/common/retryable_error_widget.dart';
 
 enum ClassScheduleInquiryLoadState { idle, loading, loaded, error }
@@ -149,7 +150,7 @@ class ClassScheduleInquiryProvider extends ChangeNotifier {
       notifyListeners();
     } catch (error) {
       if (generation != _indexGeneration) return;
-      debugPrint('Class schedule index load error: $error');
+      AppLog.e('ClassScheduleInquiryProvider', 'Index load error: $error');
       _indexState = ClassScheduleInquiryLoadState.error;
       _indexError = campusNetworkErrorType(LoadErrorType.loadFailed);
       notifyListeners();
@@ -180,7 +181,7 @@ class ClassScheduleInquiryProvider extends ChangeNotifier {
           department != _selectedDepartment) {
         return;
       }
-      debugPrint('Class schedule subjects load error: $error');
+      AppLog.e('ClassScheduleInquiryProvider', 'Subjects load error: $error');
       _subjects = const [];
       _subjectsState = ClassScheduleInquiryLoadState.error;
     }
@@ -221,7 +222,10 @@ class ClassScheduleInquiryProvider extends ChangeNotifier {
           subject != _selectedSubject) {
         return;
       }
-      debugPrint('Class schedule class options load error: $error');
+      AppLog.e(
+        'ClassScheduleInquiryProvider',
+        'Class options load error: $error',
+      );
       _classOptions = const [];
       _classOptionsState = ClassScheduleInquiryLoadState.error;
     }
@@ -303,7 +307,7 @@ class ClassScheduleInquiryProvider extends ChangeNotifier {
       )) {
         return;
       }
-      debugPrint('Class schedule classes load error: $error');
+      AppLog.e('ClassScheduleInquiryProvider', 'Classes load error: $error');
       _classesState = ClassScheduleInquiryLoadState.error;
       _classesError = campusNetworkErrorType(LoadErrorType.loadFailed);
     }
@@ -373,7 +377,7 @@ class ClassScheduleInquiryProvider extends ChangeNotifier {
       );
     } catch (error) {
       if (_detailGenerations[key] != generation) return;
-      debugPrint('Class schedule detail load error: $error');
+      AppLog.e('ClassScheduleInquiryProvider', 'Detail load error: $error');
       _details[key] = ClassScheduleDetailState(
         courses: previous.courses,
         state: ClassScheduleInquiryLoadState.error,

--- a/lib/providers/classroom_provider.dart
+++ b/lib/providers/classroom_provider.dart
@@ -4,6 +4,7 @@ import 'package:flutter/foundation.dart';
 import 'package:bugaoshan/pages/campus/models/classroom_model.dart';
 import 'package:bugaoshan/services/api/zhjw_api_service.dart';
 import 'package:bugaoshan/services/auth/scu_exceptions.dart';
+import 'package:bugaoshan/utils/app_log.dart';
 import 'package:bugaoshan/widgets/common/retryable_error_widget.dart';
 
 enum ClassroomLoadState { idle, loading, loaded, error }
@@ -65,7 +66,7 @@ class ClassroomProvider extends ChangeNotifier {
       _indexError = LoadErrorType.sessionExpired;
     } catch (error) {
       if (generation != _indexGeneration) return;
-      debugPrint('Classroom index load error: $error');
+      AppLog.e('ClassroomProvider', 'Index load error: $error');
       _indexState = ClassroomLoadState.error;
       _indexError = campusNetworkErrorType(LoadErrorType.loadFailed);
     }
@@ -151,7 +152,7 @@ class ClassroomProvider extends ChangeNotifier {
       resource.error = LoadErrorType.sessionExpired;
     } catch (error) {
       if (epoch != _queryEpoch) return;
-      debugPrint('Classroom query error: $error');
+      AppLog.e('ClassroomProvider', 'Query error: $error');
       resource.state = ClassroomLoadState.error;
       resource.error = campusNetworkErrorType(LoadErrorType.loadFailed);
     } finally {

--- a/lib/providers/course_provider.dart
+++ b/lib/providers/course_provider.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:bugaoshan/models/course.dart';
 import 'package:bugaoshan/services/database_service.dart';
+import 'package:bugaoshan/utils/app_log.dart';
 
 class CourseProvider {
   final DatabaseService _db;
@@ -31,7 +32,7 @@ class CourseProvider {
       final config = _db.getScheduleConfig();
       scheduleConfig.value = config;
     } catch (e) {
-      debugPrint('CourseProvider: failed to load data: $e');
+      AppLog.e('CourseProvider', 'Failed to load data: $e');
     } finally {
       isLoading.value = false;
       onCoursesChanged?.call();

--- a/lib/providers/exam_plan_provider.dart
+++ b/lib/providers/exam_plan_provider.dart
@@ -2,6 +2,7 @@ import 'package:flutter/foundation.dart';
 import 'package:bugaoshan/pages/campus/exam_plan/models/exam_info.dart';
 import 'package:bugaoshan/services/api/zhjw_api_service.dart';
 import 'package:bugaoshan/services/auth/scu_exceptions.dart';
+import 'package:bugaoshan/utils/app_log.dart';
 import 'package:bugaoshan/widgets/common/retryable_error_widget.dart';
 
 enum ExamPlanLoadState { idle, loading, loaded, error }
@@ -44,7 +45,7 @@ class ExamPlanProvider extends ChangeNotifier {
       _error = LoadErrorType.notLoggedIn;
     } catch (error) {
       if (generation != _generation) return;
-      debugPrint('Exam plan load error: $error');
+      AppLog.e('ExamPlanProvider', 'Load error: $error');
       _state = ExamPlanLoadState.error;
       _error = campusNetworkErrorType(LoadErrorType.loadFailed);
     }

--- a/lib/providers/grades_provider.dart
+++ b/lib/providers/grades_provider.dart
@@ -4,6 +4,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:bugaoshan/models/scheme_score.dart';
 import 'package:bugaoshan/services/api/zhjw_api_service.dart';
 import 'package:bugaoshan/services/auth/scu_exceptions.dart';
+import 'package:bugaoshan/utils/app_log.dart';
 import 'package:bugaoshan/widgets/common/retryable_error_widget.dart';
 
 const _keySchemeScores = 'grades_scheme_scores';
@@ -58,7 +59,7 @@ class GradesProvider extends ChangeNotifier {
         );
         _schemeState = GradesLoadState.loaded;
       } catch (e) {
-        debugPrint('GradesProvider scheme cache decode error: $e');
+        AppLog.w('GradesProvider', 'Scheme cache decode error: $e');
       }
     }
     final cachedPassing = _prefs.getString(
@@ -71,7 +72,7 @@ class GradesProvider extends ChangeNotifier {
         );
         _passingState = GradesLoadState.loaded;
       } catch (e) {
-        debugPrint('GradesProvider passing cache decode error: $e');
+        AppLog.w('GradesProvider', 'Passing cache decode error: $e');
       }
     }
   }
@@ -141,7 +142,7 @@ class GradesProvider extends ChangeNotifier {
       }
     } catch (e) {
       if (generation != _identityGeneration) return;
-      debugPrint('Scheme scores load error: $e');
+      AppLog.e('GradesProvider', 'Scheme scores load error: $e');
       if (_schemes != null) {
         _schemeState = GradesLoadState.loaded;
         _schemeError = campusNetworkErrorType(LoadErrorType.loadFailed);
@@ -196,7 +197,7 @@ class GradesProvider extends ChangeNotifier {
       }
     } catch (e) {
       if (generation != _identityGeneration) return;
-      debugPrint('Passing scores load error: $e');
+      AppLog.e('GradesProvider', 'Passing scores load error: $e');
       if (_passingScores != null) {
         _passingState = GradesLoadState.loaded;
         _passingError = campusNetworkErrorType(LoadErrorType.loadFailed);

--- a/lib/providers/plan_completion_provider.dart
+++ b/lib/providers/plan_completion_provider.dart
@@ -5,6 +5,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:bugaoshan/pages/campus/plan_completion/models/plan_completion.dart';
 import 'package:bugaoshan/services/api/zhjw_api_service.dart';
 import 'package:bugaoshan/services/auth/scu_exceptions.dart';
+import 'package:bugaoshan/utils/app_log.dart';
 import 'package:bugaoshan/widgets/common/retryable_error_widget.dart';
 
 const _keyPlanCompletion = 'plan_completion_nodes';
@@ -24,7 +25,7 @@ class PlanCompletionProvider extends ChangeNotifier {
         _plans = _decodeCached(list);
         _state = PlanCompletionLoadState.loaded;
       } catch (e) {
-        debugPrint('PlanCompletionProvider cache decode error: $e');
+        AppLog.w('PlanCompletionProvider', 'Cache decode error: $e');
       }
     }
   }

--- a/lib/providers/user_info_provider.dart
+++ b/lib/providers/user_info_provider.dart
@@ -8,6 +8,7 @@ import 'package:bugaoshan/services/api/wfw_api_service.dart';
 import 'package:bugaoshan/services/auth/auth_state.dart';
 import 'package:bugaoshan/services/auth/scu_exceptions.dart';
 import 'package:bugaoshan/services/auth/wfw_auth.dart';
+import 'package:bugaoshan/utils/app_log.dart';
 import 'package:bugaoshan/utils/storage_keys.dart';
 
 typedef _UserInfoResult = ({
@@ -190,7 +191,7 @@ class UserInfoProvider extends ChangeNotifier {
     _persistenceTail = operation.then<void>(
       (_) {},
       onError: (Object error, StackTrace stackTrace) {
-        debugPrint('User info persistence error: $error');
+        AppLog.e('UserInfoProvider', 'Persistence error: $error');
       },
     );
     return operation;

--- a/lib/services/api/academic_calendar_service.dart
+++ b/lib/services/api/academic_calendar_service.dart
@@ -4,6 +4,7 @@ import 'package:flutter/services.dart' show rootBundle;
 import 'package:http/http.dart' as http;
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:bugaoshan/models/academic_calendar.dart';
+import 'package:bugaoshan/utils/app_log.dart';
 import 'package:bugaoshan/utils/calendar_event_utils.dart';
 
 class AcademicCalendarService {
@@ -109,8 +110,9 @@ class AcademicCalendarService {
       try {
         return _parseCalendarJson(cached);
       } catch (e) {
-        debugPrint(
-          'AcademicCalendarService: failed to parse cached calendar: $e',
+        AppLog.w(
+          'AcademicCalendarService',
+          'Failed to parse cached calendar: $e',
         );
       }
     }
@@ -121,7 +123,7 @@ class AcademicCalendarService {
       );
       return _parseCalendarJson(assetContent);
     } catch (e) {
-      debugPrint('AcademicCalendarService: failed to load bundled asset: $e');
+      AppLog.w('AcademicCalendarService', 'Failed to load bundled asset: $e');
       return null;
     }
   }
@@ -147,8 +149,9 @@ class AcademicCalendarService {
         }
       }
     } catch (e) {
-      debugPrint(
-        'AcademicCalendarService: failed to fetch remote calendar from $url: $e',
+      AppLog.w(
+        'AcademicCalendarService',
+        'Failed to fetch remote calendar from $url: $e',
       );
     }
     return null;

--- a/lib/services/api/academic_calendar_service.dart
+++ b/lib/services/api/academic_calendar_service.dart
@@ -1,5 +1,4 @@
 import 'dart:convert';
-import 'package:flutter/material.dart';
 import 'package:flutter/services.dart' show rootBundle;
 import 'package:http/http.dart' as http;
 import 'package:shared_preferences/shared_preferences.dart';
@@ -201,8 +200,9 @@ class AcademicCalendarService {
       }
       return null;
     } catch (e) {
-      debugPrint(
-        'AcademicCalendarService: failed to find matching semester: $e',
+      AppLog.w(
+        'AcademicCalendarService',
+        'Failed to find matching semester: $e',
       );
       return null;
     }
@@ -232,8 +232,9 @@ class AcademicCalendarService {
       }
       return null;
     } catch (e) {
-      debugPrint(
-        'AcademicCalendarService: failed to find matching semester: $e',
+      AppLog.w(
+        'AcademicCalendarService',
+        'Failed to find matching semester: $e',
       );
       return null;
     }

--- a/lib/services/api/service_api_service.dart
+++ b/lib/services/api/service_api_service.dart
@@ -1,7 +1,6 @@
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
 import 'package:bugaoshan/injection/injector.dart';
 import 'package:bugaoshan/services/api/api_request.dart';
@@ -10,6 +9,7 @@ import 'package:bugaoshan/services/api/service_plugin_models.dart';
 import 'package:bugaoshan/services/auth/cookie_client.dart';
 import 'package:bugaoshan/services/auth/scu_exceptions.dart';
 import 'package:bugaoshan/services/auth/service_auth.dart';
+import 'package:bugaoshan/utils/app_log.dart';
 import 'package:bugaoshan/utils/auth_logger.dart';
 import 'package:bugaoshan/utils/constants.dart';
 
@@ -111,8 +111,9 @@ class ServiceApiService {
     _checkSessionExpiry(body, statusCode);
     // 诊断日志：记录非 2xx/非 JSON 的响应，便于定位服务端拒绝原因
     if (statusCode < 200 || statusCode >= 300) {
-      debugPrint(
-        'ServiceApi non-2xx: status=$statusCode body=${body.length > 500 ? body.substring(0, 500) : body}',
+      AppLog.w(
+        'ServiceApi',
+        'non-2xx: status=$statusCode body=${body.length > 500 ? body.substring(0, 500) : body}',
       );
     }
     final json = jsonDecode(body) as Map<String, dynamic>;
@@ -123,7 +124,6 @@ class ServiceApiService {
     // 业务错误记录到 AuthLogger，导出 auth log 可直接查看 e/m
     if (json['e']?.toString() != '0') {
       final msg = '业务错误 e=${json['e']} m=${json['m']} status=$statusCode';
-      debugPrint('ServiceApi business error: $msg');
       _log.w('SERVICE', msg);
     }
     return json;

--- a/lib/services/background_cache_service.dart
+++ b/lib/services/background_cache_service.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:flutter/widgets.dart';
 import 'package:bugaoshan/providers/app_config_provider.dart';
+import 'package:bugaoshan/utils/app_log.dart';
 
 class BackgroundCacheService {
   final AppConfigProvider _appConfig;
@@ -34,7 +35,7 @@ class BackgroundCacheService {
     try {
       _bgImageStream?.removeListener(_bgImageListener!);
     } catch (e) {
-      debugPrint('BackgroundCacheService._cleanup error: $e');
+      AppLog.w('BackgroundCacheService', 'Cleanup error: $e');
     }
     _bgImageStream = null;
     _bgImageListener = null;

--- a/lib/services/database_service.dart
+++ b/lib/services/database_service.dart
@@ -5,6 +5,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter_app_group_directory/flutter_app_group_directory.dart';
 import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
+import 'package:bugaoshan/utils/app_log.dart';
 
 import 'package:sqflite/sqflite.dart';
 import 'package:bugaoshan/models/balance_record.dart';
@@ -59,7 +60,7 @@ class DatabaseService {
           dir = await getApplicationSupportDirectory();
         }
       } catch (e) {
-        debugPrint('BugaoShan Database: Failed to get App Group directory: $e');
+        AppLog.w('DatabaseService', 'Failed to get App Group directory: $e');
         dir = await getApplicationSupportDirectory();
       }
     } else {
@@ -94,7 +95,7 @@ class DatabaseService {
           );
         }
       } catch (e) {
-        debugPrint('BugaoShan Database: Error during database migration: $e');
+        AppLog.w('DatabaseService', 'Error during database migration: $e');
       }
     }
 

--- a/lib/services/update_service.dart
+++ b/lib/services/update_service.dart
@@ -6,10 +6,10 @@ import 'package:bugaoshan/providers/app_info_provider.dart';
 import 'package:bugaoshan/services/update_asset_selector.dart';
 import 'package:bugaoshan/services/update_checker.dart';
 import 'package:crypto/crypto.dart' as crypto;
+import 'package:bugaoshan/utils/app_log.dart';
 import 'package:bugaoshan/utils/constants.dart';
 
 import 'package:bugaoshan/models/release_info.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart' show rootBundle;
 import 'package:http/http.dart' as http;
 import 'package:path_provider/path_provider.dart';
@@ -228,14 +228,14 @@ class UpdateService {
               try {
                 await ent.delete();
               } catch (e) {
-                debugPrint('UpdateService.cleanupOldPackages delete error: $e');
+                AppLog.w('UpdateService', 'Cleanup delete error: $e');
               }
             }
           }
         }
       }
     } catch (e) {
-      debugPrint('UpdateService.cleanupOldPackages error: $e');
+      AppLog.w('UpdateService', 'CleanupOldPackages error: $e');
     }
     await _prefs.setString(_keyLastInstalledVersion, _currentVersion);
   }

--- a/lib/services/widget_update_service.dart
+++ b/lib/services/widget_update_service.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:bugaoshan/models/widget_appearance.dart';
+import 'package:bugaoshan/utils/app_log.dart';
 import 'package:bugaoshan/utils/constants.dart';
 
 class WidgetUpdateService {
@@ -116,8 +117,10 @@ class WidgetUpdateService {
         await updateWidgetData(force: true);
       }
     } catch (e, stack) {
-      debugPrint('WidgetUpdate: syncWidgetShowTomorrow FAILED: $e');
-      debugPrint('WidgetUpdate: stack: $stack');
+      AppLog.e(
+        'WidgetUpdateService',
+        'syncWidgetShowTomorrow FAILED: $e\n$stack',
+      );
     }
   }
 
@@ -135,8 +138,10 @@ class WidgetUpdateService {
         'density': density.index,
       });
     } catch (e, stack) {
-      debugPrint('WidgetUpdate: syncWidgetAppearance FAILED: $e');
-      debugPrint('WidgetUpdate: stack: $stack');
+      AppLog.e(
+        'WidgetUpdateService',
+        'syncWidgetAppearance FAILED: $e\n$stack',
+      );
     }
   }
 
@@ -179,8 +184,7 @@ class WidgetUpdateService {
             'BugaoShan WidgetUpdateService: native updateWidget completed successfully',
           );
         } catch (e, stack) {
-          debugPrint('BugaoShan WidgetUpdateService: updateWidget FAILED: $e');
-          debugPrint('BugaoShan WidgetUpdateService: stack: $stack');
+          AppLog.e('WidgetUpdateService', 'updateWidget FAILED: $e\n$stack');
           // Clear follow-up flag to avoid stale state causing extra runs
           _needsRunAgain = false;
           // Propagate error to awaiting callers and stop further runs
@@ -251,7 +255,7 @@ class WidgetUpdateService {
         return false;
       }
     } catch (e) {
-      debugPrint('WidgetUpdate: pinWidget FAILED: $e');
+      AppLog.e('WidgetUpdateService', 'pinWidget FAILED: $e');
       return false;
     }
   }
@@ -265,7 +269,7 @@ class WidgetUpdateService {
       final result = await _channel.invokeMethod<List<dynamic>>('getWidgetIds');
       return result?.whereType<int>().toSet() ?? {};
     } catch (e) {
-      debugPrint('WidgetUpdate: getWidgetIds FAILED: $e');
+      AppLog.e('WidgetUpdateService', 'getWidgetIds FAILED: $e');
       return {};
     }
   }
@@ -279,7 +283,7 @@ class WidgetUpdateService {
       final result = await _channel.invokeMethod<bool>('openAppSettings');
       return result ?? false;
     } catch (e) {
-      debugPrint('WidgetUpdate: openAppSettings FAILED: $e');
+      AppLog.e('WidgetUpdateService', 'openAppSettings FAILED: $e');
       return false;
     }
   }
@@ -292,7 +296,10 @@ class WidgetUpdateService {
       );
       return result ?? false;
     } catch (e) {
-      debugPrint('WidgetUpdate: isIgnoringBatteryOptimizations FAILED: $e');
+      AppLog.e(
+        'WidgetUpdateService',
+        'isIgnoringBatteryOptimizations FAILED: $e',
+      );
       return false;
     }
   }
@@ -305,7 +312,10 @@ class WidgetUpdateService {
       );
       return result ?? false;
     } catch (e) {
-      debugPrint('WidgetUpdate: requestIgnoreBatteryOptimizations FAILED: $e');
+      AppLog.e(
+        'WidgetUpdateService',
+        'requestIgnoreBatteryOptimizations FAILED: $e',
+      );
       return false;
     }
   }

--- a/lib/utils/app_log.dart
+++ b/lib/utils/app_log.dart
@@ -1,0 +1,50 @@
+import 'package:bugaoshan/injection/injector.dart';
+import 'package:bugaoshan/utils/auth_logger.dart';
+
+/// 业务层通用日志门面。
+///
+/// 与 `AuthLogger` 共享同一个内存缓冲 / 脱敏 / 文件落盘机制（Dev 页日志查看器
+/// 能看到全部来源的日志），但提供「业务语义」的静态入口，避免业务代码直接依赖
+/// 名字里带 Auth 的类，降低认知负担。
+///
+/// 用法：
+/// ```dart
+/// AppLog.e('GradesProvider', 'cache decode failed: $e');
+/// AppLog.i('UpdateService', 'download started');
+/// ```
+///
+/// 约定：
+/// - 错误路径（catch 分支、失败状态）用 [e] / [w]；
+/// - 生命周期 / 关键里程碑用 [i]；
+/// - [d] 仅供本地调试，生产构建静默（与 [AuthLogger] 行为一致）。
+/// - 消息中出现的 access_token / password / 学号等敏感字段会被
+///   [AuthLogRedactor] 自动脱敏，无需手动处理。
+class AppLog {
+  AppLog._();
+
+  static AuthLogger? _cached;
+  static AuthLogger? _fallback;
+
+  /// 延迟获取单例：避免在 DI 装配完成前访问 getIt 抛错。
+  /// 一旦拿到实例即缓存，避免热路径反复查表。
+  ///
+  /// 在未注册 AuthLogger 的环境（如部分单元测试直接构造被测对象、
+  /// 不初始化 GetIt）下退化为独立裸实例，保证日志调用不抛异常；
+  /// 生产环境始终命中已注册的单例，行为不变。
+  static AuthLogger get _logger {
+    final cached = _cached;
+    if (cached != null) return cached;
+    try {
+      final instance = getIt<AuthLogger>();
+      _cached = instance;
+      return instance;
+    } on Object {
+      return _fallback ??= AuthLogger();
+    }
+  }
+
+  static void d(String tag, String message) => _logger.d(tag, message);
+  static void i(String tag, String message) => _logger.i(tag, message);
+  static void w(String tag, String message) => _logger.w(tag, message);
+  static void e(String tag, String message) => _logger.e(tag, message);
+}

--- a/lib/utils/holiday_utils.dart
+++ b/lib/utils/holiday_utils.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/foundation.dart';
 import 'package:tyme/tyme.dart';
+import 'package:bugaoshan/utils/app_log.dart';
 
 /// 特殊日类型
 enum SpecialDayType { ordinary, festival, holiday, solarTerm }
@@ -53,7 +53,7 @@ class HolidayUtils {
         return legalHoliday.isWork() ? null : legalHoliday.getName();
       }
     } catch (e) {
-      debugPrint('HolidayUtils.getHolidayName error: $e');
+      AppLog.w('HolidayUtils', 'getHolidayName error: $e');
     }
     // tyme 无此日数据 → 固定日期放假兜底
     return _getFixedHolidayFallback(date);
@@ -142,7 +142,7 @@ class HolidayUtils {
               count++;
             }
           } catch (e) {
-            debugPrint('HolidayUtils._computeHolidayTotalDays error: $e');
+            AppLog.w('HolidayUtils', '_computeHolidayTotalDays error: $e');
           }
         }
       }
@@ -165,7 +165,7 @@ class HolidayUtils {
         if (name != '春节' && name != '清明节') return name;
       }
     } catch (e) {
-      debugPrint('HolidayUtils.getFestivalName error: $e');
+      AppLog.w('HolidayUtils', 'getFestivalName error: $e');
     }
     return null;
   }
@@ -182,7 +182,7 @@ class HolidayUtils {
         return termDay.getSolarTerm().getName();
       }
     } catch (e) {
-      debugPrint('HolidayUtils.getSolarTermName error: $e');
+      AppLog.w('HolidayUtils', 'getSolarTermName error: $e');
     }
     return null;
   }
@@ -256,7 +256,7 @@ class HolidayUtils {
         );
       }
     } catch (e) {
-      debugPrint('HolidayUtils.getSpecialDay error: $e');
+      AppLog.w('HolidayUtils', 'getSpecialDay error: $e');
     }
 
     return SpecialDayInfo(type: SpecialDayType.ordinary);

--- a/lib/widgets/common/image_viewer.dart
+++ b/lib/widgets/common/image_viewer.dart
@@ -6,6 +6,7 @@ import 'package:http/http.dart' as http;
 import 'package:path_provider/path_provider.dart';
 import 'package:photo_view/photo_view.dart';
 import 'package:bugaoshan/l10n/app_localizations.dart';
+import 'package:bugaoshan/utils/app_log.dart';
 import 'package:bugaoshan/utils/share_utils.dart';
 
 void showFullScreenImageViewer(
@@ -121,7 +122,7 @@ class ImageViewerPage extends StatelessWidget {
         ).showSnackBar(SnackBar(content: Text(l10n.imageSavedToGallery)));
       }
     } catch (e) {
-      debugPrint('Save image error: $e');
+      AppLog.e('ImageViewer', 'Save image error: $e');
       if (context.mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
@@ -145,7 +146,7 @@ class ImageViewerPage extends StatelessWidget {
       if (!context.mounted) return;
       await shareSingleFile(file.path, context: context);
     } catch (e) {
-      debugPrint('Share image error: $e');
+      AppLog.e('ImageViewer', 'Share image error: $e');
       if (context.mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(

--- a/lib/widgets/webview/webview_notice_handlers.dart
+++ b/lib/widgets/webview/webview_notice_handlers.dart
@@ -4,6 +4,7 @@ import 'package:bugaoshan/injection/injector.dart';
 import 'package:bugaoshan/l10n/app_localizations.dart';
 import 'package:bugaoshan/pages/campus/downloads/shared_notice_downloads.dart';
 import 'package:bugaoshan/services/download_manager.dart';
+import 'package:bugaoshan/utils/app_log.dart';
 import 'package:bugaoshan/widgets/common/image_viewer.dart';
 import 'package:bugaoshan/widgets/dialog/dialog.dart'; // for appConfigService
 import 'package:flutter/material.dart';
@@ -35,7 +36,10 @@ mixin WebViewNoticeHandlers<T extends StatefulWidget> on State<T> {
           .toList();
       if (mounted) setState(() => pageAttachments = attachments);
     } catch (e) {
-      debugPrint('$debugLabel parse attachments error: $e');
+      AppLog.e(
+        'WebViewNoticeHandlers',
+        '$debugLabel parse attachments error: $e',
+      );
     }
   }
 
@@ -238,7 +242,10 @@ mixin WebViewNoticeHandlers<T extends StatefulWidget> on State<T> {
         );
       }
     } catch (e) {
-      debugPrint('$debugLabel download attachment error: $e');
+      AppLog.e(
+        'WebViewNoticeHandlers',
+        '$debugLabel download attachment error: $e',
+      );
     }
   }
 
@@ -265,7 +272,7 @@ mixin WebViewNoticeHandlers<T extends StatefulWidget> on State<T> {
       }
       return true;
     } catch (e) {
-      debugPrint('$debugLabel download error: $e');
+      AppLog.e('WebViewNoticeHandlers', '$debugLabel download error: $e');
       return false;
     }
   }

--- a/lib/widgets/webview/webview_notice_page.dart
+++ b/lib/widgets/webview/webview_notice_page.dart
@@ -2,6 +2,7 @@ import 'package:bugaoshan/l10n/app_localizations.dart';
 import 'package:bugaoshan/pages/campus/downloads/shared_notice_downloads.dart';
 import 'package:bugaoshan/providers/app_config_provider.dart';
 import 'package:bugaoshan/widgets/dialog/dialog.dart';
+import 'package:bugaoshan/utils/app_log.dart';
 import 'package:bugaoshan/widgets/route/router_utils.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart' show rootBundle;
@@ -143,13 +144,19 @@ class _WebViewNoticePageState extends State<WebViewNoticePage>
       try {
         await controller.evaluateJavascript(source: _beautifyScript);
       } catch (e) {
-        debugPrint('${widget.debugLabel} beautify script error: $e');
+        AppLog.e(
+          'WebViewNoticePage',
+          '${widget.debugLabel} beautify script error: $e',
+        );
       }
       if (_domReadyScript.isNotEmpty) {
         try {
           await controller.evaluateJavascript(source: _domReadyScript);
         } catch (e) {
-          debugPrint('${widget.debugLabel} dom ready script error: $e');
+          AppLog.e(
+            'WebViewNoticePage',
+            '${widget.debugLabel} dom ready script error: $e',
+          );
           await _finishLoading();
         }
         return;
@@ -289,7 +296,10 @@ class _WebViewNoticePageState extends State<WebViewNoticePage>
                 onLoadStart: _onLoadStart,
                 onLoadStop: _onLoadStop,
                 onReceivedError: (controller, request, error) {
-                  debugPrint('${widget.debugLabel} WebView error: $error');
+                  AppLog.e(
+                    'WebViewNoticePage',
+                    '${widget.debugLabel} WebView error: $error',
+                  );
                   if ((request.isForMainFrame ?? false) &&
                       _errorHtmlTemplate.isNotEmpty) {
                     final html = _errorHtmlTemplate.replaceAll(


### PR DESCRIPTION
## 变更内容

引入 `AppLog` 统一日志门面，将业务层的错误/警告日志从 `debugPrint` 迁移到 `AuthLogger` 的内存缓冲与脱敏体系。

## 背景

此前业务错误日志散落在各处 `debugPrint`，无法进入 Dev 页日志查看器，也不经过脱敏处理，排查问题与安全导出受限。`AuthLogger` 已具备内存缓冲、脱敏、可选文件落盘能力，本次通过静态门面 `AppLog` 让业务代码以低心智负担的方式接入。

## 实现

- **新增 `lib/utils/app_log.dart`**：静态门面，延迟取用 `getIt<AuthLogger>()` 并缓存；测试环境未注册时退化为裸实例，保证日志调用不抛异常
- **迁移 20+ 文件错误路径**：`debugPrint` → `AppLog.e` / `AppLog.w`（不可回退错误归 `e`，可回退/警告归 `w`），涉及登录、成绩、课表、教室、校历、报修、WebView 附件、小组件同步等
- **顺带清理**：移除迁移后无引用的 `foundation` import；`service_api_service` 消除与 `_log.w` 重复的日志；`widget_update_service` 将消息+stack 合并为单条日志
- **保留 `debugPrint`**：DI 装配期、startup、生命周期调试、UI 透传原始错误消息等场景

## 验证

- [x] `flutter analyze` 无警告无错误
- [x] `widget_update_service_test`、`webview_notice_handlers_test` 全部通过（验证 fallback 路径）
- [x] 7 个相关 provider/service 测试全部通过，无回归

## 影响范围

纯日志重构，无功能与 UI 行为变更。日志现在会进入 Dev 页查看器，敏感字段（access_token / password 等）自动脱敏。