### PR TITLE
build: 启用 unawaited_futures / always_declare_return_types lints 并全库修复

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -240,6 +240,17 @@ Dev page (`lib/pages/dev/auth_log/`) gains:
 - `AuthLogFilterBar` — filter chips for log level and tag selection.
 - `AuthLogViewerPage` — full-screen viewer with level filter chips + tag dropdown + clear + copy + save actions.
 
+### 业务日志（AppLog）
+
+`AppLog`（`lib/utils/app_log.dart`）是业务层日志门面：与 `AuthLogger` **共享同一个**内存环形缓冲、脱敏规则与文件落盘，Dev 页日志查看器能看到全部来源的日志。延迟从 GetIt 取 `AuthLogger` 单例；测试环境未注册时退化为独立裸实例，保证日志调用永不抛异常。
+
+约定（与 Auth Logging 一并遵守）：
+
+- 错误路径（catch 分支、失败状态）→ `AppLog.e` / `AppLog.w`，**不要**在错误分支写 `debugPrint`。
+- 生命周期 / 关键里程碑 → `AppLog.i`。
+- 本地调试输出 → `AppLog.d`（生产静默）；`debugPrint` 仅限 kDebugMode 下的 DI 装配期 / 启动期调试。
+- 消息中的 access_token / password 等敏感字段由 `AuthLogRedactor` 自动脱敏，无需手动处理。
+
 ### Notice Pages
 
 Three notice sources, each in its own subdirectory under `lib/pages/campus/notice/` (see `docs/architecture/notice-webview.md`):
@@ -290,6 +301,7 @@ Shared downloads module lives in `lib/pages/campus/downloads/`:
 - **EULA gate** — `app.dart` checks `AppConfigProvider.acceptedEulaVersion`; below `currentEulaVersion` shows `EulaGatePage` (EULA text is in `lib/widgets/eula_content.dart` and `assets/eula.md`).
 - **First-launch wizard** — `WizardPage` shown if `firstLaunchWizardCompleted` is false.
 - **手写 JSON 解析** — 统一用 `lib/utils/json_utils.dart` 的 `safeDouble` / `safeInt` / `safeString` / `safeBool` 宽松取值，替代 `(json['x'] as num?)?.toDouble() ?? 0` 样板与裸强转（脏数据回退默认值而非崩溃）。**刻意不引入** json_serializable 全量迁移——现有手写规模不值得。
+- **大文件拆分约定** — 超大文件（600+ 行）拆分用两种模式，均保持外部 import 零改动：① `part` 文件（私有符号跨文件共享，如 `repair_page.dart` + `repair_submit_tab.dart`/`repair_widgets.dart`、`zhjw_api_service.dart` + `zhjw_html_parsers.dart`、`balance_query_provider.dart` + `balance_query_state.dart`）；② barrel re-export（如 `calendar_event_utils.dart`、`service_plugin_models.dart`、`course.dart`）。**有意不拆**的单文件（勿再起拆分之心）：`notice_downloaded_page.dart` / `classroom_page.dart` / `scu_auth.dart` 为单一内聚 State/状态机；`calendar_location_mapper.dart` 为纯静态数据表（有专项单测守着）。向 `zhjw` / `zhhq` 等仍在增长的主文件加解析逻辑时，新代码进对应 part 文件而非主文件。
 
 ### Storage
 
@@ -311,11 +323,12 @@ CI builds inject git metadata via `--dart-define` flags: `GIT_TAG`, `GIT_COMMIT`
 
 ## Testing
 
-- Unit + widget tests in `test/` (`flutter test`).
+- Unit + widget tests in `test/` (`flutter test`) — 共 60+ 测试文件,覆盖认证 / API service / Provider / 纯函数工具 / Widget;下列条目仅为早期代表,非全集.
   - `widget_test.dart` — pure logic tests on `Course` + `selectVisibleCoursesForDay`.
   - `widget_update_service_test.dart` — debounce / in-flight coalescing / dispose semantics using `fake_async` and a mocked `bugaoshan/update` MethodChannel.
   - `add_widget_picker_test.dart` — widget test with `SharedPreferences.setMockInitialValues` and a `FakeWidgetUpdateService`; resets `getIt` between tests.
   - `test_page_test.dart` — integration-ish page test.
+- `service_capture_calibration_test.dart` — 办事大厅表单引擎的真实抓包端到端校准,依赖 `test/fixtures/service_capture.json`(含真实个人信息,**不入库**);fixture 缺失时整套显式 skip,测试输出中的 `~1` 跳过即此,属预期.
 - Integration driver: `test_driver/main.dart` (`flutter drive`).
 
 Always run `dart format` (the repo's pre-commit hook enforces this on staged `.dart` files — see `.githooks/pre-commit`). When adding new tests, use `SharedPreferences.setMockInitialValues({})` + `getIt.reset()` to keep them hermetic.
@@ -357,6 +370,7 @@ The auto-changelog flow:
 ## Code Style
 
 - 遵循 `package:flutter_lints/flutter.yaml`(`analysis_options.yaml` 仅引用,未禁用任何规则).
+- 额外启用 `unawaited_futures` 与 `always_declare_return_types`(逐条实测 0 噪点后启用); 有意 fire-and-forget 的 Future 用 `unawaited()` 显式声明.
 - `dart format` 由 pre-commit 强制执行,提交前不要手动改格式.
 - `.editorconfig`: LF / UTF-8 / 2 空格缩进 / 末尾换行.
 - 内部注释与日志主要使用中文;UI 文案走 ARB 国际化.

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -30,6 +30,14 @@ linter:
   # `// ignore_for_file: name_of_lint` syntax on the line or in the file
   # producing the lint.
   rules:
+    # unawaited_futures：async 函数中未 await 的 Future（浮空 Future 会静默吞错）。
+    # 有意 fire-and-forget 处用 unawaited() 显式声明（代码库既有惯用法）。
+    - unawaited_futures
+    # always_declare_return_types：缺省返回类型的函数/闭包（补齐类型信息）。
+    - always_declare_return_types
+    # avoid_redundant_argument_values：实测 138 命中（UI 刻意显式传参为主），
+    # 噪音过高不启用，仅留档备查。
+    # - avoid_redundant_argument_values
     # avoid_print: false  # Uncomment to disable the `avoid_print` rule
     # prefer_single_quotes: true  # Uncomment to enable the `prefer_single_quotes` rule
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -35,7 +35,7 @@ Future<void> _initializeApp() async {
   await ensureBasicDependencies();
 
   // 清理下载的安装包（首次打开或更新后）。
-  getIt<UpdateService>().cleanupOldPackages();
+  unawaited(getIt<UpdateService>().cleanupOldPackages());
 
   // 桌面端记住窗口位置和大小，下次启动时恢复
   if (!kIsWeb && _isDesktopPlatform) {

--- a/lib/pages/about/about_page.dart
+++ b/lib/pages/about/about_page.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:bugaoshan/injection/injector.dart';
 import 'package:bugaoshan/l10n/app_localizations.dart';
@@ -82,21 +84,27 @@ class _AboutPageState extends State<AboutPage> {
 
         if (!mounted) return;
       } else if (result.status == UpdateCheckStatus.error) {
-        showInfoDialog(
-          title: localizations.checkForUpdates,
-          content: localizations.loadFailed,
+        unawaited(
+          showInfoDialog(
+            title: localizations.checkForUpdates,
+            content: localizations.loadFailed,
+          ),
         );
       } else {
-        showInfoDialog(
-          title: localizations.checkForUpdates,
-          content: localizations.noUpdateAvailable,
+        unawaited(
+          showInfoDialog(
+            title: localizations.checkForUpdates,
+            content: localizations.noUpdateAvailable,
+          ),
         );
       }
     } catch (e) {
       if (mounted) {
-        showInfoDialog(
-          title: localizations.checkForUpdates,
-          content: localizations.loadFailed,
+        unawaited(
+          showInfoDialog(
+            title: localizations.checkForUpdates,
+            content: localizations.loadFailed,
+          ),
         );
       }
     }

--- a/lib/pages/auth/scu_login_page.dart
+++ b/lib/pages/auth/scu_login_page.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:typed_data';
 import 'package:bugaoshan/injection/injector.dart';
@@ -163,13 +164,13 @@ class _ScuLoginPageState extends State<ScuLoginPage> {
       if (!mounted) return;
       final l10n = AppLocalizations.of(context)!;
       setState(() => _errorMsg = _localizeLoginError(e, l10n));
-      _loadCaptcha();
+      unawaited(_loadCaptcha());
     } catch (e) {
       AppLog.e('ScuLoginPage', 'Login network error: $e');
       if (!mounted) return;
       final l10n = AppLocalizations.of(context)!;
       setState(() => _errorMsg = l10n.networkError);
-      _loadCaptcha();
+      unawaited(_loadCaptcha());
     } finally {
       if (mounted) setState(() => _loading = false);
     }

--- a/lib/pages/campus/classroom/classroom_page.dart
+++ b/lib/pages/campus/classroom/classroom_page.dart
@@ -107,7 +107,7 @@ class _ClassroomPageState extends State<ClassroomPage> {
         _selectedDate = picked;
       });
       if (_selectedBuilding != null) {
-        _queryBuilding(_selectedBuilding!);
+        unawaited(_queryBuilding(_selectedBuilding!));
       }
     }
   }

--- a/lib/pages/campus/downloads/file_utils.dart
+++ b/lib/pages/campus/downloads/file_utils.dart
@@ -58,7 +58,7 @@ class DownloadPathIndex {
     } finally {
       gate.complete();
       if (identical(_directoryQueues[_queueKey], current)) {
-        _directoryQueues.remove(_queueKey);
+        unawaited(_directoryQueues.remove(_queueKey));
       }
     }
   }

--- a/lib/pages/campus/downloads/notice_downloaded_page.dart
+++ b/lib/pages/campus/downloads/notice_downloaded_page.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:bugaoshan/injection/injector.dart';
@@ -363,7 +364,7 @@ class _NoticeDownloadedPageState extends State<NoticeDownloadedPage>
       ),
     );
     _exitSelection();
-    _loadFiles();
+    unawaited(_loadFiles());
   }
 
   // ── UI helpers ────────────────────────────────────────────────────────────────────

--- a/lib/pages/campus/repair/repair_widgets.dart
+++ b/lib/pages/campus/repair/repair_widgets.dart
@@ -35,10 +35,13 @@ class _MyTicketsTabState extends State<_MyTicketsTab> {
   Future<void> _refresh() async {
     await provider.loadTickets(force: true);
     if (!_scrollController.hasClients) return;
-    _scrollController.animateTo(
-      0,
-      duration: const Duration(milliseconds: 200),
-      curve: Curves.easeOut,
+    // 滚动动画无需等待完成即视为刷新结束（fire-and-forget）。
+    unawaited(
+      _scrollController.animateTo(
+        0,
+        duration: const Duration(milliseconds: 200),
+        curve: Curves.easeOut,
+      ),
     );
   }
 

--- a/lib/pages/course/edit/course_edit_page.dart
+++ b/lib/pages/course/edit/course_edit_page.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:math';
 
 import 'package:flutter/material.dart';
@@ -415,9 +416,11 @@ class _CourseEditPageState extends State<CourseEditPage> {
     }
 
     if (!isValidPeriod) {
-      showInfoDialog(
-        title: l10n.crossPeriodError,
-        content: l10n.crossPeriodErrorMessage,
+      unawaited(
+        showInfoDialog(
+          title: l10n.crossPeriodError,
+          content: l10n.crossPeriodErrorMessage,
+        ),
       );
       return;
     }
@@ -444,9 +447,11 @@ class _CourseEditPageState extends State<CourseEditPage> {
 
     if (hasConflict) {
       if (!mounted) return;
-      showInfoDialog(
-        title: l10n.timeConflict,
-        content: l10n.timeConflictMessage,
+      unawaited(
+        showInfoDialog(
+          title: l10n.timeConflict,
+          content: l10n.timeConflictMessage,
+        ),
       );
       return;
     }

--- a/lib/pages/course/import/import_schedule_page.dart
+++ b/lib/pages/course/import/import_schedule_page.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'package:flutter/material.dart';
 import 'package:bugaoshan/injection/injector.dart';
@@ -196,7 +197,12 @@ class _ImportSchedulePageState extends State<ImportSchedulePage> {
     } catch (e) {
       AppLog.e('ImportSchedulePage', 'Import from share error: $e');
       if (mounted) {
-        showInfoDialog(title: l10n.importFailed, content: l10n.importFailedTip);
+        unawaited(
+          showInfoDialog(
+            title: l10n.importFailed,
+            content: l10n.importFailedTip,
+          ),
+        );
       }
     }
   }
@@ -207,7 +213,9 @@ class _ImportSchedulePageState extends State<ImportSchedulePage> {
 
     if (!authProvider.isLoggedIn) {
       if (mounted) {
-        showInfoDialog(title: l10n.loginRequired, content: l10n.scuLogin);
+        unawaited(
+          showInfoDialog(title: l10n.loginRequired, content: l10n.scuLogin),
+        );
       }
       return;
     }
@@ -229,13 +237,17 @@ class _ImportSchedulePageState extends State<ImportSchedulePage> {
         }
       }
     } on ScuException catch (e) {
-      if (mounted) showInfoDialog(title: l10n.importFailed, content: e.message);
+      if (mounted) {
+        unawaited(showInfoDialog(title: l10n.importFailed, content: e.message));
+      }
       if (mounted) setState(() => _loading = false);
       return;
     } catch (e) {
       AppLog.e('ImportSchedulePage', 'Import online error: $e');
       if (mounted) {
-        showInfoDialog(title: l10n.importFailed, content: l10n.importFailed);
+        unawaited(
+          showInfoDialog(title: l10n.importFailed, content: l10n.importFailed),
+        );
         setState(() => _loading = false);
       }
       return;
@@ -487,11 +499,15 @@ class _ImportSchedulePageState extends State<ImportSchedulePage> {
         }
       }
     } on ScuException catch (e) {
-      if (mounted) showInfoDialog(title: l10n.importFailed, content: e.message);
+      if (mounted) {
+        unawaited(showInfoDialog(title: l10n.importFailed, content: e.message));
+      }
     } catch (e) {
       AppLog.e('ImportSchedulePage', 'Import from jwxt error: $e');
       if (mounted) {
-        showInfoDialog(title: l10n.importFailed, content: l10n.importFailed);
+        unawaited(
+          showInfoDialog(title: l10n.importFailed, content: l10n.importFailed),
+        );
       }
     } finally {
       if (mounted) setState(() => _loading = false);

--- a/lib/pages/course/main/course_page.dart
+++ b/lib/pages/course/main/course_page.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:bugaoshan/injection/injector.dart';
 import 'package:bugaoshan/l10n/app_localizations.dart';
@@ -332,7 +334,7 @@ class _CoursePageState extends State<CoursePage> with WidgetsBindingObserver {
         ),
       );
       if (confirmed == true) {
-        courseProvider.switchSchedule(matchId);
+        unawaited(courseProvider.switchSchedule(matchId));
       }
     } catch (e) {
       AppLog.w('CoursePage', 'Failed to check next semester: $e');

--- a/lib/pages/course/management/prompt_new_schedule.dart
+++ b/lib/pages/course/management/prompt_new_schedule.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:bugaoshan/l10n/app_localizations.dart';
 import 'package:bugaoshan/models/course.dart';
@@ -42,7 +44,7 @@ Future<void> promptForNewScheduleConfig(
   if (!context.mounted) return;
 
   if (courseProvider.isScheduleNameTaken(newName)) {
-    showInfoDialog(title: l10n.duplicateScheduleName, content: '');
+    unawaited(showInfoDialog(title: l10n.duplicateScheduleName, content: ''));
     return;
   }
 

--- a/lib/pages/course/management/schedule_management_page.dart
+++ b/lib/pages/course/management/schedule_management_page.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:bugaoshan/widgets/common/third_center.dart';
 import 'package:flutter/material.dart';
 import 'package:bugaoshan/injection/injector.dart';
@@ -231,9 +233,11 @@ class ScheduleManagementPage extends StatelessWidget {
                               excludeId: schedule.id,
                             )) {
                               if (context.mounted) {
-                                showInfoDialog(
-                                  title: l10n.duplicateScheduleName,
-                                  content: '',
+                                unawaited(
+                                  showInfoDialog(
+                                    title: l10n.duplicateScheduleName,
+                                    content: '',
+                                  ),
                                 );
                               }
                               return;

--- a/lib/pages/course/settings/course_schedule_setting.dart
+++ b/lib/pages/course/settings/course_schedule_setting.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:bugaoshan/injection/injector.dart';
@@ -96,7 +98,7 @@ class _CourseScheduleSettingState extends State<CourseScheduleSetting> {
       setState(() {
         _startDate = newStartDate;
       });
-      _save();
+      unawaited(_save());
     } on ScuException catch (e) {
       if (!mounted) return;
       ScaffoldMessenger.of(
@@ -263,7 +265,7 @@ class _CourseScheduleSettingState extends State<CourseScheduleSetting> {
               setState(() {
                 _totalWeeks = selected;
               });
-              _save();
+              unawaited(_save());
             }
           },
         ),
@@ -377,7 +379,7 @@ class _CourseScheduleSettingState extends State<CourseScheduleSetting> {
       setState(() {
         _startDate = newStartDate;
       });
-      _save();
+      unawaited(_save());
     }
   }
 
@@ -402,7 +404,7 @@ class _CourseScheduleSettingState extends State<CourseScheduleSetting> {
       setState(() {
         _startDate = finalDate;
       });
-      _save();
+      unawaited(_save());
     }
   }
 

--- a/lib/pages/profile/login_status_card.dart
+++ b/lib/pages/profile/login_status_card.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:bugaoshan/injection/injector.dart';
 import 'package:bugaoshan/l10n/app_localizations.dart';
@@ -78,7 +80,7 @@ class _LoginStatusCardState extends State<LoginStatusCard> {
     final result = await popupOrNavigate(context, const ScuLoginPage());
     if (!mounted) return;
     if (result == true) {
-      _loadUsername();
+      unawaited(_loadUsername());
       final l10n = AppLocalizations.of(context)!;
       ScaffoldMessenger.of(
         context,

--- a/lib/pages/settings/set_course_style_page.dart
+++ b/lib/pages/settings/set_course_style_page.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/material.dart';
@@ -302,7 +303,7 @@ class SetCourseStylePage extends StatelessWidget {
     appConfig.backgroundImagePath.value = null;
     appConfig.backgroundImageCrop.value = null;
     if (oldPath != null) {
-      FileImage(File(oldPath)).evict();
+      unawaited(FileImage(File(oldPath)).evict());
       File(oldPath).delete().ignore();
     }
     if (appConfig.themeColorMode.value == ThemeColorMode.backgroundImage) {
@@ -345,7 +346,7 @@ class SetCourseStylePage extends StatelessWidget {
     // Delete old background file and evict from image cache
     final oldPath = appConfig.backgroundImagePath.value;
     if (oldPath != null) {
-      FileImage(File(oldPath)).evict();
+      unawaited(FileImage(File(oldPath)).evict());
       final oldFile = File(oldPath);
       if (await oldFile.exists()) {
         await oldFile.delete();

--- a/lib/widgets/dialog/dialog.dart
+++ b/lib/widgets/dialog/dialog.dart
@@ -1,4 +1,6 @@
-﻿import 'package:async/async.dart';
+﻿import 'dart:async';
+
+import 'package:async/async.dart';
 import 'package:flutter/material.dart';
 import 'package:bugaoshan/injection/injector.dart';
 import 'package:bugaoshan/l10n/app_localizations.dart';
@@ -138,7 +140,7 @@ Future showLoadingDialogWithErrorString({
   final l10n = AppLocalizations.of(logicRootContext)!;
   bool isError = false;
   ContextWrapper contextWrapper = ContextWrapper();
-  rebuildDialog() {
+  void rebuildDialog() {
     if (contextWrapper.context.mounted) {
       (contextWrapper.context as Element).markNeedsBuild();
     }

--- a/lib/widgets/dialog/download_progress_dialog.dart
+++ b/lib/widgets/dialog/download_progress_dialog.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/foundation.dart';
@@ -235,22 +236,24 @@ Future<bool> showDownloadProgressDialog({
   final progressState = updateProvider.progressState;
   var visible = true;
 
-  showDialog(
-    context: context,
-    useRootNavigator: true,
-    barrierDismissible: false,
-    builder: (dialogContext) => DownloadProgressDialogView(
-      progressState: progressState,
-      l10n: l10n,
-      filename: filename,
-      onDownloadInBackground: () {
-        visible = false;
-        Navigator.of(dialogContext).pop();
-      },
-      onCancel: () {
-        updateProvider.cancelDownload();
-        Navigator.of(dialogContext).pop();
-      },
+  unawaited(
+    showDialog(
+      context: context,
+      useRootNavigator: true,
+      barrierDismissible: false,
+      builder: (dialogContext) => DownloadProgressDialogView(
+        progressState: progressState,
+        l10n: l10n,
+        filename: filename,
+        onDownloadInBackground: () {
+          visible = false;
+          Navigator.of(dialogContext).pop();
+        },
+        onCancel: () {
+          updateProvider.cancelDownload();
+          Navigator.of(dialogContext).pop();
+        },
+      ),
     ),
   );
 
@@ -265,7 +268,7 @@ Future<bool> showDownloadProgressDialog({
     return false;
   } catch (e) {
     if (context.mounted && visible) {
-      Navigator.of(context, rootNavigator: true).maybePop();
+      unawaited(Navigator.of(context, rootNavigator: true).maybePop());
       ScaffoldMessenger.of(
         context,
       ).showSnackBar(SnackBar(content: Text('${l10n.updateFailed}: $e')));
@@ -274,7 +277,7 @@ Future<bool> showDownloadProgressDialog({
   }
 
   if (context.mounted && visible) {
-    Navigator.of(context, rootNavigator: true).maybePop();
+    unawaited(Navigator.of(context, rootNavigator: true).maybePop());
   }
   return true;
 }

--- a/lib/widgets/route/router_utils.dart
+++ b/lib/widgets/route/router_utils.dart
@@ -1,4 +1,6 @@
-﻿import 'package:flutter/material.dart';
+﻿import 'dart:async';
+
+import 'package:flutter/material.dart';
 import 'package:bugaoshan/theme_shape.dart';
 
 import 'popup_context.dart';
@@ -93,12 +95,14 @@ Future<dynamic> popupOrNavigate(
 
   // 如果已经在弹窗内，直接导航而不是再弹窗
   if (isInPopup) {
-    Navigator.push(
-      context,
-      MaterialPageRoute(
-        builder: (builder) {
-          return page;
-        },
+    unawaited(
+      Navigator.push(
+        context,
+        MaterialPageRoute(
+          builder: (builder) {
+            return page;
+          },
+        ),
       ),
     );
     return;

--- a/test/widget_update_service_test.dart
+++ b/test/widget_update_service_test.dart
@@ -85,7 +85,7 @@ void main() {
     await started.future;
 
     // Request another update while in-flight (force immediate path sets _needsRunAgain)
-    service.updateWidgetData(force: true);
+    unawaited(service.updateWidgetData(force: true));
 
     // Unblock the first native call
     block.complete();


### PR DESCRIPTION
## 变更内容

启用 `unawaited_futures` 与 `always_declare_return_types` 两个 lint 规则，并完成全库修复，维持零噪点验收。

## 背景

async 函数中未 await 的 Future（浮空 Future）会静默吞错；缺省返回类型的函数/闭包损失类型信息。为强化代码质量基线，启用这两个 lint 并全库清理。

## 实现

- **`analysis_options.yaml`**：启用 `unawaited_futures` + `always_declare_return_types`；`avoid_redundant_argument_values` 实测 138 命中（UI 刻意显式传参为主）噪音过高，不启用并留档原因
- **32 处 fire-and-forget Future 显式 `unawaited()`**：明确"有意不等待"意图，覆盖启动清理、弹窗（info/download 进度）、页面导航、验证码刷新、图片缓存驱逐等场景
- **`dialog.dart`**：`rebuildDialog` 补 `void` 返回类型
- **13 个文件补 `dart:async` import**
- **AGENTS.md**：补全 AppLog 日志门面 / 大文件拆分约定 / 额外 lints / 校准 fixture 说明

## 验证

- [x] `flutter analyze` 0 issues
- [x] 完整测试套件 420/420 通过，无回归

## 影响范围

无功能与 UI 行为变更；代码风格基线收紧，后续新增代码需遵守新 lint 规则。