### PR TITLE
feat(course): 支持在课表显示设置中控制是否显示课程周数

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- 课表显示设置新增「显示课程周数」开关，支持自由控制课程卡片上是否显示周数范围
+
 ## [2.5.1] - 2026-09-11
 
 ### Added

--- a/docs/decisions/0003-make-course-display-settings-global.md
+++ b/docs/decisions/0003-make-course-display-settings-global.md
@@ -15,11 +15,12 @@
 
 ## 决策
 
-四个显示偏好属于全局视觉设置：
+五个显示偏好属于全局视觉设置：
 
 ```text
 showTeacherName
 showLocation
+showCourseWeeks
 showWeekend
 showNonCurrentWeekCourses
 ```
@@ -27,8 +28,8 @@ showNonCurrentWeekCourses
 具体规则：
 
 1. 持久化所有权归 `AppConfigProvider`，使用 `SharedPreferences`。
-2. `ScheduleConfig` 不保存、复制或导出这四个字段。
-3. 四个开关只在全局课程表样式页编辑。
+2. `ScheduleConfig` 不保存、复制或导出这些字段。
+3. 这些开关只在全局课程表样式页编辑。
 4. 切换或新建课表不改变用户的持久化视觉偏好；导入行为见下方“未决边界”。
 5. 特定视图可以通过显式参数做临时覆盖，例如班级课表详情强制展示周末；局部覆盖不能写回全局值。
 6. `grid_logic` 等纯逻辑函数继续接收解析后的参数，不直接从 GetIt 读取设置，以保留测试边界。
@@ -39,6 +40,7 @@ showNonCurrentWeekCourses
 |---|---|
 | 显示教师 | `true` |
 | 显示教室 | `true` |
+| 显示课程周数 | `true` |
 | 显示周末 | `false` |
 | 显示非本周课程 | `true` |
 

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -307,6 +307,7 @@
     "backgroundImageSetHint": "Background image set. You can go to Theme Color to modify the theme color.",
     "showTeacher": "Show Teacher",
     "showLocation": "Show Location",
+    "showCourseWeeks": "Show Course Weeks",
     "showWeekend": "Show Weekend",
     "showNonCurrentWeekCourses": "Show Non-Current Week Courses",
     "save": "Save",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1429,6 +1429,12 @@ abstract class AppLocalizations {
   /// **'Show Location'**
   String get showLocation;
 
+  /// No description provided for @showCourseWeeks.
+  ///
+  /// In en, this message translates to:
+  /// **'Show Course Weeks'**
+  String get showCourseWeeks;
+
   /// No description provided for @showWeekend.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -723,6 +723,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get showLocation => 'Show Location';
 
   @override
+  String get showCourseWeeks => 'Show Course Weeks';
+
+  @override
   String get showWeekend => 'Show Weekend';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -699,6 +699,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get showLocation => '显示教室';
 
   @override
+  String get showCourseWeeks => '显示课程周数';
+
+  @override
   String get showWeekend => '显示周末';
 
   @override

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -286,6 +286,7 @@
     "backgroundImageSetHint": "背景图片已设置，您可以前往「主题颜色」修改主题色",
     "showTeacher": "显示教师",
     "showLocation": "显示教室",
+    "showCourseWeeks": "显示课程周数",
     "showWeekend": "显示周末",
     "showNonCurrentWeekCourses": "显示非本周课程",
     "save": "保存",

--- a/lib/pages/course/widgets/course_card.dart
+++ b/lib/pages/course/widgets/course_card.dart
@@ -34,6 +34,7 @@ class CourseCard extends StatelessWidget {
         appConfig.courseCardFontSize,
         appConfig.showLocation,
         appConfig.showTeacherName,
+        appConfig.showCourseWeeks,
       ]),
       builder: (context, _) {
         final isActive = showAllWeeks || course.isActiveInWeek(displayWeek);
@@ -57,11 +58,12 @@ class CourseCard extends StatelessWidget {
                 ),
               if (appConfig.showTeacherName.value && course.teacher.isNotEmpty)
                 (text: course.teacher, preferredMaxLines: 1, renderMaxLines: 2),
-              (
-                text: l10n.weekRange(course.startWeek, course.endWeek),
-                preferredMaxLines: 1,
-                renderMaxLines: 4,
-              ),
+              if (appConfig.showCourseWeeks.value)
+                (
+                  text: l10n.weekRange(course.startWeek, course.endWeek),
+                  preferredMaxLines: 1,
+                  renderMaxLines: 4,
+                ),
             ];
 
         return GestureDetector(

--- a/lib/pages/settings/set_course_style_page.dart
+++ b/lib/pages/settings/set_course_style_page.dart
@@ -34,6 +34,7 @@ class SetCourseStylePage extends StatelessWidget {
         appConfig.courseRowHeight,
         appConfig.showTeacherName,
         appConfig.showLocation,
+        appConfig.showCourseWeeks,
         appConfig.showWeekend,
         appConfig.showNonCurrentWeekCourses,
       ]),
@@ -207,6 +208,12 @@ class SetCourseStylePage extends StatelessWidget {
         contentPadding: EdgeInsets.zero,
       ),
       SwitchListTile(
+        title: Text(localizations.showCourseWeeks),
+        value: appConfig.showCourseWeeks.value,
+        onChanged: (v) => appConfig.showCourseWeeks.value = v,
+        contentPadding: EdgeInsets.zero,
+      ),
+      SwitchListTile(
         title: Text(localizations.showWeekend),
         value: appConfig.showWeekend.value,
         onChanged: (v) => appConfig.showWeekend.value = v,
@@ -288,6 +295,7 @@ class SetCourseStylePage extends StatelessWidget {
             appConfig.backgroundImageOpacity.value = 0.3;
             appConfig.showTeacherName.value = true;
             appConfig.showLocation.value = true;
+            appConfig.showCourseWeeks.value = true;
             appConfig.showWeekend.value = false;
             appConfig.showNonCurrentWeekCourses.value = true;
           },

--- a/lib/providers/app_config_provider.dart
+++ b/lib/providers/app_config_provider.dart
@@ -31,6 +31,7 @@ const String _keyWidgetDensity = 'widget_density';
 const String _keyUsePreviewUpdateSource = 'usePreviewUpdateSource';
 const String _keyShowTeacherName = 'showTeacherName';
 const String _keyShowLocation = 'showLocation';
+const String _keyShowCourseWeeks = 'showCourseWeeks';
 const String _keyShowWeekend = 'showWeekend';
 const String _keyShowNonCurrentWeekCourses = 'showNonCurrentWeekCourses';
 const String _keyUseGoogleFonts = 'useGoogleFonts';
@@ -91,6 +92,7 @@ class AppConfigProvider {
   final ValueNotifier<bool> useGoogleFonts = ValueNotifier<bool>(true);
   final ValueNotifier<bool> showTeacherName = ValueNotifier<bool>(true);
   final ValueNotifier<bool> showLocation = ValueNotifier<bool>(true);
+  final ValueNotifier<bool> showCourseWeeks = ValueNotifier<bool>(true);
   final ValueNotifier<bool> showWeekend = ValueNotifier<bool>(false);
   final ValueNotifier<bool> showNonCurrentWeekCourses = ValueNotifier<bool>(
     true,
@@ -167,6 +169,8 @@ class AppConfigProvider {
     showTeacherName.value =
         _sharedPreferences.getBool(_keyShowTeacherName) ?? true;
     showLocation.value = _sharedPreferences.getBool(_keyShowLocation) ?? true;
+    showCourseWeeks.value =
+        _sharedPreferences.getBool(_keyShowCourseWeeks) ?? true;
     showWeekend.value = _sharedPreferences.getBool(_keyShowWeekend) ?? false;
     showNonCurrentWeekCourses.value =
         _sharedPreferences.getBool(_keyShowNonCurrentWeekCourses) ?? true;
@@ -294,6 +298,9 @@ class AppConfigProvider {
     });
     showLocation.addListener(() {
       _sharedPreferences.setBool(_keyShowLocation, showLocation.value);
+    });
+    showCourseWeeks.addListener(() {
+      _sharedPreferences.setBool(_keyShowCourseWeeks, showCourseWeeks.value);
     });
     showWeekend.addListener(() {
       _sharedPreferences.setBool(_keyShowWeekend, showWeekend.value);

--- a/test/course_display_settings_test.dart
+++ b/test/course_display_settings_test.dart
@@ -1,0 +1,221 @@
+import 'package:bugaoshan/injection/injector.dart';
+import 'package:bugaoshan/l10n/app_localizations.dart';
+import 'package:bugaoshan/models/course.dart';
+import 'package:bugaoshan/pages/course/widgets/course_card.dart';
+import 'package:bugaoshan/pages/settings/set_course_style_page.dart';
+import 'package:bugaoshan/providers/app_config_provider.dart';
+import 'package:bugaoshan/providers/course_provider.dart';
+import 'package:bugaoshan/services/database_service.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _FakeDatabaseService implements DatabaseService {
+  final List<ScheduleConfig> schedules;
+
+  _FakeDatabaseService({this.schedules = const []});
+
+  @override
+  List<ScheduleConfig> getAllSchedules() => schedules;
+
+  @override
+  ScheduleConfig? getScheduleConfig() =>
+      schedules.isNotEmpty ? schedules.first : null;
+
+  @override
+  List<Course> getCourses({String? scheduleId}) => const [];
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+Widget _wrap(Widget child) => MaterialApp(
+  localizationsDelegates: AppLocalizations.localizationsDelegates,
+  supportedLocales: AppLocalizations.supportedLocales,
+  home: child,
+);
+
+void main() {
+  setUp(() async {
+    await getIt.reset();
+  });
+
+  tearDown(() async {
+    await getIt.reset();
+  });
+
+  group('showCourseWeeks setting and display', () {
+    test('loads and persists showCourseWeeks in AppConfigProvider', () async {
+      SharedPreferences.setMockInitialValues({'showCourseWeeks': false});
+      final prefs = await SharedPreferences.getInstance();
+      final provider = AppConfigProvider(prefs);
+      await provider.init();
+
+      expect(provider.showCourseWeeks.value, isFalse);
+
+      provider.showCourseWeeks.value = true;
+      expect(prefs.getBool('showCourseWeeks'), isTrue);
+
+      provider.showCourseWeeks.value = false;
+      expect(prefs.getBool('showCourseWeeks'), isFalse);
+    });
+
+    test(
+      'defaults to true when showCourseWeeks is absent from SharedPreferences',
+      () async {
+        SharedPreferences.setMockInitialValues({});
+        final prefs = await SharedPreferences.getInstance();
+        final provider = AppConfigProvider(prefs);
+        await provider.init();
+
+        expect(provider.showCourseWeeks.value, isTrue);
+      },
+    );
+
+    testWidgets(
+      'CourseCard toggles week range display based on showCourseWeeks',
+      (tester) async {
+        SharedPreferences.setMockInitialValues({});
+        final prefs = await SharedPreferences.getInstance();
+        final appConfig = AppConfigProvider(prefs);
+        await appConfig.init();
+        getIt.registerSingleton<AppConfigProvider>(appConfig);
+
+        final course = Course(
+          name: '高等数学',
+          teacher: '张老师',
+          location: '一教101',
+          startWeek: 1,
+          endWeek: 16,
+          dayOfWeek: 1,
+          startSection: 1,
+          endSection: 2,
+          colorValue: 0xFF2196F3,
+        );
+        final config = ScheduleConfig(
+          semesterStartDate: DateTime(2026, 9, 1),
+          totalWeeks: 20,
+        );
+
+        await tester.pumpWidget(
+          _wrap(
+            Scaffold(
+              body: SizedBox(
+                height: 200,
+                width: 100,
+                child: CourseCard(
+                  course: course,
+                  config: config,
+                  displayWeek: 1,
+                ),
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final l10n = AppLocalizations.of(
+          tester.element(find.byType(CourseCard)),
+        )!;
+        final weekRangeText = l10n.weekRange(1, 16);
+
+        expect(find.text('高等数学'), findsOneWidget);
+        expect(find.text('张老师'), findsOneWidget);
+        expect(find.text('一教101'), findsOneWidget);
+        expect(find.text(weekRangeText), findsOneWidget);
+
+        // Turn off showCourseWeeks
+        appConfig.showCourseWeeks.value = false;
+        await tester.pumpAndSettle();
+
+        expect(find.text('高等数学'), findsOneWidget);
+        expect(find.text('张老师'), findsOneWidget);
+        expect(find.text('一教101'), findsOneWidget);
+        expect(find.text(weekRangeText), findsNothing);
+
+        // Turn on showCourseWeeks again
+        appConfig.showCourseWeeks.value = true;
+        await tester.pumpAndSettle();
+
+        expect(find.text(weekRangeText), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'SetCourseStylePage displays toggle, controls showCourseWeeks, and resets to default',
+      (tester) async {
+        SharedPreferences.setMockInitialValues({});
+        final prefs = await SharedPreferences.getInstance();
+        final appConfig = AppConfigProvider(prefs);
+        await appConfig.init();
+        getIt.registerSingleton<AppConfigProvider>(appConfig);
+
+        final fakeDb = _FakeDatabaseService(
+          schedules: [
+            ScheduleConfig(
+              id: 'test_id',
+              semesterName: '2026秋',
+              semesterStartDate: DateTime(2026, 9, 1),
+              totalWeeks: 20,
+            ),
+          ],
+        );
+        getIt.registerSingleton<CourseProvider>(CourseProvider(fakeDb));
+
+        await tester.pumpWidget(_wrap(const SetCourseStylePage()));
+        await tester.pumpAndSettle();
+
+        final l10n = AppLocalizations.of(
+          tester.element(find.byType(SetCourseStylePage)),
+        )!;
+
+        // Verify the switch tile is rendered
+        final scrollableFinder = find.byType(Scrollable).last;
+        final switchFinder = find.widgetWithText(
+          SwitchListTile,
+          l10n.showCourseWeeks,
+        );
+        await tester.scrollUntilVisible(
+          switchFinder,
+          100,
+          scrollable: scrollableFinder,
+        );
+        expect(switchFinder, findsOneWidget);
+
+        final switchWidget = tester.widget<SwitchListTile>(switchFinder);
+        expect(switchWidget.value, isTrue);
+
+        // Verify preview updates reactively when showCourseWeeks changes
+        final demoWeekRangeText = l10n.weekRange(1, 20);
+        expect(find.text(demoWeekRangeText), findsWidgets);
+
+        // Tap the switch to toggle it off
+        await tester.tap(switchFinder);
+        await tester.pumpAndSettle();
+
+        expect(appConfig.showCourseWeeks.value, isFalse);
+        final switchOff = tester.widget<SwitchListTile>(switchFinder);
+        expect(switchOff.value, isFalse);
+        // In preview, week range text should no longer be visible
+        expect(find.text(demoWeekRangeText), findsNothing);
+
+        // Scroll to and click Reset to default
+        final resetFinder = find.widgetWithText(
+          TextButton,
+          l10n.resetToDefault,
+        );
+        await tester.scrollUntilVisible(
+          resetFinder,
+          100,
+          scrollable: scrollableFinder,
+        );
+        await tester.tap(resetFinder);
+        await tester.pumpAndSettle();
+
+        expect(appConfig.showCourseWeeks.value, isTrue);
+        final switchReset = tester.widget<SwitchListTile>(switchFinder);
+        expect(switchReset.value, isTrue);
+      },
+    );
+  });
+}


### PR DESCRIPTION
## 概述

在课表显示设置 (`SetCourseStylePage`) 中新增「显示课程周数」开关（默认开启）。关闭后，课程卡片 (`CourseCard`) 将隐藏周数区间（如 `1-16 周` / `Week 1-16`），并将行数预算分配给教室、教师等其他信息。同时，开关操作会实时联动更新样式设置页顶部的课表预览。

遵循 [ADR-0003](docs/decisions/0003-make-course-display-settings-global.md) 规则，将该显示偏好归入 `AppConfigProvider` 全局设置，避免污染各独立课表的数据存储。

## 变更内容

1. **全局配置与持久化** ([lib/providers/app_config_provider.dart](lib/providers/app_config_provider.dart)):
   - 增加 `_keyShowCourseWeeks = 'showCourseWeeks'` 常量；
   - 增加 `ValueNotifier<bool> showCourseWeeks = ValueNotifier<bool>(true)`；
   - 在 `init()` 中加载本地配置并自动监听落盘。
2. **课程卡片渲染联动** ([lib/pages/course/widgets/course_card.dart](lib/pages/course/widgets/course_card.dart)):
   - 监听 `appConfig.showCourseWeeks`；
   - 仅在开启时向 `details` 添加周数范围；关闭时隐藏周数并释放 `detailLineBudget`。
3. **样式设置与实时预览** ([lib/pages/settings/set_course_style_page.dart](lib/pages/settings/set_course_style_page.dart)):
   - 顶层 `ListenableBuilder` 监听 `showCourseWeeks`，切换时上方 demoMode 课表预览实时响应；
   - 添加「显示课程周数」`SwitchListTile` 开关；
   - 接入「恢复默认」逻辑，重置为 `true`。
4. **多语言支持** ([lib/l10n/app_zh.arb](lib/l10n/app_zh.arb) / [lib/l10n/app_en.arb](lib/l10n/app_en.arb)):
   - 补充中英文文案并生成本地化代码。
5. **文档更新** ([docs/decisions/0003-make-course-display-settings-global.md](docs/decisions/0003-make-course-display-settings-global.md), [CHANGELOG.md](CHANGELOG.md)):
   - 扩充 ADR-0003 决策记录，更新五个全局显示设置及默认值；
   - 在 CHANGELOG 的 `[Unreleased]` 中记录此功能。
6. **测试覆盖** ([test/course_display_settings_test.dart](test/course_display_settings_test.dart)):
   - 覆盖 `AppConfigProvider` 的默认值与读写持久化；
   - 覆盖 `CourseCard` 的周数文本显隐切换；
   - 覆盖 `SetCourseStylePage` 的 Switch 交互、实时预览更新与恢复默认。

## 验证结果

- `dart analyze --fatal-infos`: 0 issues
- `flutter test`: 459 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)