### PR TITLE
ci: 在 Release 中链接 iOS 镜像构建 IPA 并优化文档

### DIFF
--- a/.github/scripts/release_body.py
+++ b/.github/scripts/release_body.py
@@ -11,8 +11,8 @@ def main():
     body = f"""## ⬇️ 下载 (Downloads)
 - Android: [arm64-Apk]({repo}/releases/download/v{version}/bugaoshan_{version}_arm64-v8a.apk)
 - Windows: [x64 Zip]({repo}/releases/download/v{version}/bugaoshan_{version}_windows_x64.zip)
-- macOS (Apple Silicon): [DMG](https://github.com/Visio-Vanitas/Bugaoshan/releases/download/v{version}/bugaoshan_{version}_macos_arm64.dmg)
-- IOS: 未发布正式版，可安装testflight后点击链接进行邀测: https://testflight.apple.com/join/Vyenb6gC
+- macOS (Apple Silicon): [dmg](https://github.com/Visio-Vanitas/Bugaoshan/releases/download/v{version}/bugaoshan_{version}_macos_arm64.dmg)
+- iOS: 未发布正式版，可安装testflight后点击链接进行邀测: https://testflight.apple.com/join/Vyenb6gC ；另提供 [ipa](https://github.com/Visio-Vanitas/Bugaoshan/releases/download/v{version}/bugaoshan_{version}_ios_unsigned.ipa)（ipa仅供理解有关技术的同学测试使用，非技术背景同学请勿下载）
 
 > 💡 **Note**: 当前项目优先保障 Android 端的稳定与体验。 Windows 版本可能存在部分兼容性或体验问题。
 

--- a/.github/scripts/tests/test_release_workflow.py
+++ b/.github/scripts/tests/test_release_workflow.py
@@ -12,8 +12,23 @@ class ReleaseWorkflowTest(unittest.TestCase):
         ).read_text(encoding="utf-8")
 
         self.assertIn(
-            "https://github.com/Visio-Vanitas/Bugaoshan/releases/download/"
-            "v{version}/bugaoshan_{version}_macos_arm64.dmg",
+            "[dmg](https://github.com/Visio-Vanitas/Bugaoshan/releases/download/"
+            "v{version}/bugaoshan_{version}_macos_arm64.dmg)",
+            release_body,
+        )
+
+    def test_ios_download_points_to_apple_mirror_release(self):
+        release_body = (
+            REPOSITORY_ROOT / ".github/scripts/release_body.py"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn(
+            "[ipa](https://github.com/Visio-Vanitas/Bugaoshan/releases/download/"
+            "v{version}/bugaoshan_{version}_ios_unsigned.ipa)",
+            release_body,
+        )
+        self.assertIn(
+            "ipa仅供理解有关技术的同学测试使用，非技术背景同学请勿下载",
             release_body,
         )
 


### PR DESCRIPTION
## 原因

iOS unsigned IPA 由公开镜像仓库（Visio-Vanitas/Bugaoshan）的流水线自动化构建产出并上传到同名 Mirror Release 中。
主仓库目前在 Release 模版中仅提供 TestFlight 邀测链接以及 macOS 的 dmg 下载链接。对于具备自签名/侧载技术背景的开发者和测试同学，直接获取未签名 IPA 具有测试与调试价值。

## 改动

- 将 Release 下载列表中的 `DMG` 修改为小写 `dmg`；
- 将 `IOS` 规范大小写为 `iOS`；
- 在 iOS 项中增加对应 tag 的镜像仓库 unsigned IPA 链接；
- 明确添加提示文案：`（ipa仅供理解有关技术的同学测试使用，非技术背景同学请勿下载）`；
- 在测试用例 `test_release_workflow.py` 中更新断言并补充对 `[dmg]`、`[ipa]` 以及提示文案的测试。

## 验证

- `python3 -m unittest discover -s .github/scripts/tests/` 全部测试通过（3 tests OK）
- 本地注入模拟环境变量调用 `.github/scripts/release_body.py` 验证生成的 markdown 格式完整且符合预期

🤖 Generated with [Claude Code](https://claude.com/claude-code)