### PR TITLE
feat: 增加登录页强特征判断，避免误判业务页面为登录页（issue #282）

### DIFF
--- a/lib/services/api/api_request.dart
+++ b/lib/services/api/api_request.dart
@@ -1,5 +1,81 @@
 import 'package:bugaoshan/services/auth/scu_exceptions.dart';
 
+/// 登录页强特征（对大小写不敏感，body 需先转小写后再匹配）。
+final RegExp _titlePattern = RegExp(r'<title[^>]*>([^<]*)</title>');
+final RegExp _springSecurityLoginPattern = RegExp('/j_spring_security_check');
+final RegExp _metaRefreshPattern = RegExp(
+  r'''content\s*=\s*["'][^"']*url=([^"'>\s]+)''',
+);
+final RegExp _jsLocationRedirectPattern = RegExp(
+  r'''location(?:\.(?:href|replace|assign))?\s*=?\s*\(?\s*["']([^"']+)["']''',
+);
+final RegExp _formActionPattern = RegExp(
+  r'''<form[^>]+action\s*=\s*["']([^"']*)["']''',
+);
+
+/// URL 里的 login 必须是独立路径段/文件名（`\blogin\b`）：
+/// `/login`、`/cas/login?service=…`、`login.aspx` 命中；
+/// `loginStatus`、`clientLogin` 这类子串刻意不命中（issue #282）。
+final RegExp _loginUrlPattern = RegExp(r'\blogin\b');
+
+/// 判断响应 body 是否为「被踢到登录页」的落点页。
+///
+/// 特征按 **真实 zhjw 登录页**（2026-09 抓取样本）校准，该页具备：
+/// `<title>登录</title>`、`<form action="/j_spring_security_check">`、
+/// `j_username` / `j_password` 字段。任一强特征命中即视为登录页：
+///
+/// 1. `<title>` 明确是登录页（含「登录」或独立 login 词）；
+/// 2. Spring Security 登录端点 `/j_spring_security_check`（教务系统登录表单）；
+/// 3. meta refresh / JS `location` 跳转目标指向登录 URL；
+/// 4. `<form action="…">` 提交到登录 URL。
+///
+/// 刻意 **不用** `type="password"` 做特征：修改密码等业务页同样含密码输入框。
+/// 也不做裸 login 子串匹配：`loginStatus`、`clientLogin` 等业务 JS
+/// 变量/链接会误伤（issue #282）。
+///
+/// 用于 zhjw / wfw / newservice 等服务的会话过期判定（wfw / newservice 的
+/// 登录落点页尚未抓样，共用本套通用特征，其过期主信号仍是 302/401/403
+/// 状态码与 JSON 业务错误码）；
+/// PayApp 的登录超时页判断（`balance_query_service.dart`）带站点白名单，
+/// 仍保持各自的强特征实现。
+bool looksLikeLoginPage(String body) {
+  final lower = body.toLowerCase();
+
+  // 1) 标题明确是登录页（「登录」不受 toLowerCase 影响）
+  final title = _titlePattern.firstMatch(lower)?.group(1);
+  if (title != null &&
+      (title.contains('登录') || _loginUrlPattern.hasMatch(title))) {
+    return true;
+  }
+
+  // 2) Spring Security 登录表单端点（真实 zhjw 登录页的 form action）
+  if (_springSecurityLoginPattern.hasMatch(lower)) {
+    return true;
+  }
+
+  // 3) meta refresh / JS location 跳转到登录 URL 的短跳转页
+  for (final pattern in [_metaRefreshPattern, _jsLocationRedirectPattern]) {
+    for (final match in pattern.allMatches(lower)) {
+      final url = match.group(1);
+      if (url != null && _loginUrlPattern.hasMatch(url)) {
+        return true;
+      }
+    }
+  }
+
+  // 4) 表单提交到登录 URL
+  for (final match in _formActionPattern.allMatches(lower)) {
+    final action = match.group(1);
+    if (action != null &&
+        action.isNotEmpty &&
+        _loginUrlPattern.hasMatch(action)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 /// API 请求自动重试包装。
 ///
 /// 如果 [getClient] 或 [fn] 抛出 [UnauthenticatedException]（认证失败），

--- a/lib/services/api/api_request.dart
+++ b/lib/services/api/api_request.dart
@@ -2,12 +2,22 @@ import 'package:bugaoshan/services/auth/scu_exceptions.dart';
 
 /// 登录页强特征（对大小写不敏感，body 需先转小写后再匹配）。
 final RegExp _titlePattern = RegExp(r'<title[^>]*>([^<]*)</title>');
-final RegExp _springSecurityLoginPattern = RegExp('/j_spring_security_check');
+
+/// Spring Security 登录端点必须出现在 `<form action="…">` 里：
+/// HTML/JS 文本中提及该端点（如业务脚本里的跳转 URL 字面量）不判为登录页。
+final RegExp _springSecurityLoginPattern = RegExp(
+  r'''<form[^>]+action\s*=\s*["'][^"']*j_spring_security_check''',
+);
 final RegExp _metaRefreshPattern = RegExp(
   r'''content\s*=\s*["'][^"']*url=([^"'>\s]+)''',
 );
+
+/// JS location 跳转必须是真实的属性赋值（`location.href = "…"`）或
+/// 方法调用（`location.replace("…")` / `location.assign("…")`）：
+/// `=`、`(`、`.href` 缺一不可，`location("…")`、`location "…"` 等乱写
+/// 及纯字符串字面量均不命中。
 final RegExp _jsLocationRedirectPattern = RegExp(
-  r'''location(?:\.(?:href|replace|assign))?\s*=?\s*\(?\s*["']([^"']+)["']''',
+  r'''location\s*\.\s*(?:href|replace|assign)\s*[=(]\s*["']([^"']+)["']''',
 );
 final RegExp _formActionPattern = RegExp(
   r'''<form[^>]+action\s*=\s*["']([^"']*)["']''',
@@ -20,12 +30,17 @@ final RegExp _loginUrlPattern = RegExp(r'\blogin\b');
 
 /// 判断响应 body 是否为「被踢到登录页」的落点页。
 ///
+/// 仅对 **HTML 内容** 做特征匹配：纯 JSON / 文本响应不做判断——业务 JSON
+/// 里带 `/j_spring_security_check`、`location.href = '…/login'` 之类的
+/// 字符串字面量（登录跳转 URL）很常见，不能据此触发重认证。
+///
 /// 特征按 **真实 zhjw 登录页**（2026-09 抓取样本）校准，该页具备：
 /// `<title>登录</title>`、`<form action="/j_spring_security_check">`、
 /// `j_username` / `j_password` 字段。任一强特征命中即视为登录页：
 ///
 /// 1. `<title>` 明确是登录页（含「登录」或独立 login 词）；
-/// 2. Spring Security 登录端点 `/j_spring_security_check`（教务系统登录表单）；
+/// 2. `<form action>` 提交到 Spring Security 登录端点
+///    `/j_spring_security_check`（教务系统登录表单）；
 /// 3. meta refresh / JS `location` 跳转目标指向登录 URL；
 /// 4. `<form action="…">` 提交到登录 URL。
 ///
@@ -39,6 +54,9 @@ final RegExp _loginUrlPattern = RegExp(r'\blogin\b');
 /// PayApp 的登录超时页判断（`balance_query_service.dart`）带站点白名单，
 /// 仍保持各自的强特征实现。
 bool looksLikeLoginPage(String body) {
+  // HTML 哨兵：只有 HTML 才走特征匹配，纯 JSON / 文本直接不命中。
+  if (!body.trimLeft().startsWith('<')) return false;
+
   final lower = body.toLowerCase();
 
   // 1) 标题明确是登录页（「登录」不受 toLowerCase 影响）

--- a/lib/services/api/new_service_api_service.dart
+++ b/lib/services/api/new_service_api_service.dart
@@ -63,7 +63,8 @@ class NewServiceApiService {
         body.trim().isEmpty) {
       throw const UnauthenticatedException();
     }
-    if (body.trimLeft().startsWith('<') && body.contains('login')) {
+    // 登录页强特征判断，不做裸 login 子串匹配（issue #282）
+    if (looksLikeLoginPage(body)) {
       throw const UnauthenticatedException();
     }
   }

--- a/lib/services/api/wfw_api_service.dart
+++ b/lib/services/api/wfw_api_service.dart
@@ -28,7 +28,8 @@ class WfwApiService {
         body.trim().isEmpty) {
       throw const UnauthenticatedException();
     }
-    if (body.trimLeft().startsWith('<') && body.contains('login')) {
+    // 登录页强特征判断，不做裸 login 子串匹配（issue #282）
+    if (looksLikeLoginPage(body)) {
       throw const UnauthenticatedException();
     }
   }

--- a/lib/services/api/zhjw_api_service.dart
+++ b/lib/services/api/zhjw_api_service.dart
@@ -40,6 +40,9 @@ class ZhjwApiService {
   ///
   /// zhjw 在 session 过期时返回 302、空 body 或 HTML 登录页。
   /// 检测到时抛 [UnauthenticatedException]，由 [_request] 捕获重试。
+  /// 登录页用 [looksLikeLoginPage] 的强特征组合判断，不做裸 login 子串
+  /// 匹配——正常业务页（如选课页含 loginStatus/clientLogin）不能误伤
+  /// （issue #282）。
   void _checkSessionExpiry(String body, int statusCode) {
     if (statusCode == 302) {
       throw const UnauthenticatedException();
@@ -47,7 +50,7 @@ class ZhjwApiService {
     if (body.trim().isEmpty) {
       throw const UnauthenticatedException();
     }
-    if (body.startsWith('<') && body.contains('login')) {
+    if (looksLikeLoginPage(body)) {
       throw const UnauthenticatedException();
     }
   }
@@ -160,7 +163,7 @@ class ZhjwApiService {
         r'var\s+url\s*=\s*"(/student/integratedQuery/scoreQuery/[^/]+/allPassingScores/callback)"',
       ).firstMatch(indexBody);
       if (urlMatch == null) {
-        if (indexBody.contains('login') || indexBody.contains('Login')) {
+        if (looksLikeLoginPage(indexBody)) {
           throw const UnauthenticatedException();
         }
         throw const ServiceException('无法从页面提取 allPassingScores callback URL');
@@ -206,7 +209,7 @@ class ZhjwApiService {
         r'var\s+url\s*=\s*"(/student/integratedQuery/scoreQuery/[^/]+/schemeScores/callback)"',
       ).firstMatch(indexBody);
       if (urlMatch == null) {
-        if (indexBody.contains('login') || indexBody.contains('Login')) {
+        if (looksLikeLoginPage(indexBody)) {
           throw const UnauthenticatedException();
         }
         throw const ServiceException('无法从页面提取 schemeScores callback URL');
@@ -565,7 +568,7 @@ class ZhjwApiService {
       //    - 页面是登录页/会话过期页 → 抛 UnauthenticatedException 走重认证；
       //    - 其它无法识别的 HTML（如错误页）→ 抛 ServiceException，
       //      避免触发重认证风暴（每次都会重新 SSO，进一步触发限流）。
-      if (body.toLowerCase().contains('login')) {
+      if (looksLikeLoginPage(body)) {
         throw const UnauthenticatedException();
       }
       throw const ServiceException('方案修读数据格式异常：页面无法解析');

--- a/test/looks_like_login_page_test.dart
+++ b/test/looks_like_login_page_test.dart
@@ -1,0 +1,110 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:bugaoshan/services/api/api_request.dart';
+
+void main() {
+  group('looksLikeLoginPage: 正常业务页不应误判（issue #282）', () {
+    test('含 loginStatus / clientLogin 等子串的选课页不命中', () {
+      const body = '''
+<html>
+<head><title>学期理论课表</title></head>
+<body>
+  <script>var loginStatus = 1; function clientLogin() {}</script>
+  <a href="/login?refer=%2Fstudent" class="login-link">登录</a>
+  <select name="xnxdm"><option value="2025-2026-2-1">2025-2026学年2学期</option></select>
+</body>
+</html>
+''';
+      expect(looksLikeLoginPage(body), isFalse);
+    });
+
+    test('跳转到非登录路径（含 login 子串的变量/URL）不命中', () {
+      const body = '''
+<script>var loginUrl = '/student/loginStatus'; location.href = '?refer=loginPage';</script>
+''';
+      expect(looksLikeLoginPage(body), isFalse);
+    });
+
+    test('JSON 业务响应不命中', () {
+      expect(looksLikeLoginPage('{"e":0,"m":"","d":{"labels":[]}}'), isFalse);
+    });
+  });
+
+  group('looksLikeLoginPage: 登录页强特征应命中', () {
+    test('Spring Security 登录表单端点命中（真实 zhjw 登录页特征）', () {
+      const body = '''
+<html><head><title>欢迎使用</title></head><body>
+<form class="form-signin" action="/j_spring_security_check" method="post">
+  <input type="text" name="j_username" placeholder="学号"/>
+  <input type="password" name="j_password" placeholder="密码"/>
+</form></body></html>
+''';
+      expect(looksLikeLoginPage(body), isTrue);
+    });
+
+    test('标题为「登录」命中', () {
+      expect(
+        looksLikeLoginPage('<html><head><title>登录超时</title></head></html>'),
+        isTrue,
+      );
+    });
+
+    test('标题含 login（大小写不敏感）命中', () {
+      expect(
+        looksLikeLoginPage('<TITLE>Login - Educational System</TITLE>'),
+        isTrue,
+      );
+    });
+
+    test('meta refresh 到登录路径命中', () {
+      expect(
+        looksLikeLoginPage(
+          '<meta http-equiv="refresh" content="0;url=/login?new=true">',
+        ),
+        isTrue,
+      );
+    });
+
+    test('JS location.href / location.replace 到登录路径命中', () {
+      expect(
+        looksLikeLoginPage(
+          "<script>location.href = 'https://zhjw.scu.edu.cn/login?refer=x'</script>",
+        ),
+        isTrue,
+      );
+      expect(
+        looksLikeLoginPage(
+          "<script>document.location.replace('/cas/login?service=abc')</script>",
+        ),
+        isTrue,
+      );
+    });
+
+    test('表单提交到登录路径命中', () {
+      expect(
+        looksLikeLoginPage(
+          '<html><body><form action="/login">请登录</form></body></html>',
+        ),
+        isTrue,
+      );
+    });
+  });
+
+  group('looksLikeLoginPage: 含密码框的业务页不应误判', () {
+    test('修改密码页（含多个密码输入框）不命中', () {
+      // 密码输入框不是登录页特征：修改密码等业务页同样有（issue #282 反馈）。
+      const body = '''
+<html>
+<head><title>修改密码</title></head>
+<body>
+  <form action="/student/personalInfo/passwordModify" method="post">
+    <input type="password" name="oldPassword" placeholder="原密码"/>
+    <input type="password" name="newPassword" placeholder="新密码"/>
+    <input type="password" name="confirmPassword" placeholder="确认新密码"/>
+  </form>
+</body>
+</html>
+''';
+      expect(looksLikeLoginPage(body), isFalse);
+    });
+  });
+}

--- a/test/looks_like_login_page_test.dart
+++ b/test/looks_like_login_page_test.dart
@@ -27,6 +27,36 @@ void main() {
     test('JSON 业务响应不命中', () {
       expect(looksLikeLoginPage('{"e":0,"m":"","d":{"labels":[]}}'), isFalse);
     });
+
+    test('JSON 里含登录端点 / location.href 字面量不命中', () {
+      // 业务 JSON 里带登录跳转 URL 字面量很常见，不能据此触发重认证。
+      const body =
+          '{"e":0,"m":"","d":{'
+          '"authApi":"/j_spring_security_check",'
+          '"jump":"location.href=\'/login\'"}}';
+      expect(looksLikeLoginPage(body), isFalse);
+    });
+
+    test('登录端点只出现在 form action 里才命中', () {
+      // HTML/JS 文本中提及端点（业务脚本里的 URL 常量）不算登录页。
+      expect(
+        looksLikeLoginPage(
+          '<html><body>'
+          '<script>var checkUrl = "/j_spring_security_check";</script>'
+          '</body></html>',
+        ),
+        isFalse,
+      );
+    });
+
+    test('JS location 缺少属性赋值 / 方法调用时不命中', () {
+      // `location("…")`、`location "…"` 这类乱写与纯字符串不算跳转特征。
+      expect(
+        looksLikeLoginPage("<script>location('/login')</script>"),
+        isFalse,
+      );
+      expect(looksLikeLoginPage('<p>请前往 location "login" 页面</p>'), isFalse);
+    });
   });
 
   group('looksLikeLoginPage: 登录页强特征应命中', () {

--- a/test/zhjw_api_service_test.dart
+++ b/test/zhjw_api_service_test.dart
@@ -133,12 +133,82 @@ void main() {
     );
     addTearDown(helper.auth.dispose);
 
-    // 入口页含 login 特征 → _checkSessionExpiry 抛 UnauthenticatedException
-    // → retryOnUnauthenticated 触发重认证（SSO）。测试环境无真实 SSO，
-    // 重认证失败表现为 ServiceException('教务 SSO 登录失败')——
+    // 入口页含登录页强特征（表单提交到 /login）→ _checkSessionExpiry 抛
+    // UnauthenticatedException → retryOnUnauthenticated 触发重认证（SSO）。
+    // 测试环境无真实 SSO，重认证失败表现为 ServiceException('教务 SSO 登录失败')——
     // 重点是与下方"格式异常"用例区分：会话过期走重认证而非格式错误提示。
     await expectLater(
       helper.api.fetchPlanCompletion(),
+      throwsA(
+        isA<ServiceException>().having(
+          (e) => e.message,
+          'message',
+          contains('SSO'),
+        ),
+      ),
+    );
+  });
+
+  test('fetchSemesters: business page containing login substrings must not '
+      'trigger invalidate (issue #282)', () async {
+    // issue #282 的真实场景：calendarSemesterCurriculum/index 正常返回 200，
+    // 页面里的 loginStatus / clientLogin / 登录链接都是业务内容，
+    // 旧判断 `startsWith('<') && contains('login')` 会误判为登录页，
+    // 触发 invalidate + 重走 SSO。新判断应正常解析出学期列表。
+    final helper = _buildRoutingApi(
+      {
+        '/student/courseSelect/calendarSemesterCurriculum/index': '''
+<html>
+<head><title>学期理论课表</title></head>
+<body>
+  <script>var loginStatus = 1; function clientLogin() {}</script>
+  <a href="/login?refer=%2Fstudent" class="hidden">登录</a>
+  <select name="xnxdm">
+    <option value="2025-2026-2-1">2025-2026学年2学期</option>
+  </select>
+</body>
+</html>
+''',
+      },
+      prefs,
+      logger,
+    );
+    addTearDown(helper.auth.dispose);
+
+    final semesters = await helper.api.fetchSemesters();
+    expect(semesters, hasLength(1));
+    expect(semesters.single.value, '2025-2026-2-1');
+  });
+
+  test('fetchSemesters: real login page still triggers re-auth', () async {
+    // fixture 按真实 zhjw 登录页（2026-09 抓取样本）裁剪：
+    // <title>登录</title> + form action=/j_spring_security_check +
+    // j_username/j_password 字段。
+    final helper = _buildRoutingApi(
+      {
+        '/student/courseSelect/calendarSemesterCurriculum/index': '''
+<html>
+<head><title>登录</title></head>
+<body>
+  <h2>欢迎登录四川大学教务管理系统<br />学生端</h2>
+  <form class="form-signin" action="/j_spring_security_check" method="post">
+    <input type="text" id="input_username" name="j_username" maxlength="50" placeholder="学号"/>
+    <input type="password" id="input_password" name="j_password" autocomplete="off" placeholder="密码"/>
+    <input type="submit" id="loginButton" value="登 录"/>
+  </form>
+</body>
+</html>
+''',
+      },
+      prefs,
+      logger,
+    );
+    addTearDown(helper.auth.dispose);
+
+    // 真登录页 → UnauthenticatedException → 重认证（测试环境 SSO 失败
+    // 表现为 '教务 SSO 登录失败'），而不是"无法获取学期列表"。
+    await expectLater(
+      helper.api.fetchSemesters(),
       throwsA(
         isA<ServiceException>().having(
           (e) => e.message,


### PR DESCRIPTION
## 变更范围

修复 #282：登录页被误判为业务页（裸 `body.contains('login')` 子串匹配把 `loginStatus` / `clientLogin` 等业务变量当成登录页，反之业务页面也不会再被误判触发会话过期）。

- `looksLikeLoginPage`（`lib/services/api/api_request.dart`）：zhjw / wfw / newservice 三处裸 login 子串判断替换为登录页强特征组合——HTML 哨兵（仅 HTML 内容参与匹配）+ `<title>` 明确是登录页 / `<form action>` 指向 Spring Security 端点 `/j_spring_security_check` / meta refresh 与 JS `location` 跳转登录 URL。
- 刻意不用 `type="password"` 做特征（修改密码等业务页同样含密码框），不做裸 login 子串匹配。
- PayApp 的登录超时页判断（`balance_query_service.dart`）自带站点白名单，保留各自实现，本 PR 未改动。
- 测试：`test/looks_like_login_page_test.dart` 覆盖正反用例——选课页 loginStatus / clientLogin、改密码页、JSON 业务响应（含登录跳转 URL 字面量）不命中；真实 zhjw 登录页特征（title 登录 / form action 端点 / location 跳转）命中。