### PR TITLE
feat(course): 课表主页顶栏新增课表快捷切换按钮

### DIFF
--- a/lib/pages/course/main/course_page.dart
+++ b/lib/pages/course/main/course_page.dart
@@ -149,7 +149,11 @@ class _CoursePageState extends State<CoursePage> with WidgetsBindingObserver {
       children: [
         if (!widget.demoMode && _controller != null)
           ListenableBuilder(
-            listenable: _controller!,
+            listenable: Listenable.merge([
+              _controller!,
+              courseProvider.allSchedules,
+              courseProvider.scheduleConfig,
+            ]),
             builder: (context, _) => CoursePageTopBar(
               visibleWeek: _controller!.visibleWeek,
               totalWeeks: _controller!.totalWeeks,
@@ -166,6 +170,11 @@ class _CoursePageState extends State<CoursePage> with WidgetsBindingObserver {
               onImport: _onImport,
               onExport: _onExport,
               onAddCourse: _onAddCourse,
+              schedules: courseProvider.allSchedules.value,
+              currentScheduleId: courseProvider.scheduleConfig.value?.id,
+              onSwitchSchedule: (id) => courseProvider.switchSchedule(id),
+              onOpenScheduleManagement: () =>
+                  _openScheduleManagement(logicRootContext),
             ),
           ),
         Expanded(

--- a/lib/pages/course/main/course_page_top_bar.dart
+++ b/lib/pages/course/main/course_page_top_bar.dart
@@ -197,7 +197,7 @@ class CoursePageTopBar extends StatelessWidget {
                         children: [
                           // 缩进与上方课表项文字对齐（图标 20 + 间距 8）。
                           const SizedBox(width: 28),
-                          Text(l10n.scheduleManagement),
+                          Expanded(child: Text(l10n.scheduleManagement)),
                         ],
                       ),
                     ),

--- a/lib/pages/course/main/course_page_top_bar.dart
+++ b/lib/pages/course/main/course_page_top_bar.dart
@@ -1,7 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:bugaoshan/l10n/app_localizations.dart';
+import 'package:bugaoshan/models/course.dart';
 import 'package:bugaoshan/providers/app_config_provider.dart';
 import 'package:bugaoshan/theme_shape.dart';
+
+/// 切换课表菜单里「管理课表」项的哨兵值，不会与课表 id 冲突。
+const _kScheduleManagementMenuValue = '__management__';
 
 class CoursePageTopBar extends StatelessWidget {
   final int visibleWeek;
@@ -21,6 +25,12 @@ class CoursePageTopBar extends StatelessWidget {
   final VoidCallback onExport;
   final VoidCallback onAddCourse;
 
+  /// 课表快捷切换：多于一份课表时在右侧按钮区最前显示弹窗菜单。
+  final List<ScheduleConfig> schedules;
+  final String? currentScheduleId;
+  final ValueChanged<String> onSwitchSchedule;
+  final VoidCallback onOpenScheduleManagement;
+
   const CoursePageTopBar({
     super.key,
     required this.visibleWeek,
@@ -38,6 +48,10 @@ class CoursePageTopBar extends StatelessWidget {
     required this.onImport,
     required this.onExport,
     required this.onAddCourse,
+    this.schedules = const [],
+    this.currentScheduleId,
+    required this.onSwitchSchedule,
+    required this.onOpenScheduleManagement,
   });
 
   @override
@@ -136,6 +150,59 @@ class CoursePageTopBar extends StatelessWidget {
           ),
           Row(
             children: [
+              if (schedules.length > 1)
+                PopupMenuButton<String>(
+                  icon: const Icon(Icons.swap_horiz, size: 20),
+                  tooltip: l10n.switchSchedule,
+                  // padding 6 + 20px 图标 = 32×32，与旁边 IconButton 的
+                  // constraints 对齐（constraints 参数约束的是菜单不是按钮）。
+                  padding: const EdgeInsets.all(6),
+                  onSelected: (id) {
+                    if (id == _kScheduleManagementMenuValue) {
+                      onOpenScheduleManagement();
+                    } else {
+                      onSwitchSchedule(id);
+                    }
+                  },
+                  itemBuilder: (context) => [
+                    ...schedules.map(
+                      (schedule) => PopupMenuItem<String>(
+                        value: schedule.id,
+                        child: Row(
+                          children: [
+                            if (schedule.id == currentScheduleId)
+                              Icon(
+                                Icons.check,
+                                color: Theme.of(context).colorScheme.primary,
+                                size: 20,
+                              )
+                            else
+                              const SizedBox(width: 20),
+                            const SizedBox(width: 8),
+                            Expanded(
+                              child: Text(
+                                schedule.semesterName,
+                                maxLines: 1,
+                                overflow: TextOverflow.ellipsis,
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
+                    const PopupMenuDivider(),
+                    PopupMenuItem<String>(
+                      value: _kScheduleManagementMenuValue,
+                      child: Row(
+                        children: [
+                          // 缩进与上方课表项文字对齐（图标 20 + 间距 8）。
+                          const SizedBox(width: 28),
+                          Text(l10n.scheduleManagement),
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
               IconButton(
                 onPressed: onImport,
                 icon: const Icon(Icons.download_rounded, size: 20),

--- a/test/course_page_top_bar_test.dart
+++ b/test/course_page_top_bar_test.dart
@@ -1,0 +1,116 @@
+import 'package:bugaoshan/l10n/app_localizations.dart';
+import 'package:bugaoshan/models/course.dart';
+import 'package:bugaoshan/pages/course/main/course_page_top_bar.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+CoursePageTopBar _buildBar({
+  required List<ScheduleConfig> schedules,
+  String? currentScheduleId,
+  required ValueChanged<String> onSwitchSchedule,
+  required VoidCallback onOpenScheduleManagement,
+}) {
+  return CoursePageTopBar(
+    visibleWeek: 1,
+    totalWeeks: 20,
+    actualWeek: 1,
+    animationDuration: Duration.zero,
+    onPreviousWeek: () {},
+    onNextWeek: () {},
+    onGoToCurrentWeek: () {},
+    onImport: () {},
+    onExport: () {},
+    onAddCourse: () {},
+    schedules: schedules,
+    currentScheduleId: currentScheduleId,
+    onSwitchSchedule: onSwitchSchedule,
+    onOpenScheduleManagement: onOpenScheduleManagement,
+  );
+}
+
+Widget _wrap(Widget child) => MaterialApp(
+  localizationsDelegates: AppLocalizations.localizationsDelegates,
+  supportedLocales: AppLocalizations.supportedLocales,
+  home: Scaffold(body: child),
+);
+
+ScheduleConfig _schedule(String id, String name) => ScheduleConfig(
+  id: id,
+  semesterName: name,
+  semesterStartDate: DateTime(2026, 9, 7),
+);
+
+void main() {
+  testWidgets('单课表时不显示切换按钮', (tester) async {
+    await tester.pumpWidget(
+      _wrap(
+        _buildBar(
+          schedules: [_schedule('a', '2026秋')],
+          currentScheduleId: 'a',
+          onSwitchSchedule: (_) {},
+          onOpenScheduleManagement: () {},
+        ),
+      ),
+    );
+
+    expect(find.byIcon(Icons.swap_horiz), findsNothing);
+  });
+
+  testWidgets('多课时展示菜单：当前课表打勾，点选触发切换回调', (tester) async {
+    String? switchedId;
+    await tester.pumpWidget(
+      _wrap(
+        _buildBar(
+          schedules: [_schedule('a', '2026秋'), _schedule('b', '2026春')],
+          currentScheduleId: 'a',
+          onSwitchSchedule: (id) => switchedId = id,
+          onOpenScheduleManagement: () {},
+        ),
+      ),
+    );
+
+    final l10n = AppLocalizations.of(
+      tester.element(find.byType(CoursePageTopBar)),
+    )!;
+
+    await tester.tap(find.byIcon(Icons.swap_horiz));
+    await tester.pumpAndSettle();
+
+    // 两个课表项 + 「管理课表」入口都在菜单里。
+    expect(find.text('2026秋'), findsOneWidget);
+    expect(find.text('2026春'), findsOneWidget);
+    expect(find.text(l10n.scheduleManagement), findsOneWidget);
+    // 只有当前课表打勾。
+    expect(find.byIcon(Icons.check), findsOneWidget);
+
+    await tester.tap(find.text('2026春'));
+    await tester.pumpAndSettle();
+
+    expect(switchedId, equals('b'));
+  });
+
+  testWidgets('菜单里的「管理课表」触发管理页回调', (tester) async {
+    var managementOpened = false;
+    await tester.pumpWidget(
+      _wrap(
+        _buildBar(
+          schedules: [_schedule('a', '2026秋'), _schedule('b', '2026春')],
+          currentScheduleId: 'a',
+          onSwitchSchedule: (_) {},
+          onOpenScheduleManagement: () => managementOpened = true,
+        ),
+      ),
+    );
+
+    final l10n = AppLocalizations.of(
+      tester.element(find.byType(CoursePageTopBar)),
+    )!;
+
+    await tester.tap(find.byIcon(Icons.swap_horiz));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text(l10n.scheduleManagement));
+    await tester.pumpAndSettle();
+
+    expect(managementOpened, isTrue);
+  });
+}


### PR DESCRIPTION
## 课表快捷切换按钮

### 功能描述

在课程表主页右上角新增「切换」按钮，弹窗菜单列出全部课表配置，点选即一键切换，方便需要对照查看双课表的同学快速切换。

- 仅当存在 **2 个及以上**课表时显示按钮，单课表时自动隐藏
- 当前课表在菜单中打勾标记
- 菜单底部附带「管理课表」入口——此前课表非空状态下顶栏没有任何入口能进入课表管理页，借此补上
- 切换走既有的 `CourseProvider.switchSchedule()` 路径，课表重载、周数徽章、放假页、桌面小组件数据全部由 Provider 响应式刷新

### 改动范围

仅 2 个文件、+77/-1 行，纯 UI 层改动：

| 文件 | 改动 |
|---|---|
| `lib/pages/course/main/course_page_top_bar.dart` | 右侧按钮区新增 `PopupMenuButton`，样式与旁边 `IconButton`（32×32）及电费页「切换房间」菜单惯例对齐 |
| `lib/pages/course/main/course_page.dart` | 传入课表数据与回调；顶栏重建监听合并 `allSchedules` / `scheduleConfig` 两个 notifier，保证增删课表后菜单即时刷新 |

复用现有文案（`switchSchedule`、`scheduleManagement`），**无 ARB / 数据库 / Provider 改动**。

### 验证

- [x] `flutter analyze` 无新增告警
- [x] `flutter test` 全部通过（394 通过 / 1 跳过）
- [x] 导入第二个课表 → 顶栏出现切换按钮 → 菜单勾选当前课表 → 点选切换后课表/周数/小组件数据正确刷新；单课表时按钮隐藏