### PR TITLE
ci: 引入 preview->main 两级发布流水线与发布前质量门禁

### DIFF
--- a/.claude/commands/prerelease.md
+++ b/.claude/commands/prerelease.md
@@ -1,26 +1,33 @@
 # Prerelease Skill
 
-为 Bugaoshan 项目创建预览版发布。按以下步骤执行：
+为 Bugaoshan 项目准备预览版发布。按以下步骤执行：
 
 **所有与用户的交互必须使用中文。**
 
-## Step 1: 获取预览版名称
+> **流水线背景**：仓库采用 `feature -> preview -> main` 两级流水线。变更合并进
+> `preview` 分支后，`release.yml`（preview 通道）自动推导 tag：常态（pubspec 与
+> 最新正式版一致）为最新正式版递增 Z 位加 `-preview[.N]`（如上一正式版 v2.5.1 →
+> `v2.5.2-preview`、`-preview.2`…）；`/release` bump 之后进入准备期，切换为 rc
+> 命名（`vX.Y.Z-rc`、`-rc1`…）。预览构建的包体版本号统一注入上一正式版。本命令
+> 只准备 CHANGELOG 并推送到 `preview`，**不修改 `pubspec.yaml`，也不手动打 tag**。
+>
+> 注意：其他自定义后缀（`-beta` 等）仍需在 GitHub Actions 手动触发 `release.yml`
+> 并通过 `version_override` 指定。
 
-如果用户在调用时提供了参数（如 `/prerelease v1.2.3-preview`），直接用作预览版名称。否则，向用户询问预览版名称（如 `v1.2.3-preview`、`v1.2.3-rc1`、`v1.2.3-beta` 等）。
+## Step 1: 检查工作区与分支
 
-## Step 2: 检验版本号
+- 运行 `git status --short` 检查未提交的更改。如果有未提交的更改，**警告用户**并列出变更文件，询问是否继续或中止。未经用户确认不要继续。
+- 运行 `git branch --show-current` 确认当前在 **`preview`** 分支。若不是，说明预览版发布必须在 `preview` 上进行，询问用户是否切换：
 
-从 `pubspec.yaml` 读取当前 `version:` 字段，提取基础版本号。
+  ```bash
+  git fetch origin && git checkout preview && git pull origin preview
+  ```
 
-验证：预览版名称版本号语义上必须>基础版本号。否则警告。
+- 校验 pubspec 与最新正式 tag 的一致性：取最新正式 tag（`git tag -l "v[0-9]*.[0-9]*.[0-9]*" --sort=-v:refname | head -n 1`）并与 `pubspec.yaml` 的 `version:` 比较——**一致**为常态，直接继续；pubspec **落后**则警告用户先对齐（否则下一次正式发布会被幂等守卫卡住）；pubspec **领先**说明处于 `/release` 准备期，告知用户本轮预览将使用 `-rc` 命名（若本意是发正式版，建议改走 `/release`）。
 
-## Step 3: 检查工作区
+## Step 2: 检查 CHANGELOG.md
 
-运行 `git status --short` 检查未提交的更改。如果有未提交的更改，**警告用户**并列出变更文件，询问是否继续或中止。未经用户确认不要继续。
-
-## Step 4: 检查 CHANGELOG.md
-
-读取 `CHANGELOG.md`，检查 `## [unreleased]` 条目是否存在且有内容。
+读取 `CHANGELOG.md`，检查 `## [Unreleased]` 条目是否存在且有内容。
 
 - **如果有内容**：转到下一步。
 - **如果为空或不存在**：警告用户，然后提供两个选项：
@@ -59,25 +66,32 @@
 > - 修复aaa问题
 > ```
 
-将子代理的输出插入 `## [unreleased]` 条目（若不存在则先创建）。
+将子代理的输出插入 `## [Unreleased]` 条目（若不存在则先创建）。
 
-## Step 5: 推送前审查确认
+**不要重命名 `[Unreleased]` 章节**：预览版的 release body 取 CHANGELOG 第一个章节的内容，`[Unreleased]` 留到正式版 `/release` 时才重命名为 `[X.Y.Z]`。
 
-向用户展示变更摘要以获取最终确认：
+## Step 3: 本地预检
 
-- 即将创建的 tag：`vX.Y.Z-{后缀}`
-- 注意：不会修改 `pubspec.yaml` 版本号
+```bash
+python tool/pre_release_check.py --ci --prerelease
+```
+
+- 该命令为 CI 门禁模式：发布时机类检查（版本号递增、tag 冲突、`[Unreleased]` 空置）为 **WARN** 提示，向用户展示即可。
+- 版本号格式、CHANGELOG 结构等**结构性 FAIL** 必须处理后重跑，通过前不要继续。
+
+## Step 4: 提交并推送 preview
+
+推送前，向用户展示变更摘要以获取最终确认：
+
+- 本次预览版基于 `X.Y.Z`，最终 tag 由流水线自动推导，**不会修改 `pubspec.yaml`**。
 - 询问用户确认：继续推送，还是中止。
 
-只有用户明确确认后才继续。
-
-## Step 6: 打 tag 并推送
+只有用户明确确认后才继续：
 
 ```bash
 git add CHANGELOG.md
 git commit -m "docs: 更新 CHANGELOG prerelease 条目"  # 仅在 CHANGELOG 有变更时
-git tag vX.Y.Z-{后缀}
-git push && git push --tags
+git push origin preview
 ```
 
-推送完成后，向用户确认发布已触发，说明 GitHub Actions 会自动检测到 tag 并构建预览版发布（标记为 prerelease）。
+推送完成后，向用户确认预览版流水线已触发：CI 会自动创建 `vX.Y.Z-preview`（或递增序号）tag、构建并发布 GitHub Prerelease。全程**不要手动 `git tag` / `git push --tags`**。

--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -1,20 +1,30 @@
 # Release Skill
 
-为 Bugaoshan 项目创建新版本发布。按以下步骤执行：
+为 Bugaoshan 项目准备正式版发布。按以下步骤执行：
 
 **所有与用户的交互必须使用中文。**
+
+> **流水线背景**：仓库采用 `feature -> preview -> main` 两级流水线，`main` 只接收
+> 来自 `preview` 分支的 PR。合并进 `main` 后，`release.yml` 会自动从 `pubspec.yaml`
+> 推导 `vX.Y.Z` tag、构建双端产物并发布 GitHub Release（latest）。本命令只负责
+> **准备发布内容并发起 PR**，不再手动打 tag / 推 tag。
 
 ## Step 1: 获取目标版本
 
 如果用户在调用时提供了版本参数（如 `/release 1.2.0`），直接使用。否则，向用户询问目标版本号（格式：`X.Y.Z`，如 `1.1.0`）。在获得有效版本前不要继续。
 
-## Step 2: 检查工作区
+## Step 2: 检查工作区与分支
 
-运行 `git status --short` 检查未提交的更改。如果有未提交的更改，**警告用户**并列出变更文件，询问是否继续或中止。未经用户确认不要继续。
+- 运行 `git status --short` 检查未提交的更改。如果有未提交的更改，**警告用户**并列出变更文件，询问是否继续或中止。未经用户确认不要继续。
+- 运行 `git branch --show-current` 确认当前在 **`preview`** 分支。若不是，说明正式版发布准备必须在 `preview` 上进行（`main` 只接收来自 `preview` 的 PR），询问用户是否切换：
+
+  ```bash
+  git fetch origin && git checkout preview && git pull origin preview
+  ```
 
 ## Step 3: 更新 pubspec.yaml
 
-编辑 `pubspec.yaml`：将 `version:` 行改为 `version: X.Y.Z`（不含 `v` 前缀）。
+编辑 `pubspec.yaml`：将 `version:` 的 `X.Y.Z` 部分改为目标版本，**保留 `+buildNumber` 后缀并按现有规则同步更新**（buildNumber = `major*10000 + minor*100 + patch`，如 `2.5.1+20501` -> `2.6.0+20600`）。若 `pubspec.yaml` 已经是目标版本（例如重复执行本命令），跳过本步。
 
 ## Step 4: 更新 CHANGELOG.md
 
@@ -70,28 +80,45 @@
    ## [X.Y.Z] - YYYY-MM-DD
    ```
 
-## Step 5: 提交并打 tag
+## Step 5: 更新 F-Droid 元数据
+
+1. 运行 `python .github/scripts/metadata_changelog.py --skip-existing`，为 `X.Y.Z` 生成 `metadata/{en-US,zh-CN}/changelogs/` 下的版本说明文件（versionCode = `base*10 + 1/2/4`，如 2.6.0 -> 206001 / 206002 / 206004）。
+2. 编辑 `metadata/*.yml`：参照既有版本条目的写法，在 Builds 中追加新版本，`versionName` 为 `X.Y.Z`，三个 ABI 的 `versionCode` 按上述公式填写。
+
+## Step 6: 本地发布前检查
 
 ```bash
-git add pubspec.yaml CHANGELOG.md
-git commit -m "chore: release vX.Y.Z"
-git tag vX.Y.Z
+python tool/pre_release_check.py X.Y.Z
 ```
 
-## Step 6: 推送前审查确认
+- 该命令为**严格模式**：版本号递增、tag 冲突、CHANGELOG `[X.Y.Z]` 章节、F-Droid 元数据等任何 FAIL 都必须处理后重跑，通过前不要继续。
+- 若提示「已存在 tag vX.Y.Z」，说明该版本已发布过，停止并提示用户更换版本号。
+- WARN 项（如 CHANGELOG 日期、Unreleased 占位符残留）向用户展示并人工确认。
+
+## Step 7: 提交并推送 preview
 
 推送前，向用户展示变更摘要以获取最终确认：
 
-- 展示 `git diff HEAD~1`（提交差异），让用户审查 pubspec.yaml 和 CHANGELOG.md 的改动。
-- 展示即将推送的 tag：`vX.Y.Z`。
-- 询问用户确认：继续推送，还是中止（中止需执行 `git tag -d vX.Y.Z` 和 `git reset HEAD~1` 回退）。
+- 展示 `git diff HEAD~1`（提交差异），让用户审查 pubspec.yaml、CHANGELOG.md 与 metadata 的改动。
+- 说明推送 `preview` 会自动触发预览版构建（tag 由流水线推导为 `vX.Y.Z-preview` 或下一序号）。
+- 询问用户确认：继续推送，还是中止（中止需 `git reset HEAD~1` 回退提交）。
 
-只有用户明确确认后才继续推送。
-
-## Step 7: 推送
+只有用户明确确认后才继续：
 
 ```bash
-git push && git push --tags
+git add pubspec.yaml CHANGELOG.md metadata/
+git commit -m "chore: release vX.Y.Z"
+git push origin preview
 ```
 
-推送完成后，向用户确认发布已触发，说明 GitHub Actions 会自动检测到 tag 并构建发布。
+## Step 8: 创建 preview -> main 发布 PR
+
+```bash
+gh pr create --base main --head preview --title "release: vX.Y.Z" --fill
+```
+
+创建后向用户说明：
+
+- PR 合并进 `main` 后，流水线自动创建 `vX.Y.Z` tag、构建并发布正式版（GitHub Release latest），F-Droid 元数据 changelog 由 CI 兜底提交。
+- 若 `vX.Y.Z` tag 已存在，流水线会幂等跳过，不会重复发布。
+- 全程**不要手动 `git tag` / `git push --tags`**，tag 完全由 CI 管理。

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -38,6 +38,11 @@ runs:
     - name: Get dependencies
       run: flutter pub get
       shell: bash
+      # 提交的 pubspec.lock 锁定的是国内镜像：不设 PUB_HOSTED_URL 时 pub get 会把
+      # lock 全量翻成 pub.dev，造成「生成物漂移」假失败（三个调用方共用本 action，
+      # 在此统一设置；build-android 自身的 job 级 env 与此处取值相同，保留无妨）。
+      env:
+        PUB_HOSTED_URL: https://pub.flutter-io.cn
 
     - name: Set up Python 3
       uses: actions/setup-python@v3

--- a/.github/scripts/release_changelog.py
+++ b/.github/scripts/release_changelog.py
@@ -16,9 +16,10 @@ def main():
     end_idx = len(lines)
 
     if is_prerelease:
-        # Prerelease: use the latest (first) changelog section
+        # 预览/RC 固定取 [Unreleased] 章节：按名称匹配而非按位置取第一个章节，
+        # 避免章节缺失时静默借用其他版本（通常是上一个正式版）的更新说明。
         for i, line in enumerate(lines):
-            if re.match(r"^##\s", line.strip()):
+            if re.match(r"^##\s*\[?unreleased\]?\s*$", line.strip(), re.IGNORECASE):
                 start_idx = i
                 break
     else:
@@ -31,6 +32,8 @@ def main():
     if start_idx == -1:
         if is_prerelease:
             changelog = "*No changelog entry for this version.*"
+            if os.environ.get("GITHUB_OUTPUT"):
+                print("::warning::CHANGELOG.md 缺少 [Unreleased] 章节，本次预发布版将没有更新说明")
         else:
             print(f"::error::No changelog entry found for release version {version}. "
                   "Please add a changelog entry before releasing.", file=sys.stderr)
@@ -52,6 +55,9 @@ def main():
             print(f"::error::Changelog entry for {version} is empty. "
                   "Please add content before releasing.", file=sys.stderr)
             sys.exit(1)
+        if is_prerelease and changelog.startswith("*No changelog"):
+            if os.environ.get("GITHUB_OUTPUT"):
+                print("::warning::CHANGELOG.md 的 [Unreleased] 章节为空，本次预发布版将没有更新说明")
 
     output = os.environ.get("GITHUB_OUTPUT", "")
     if output:

--- a/.github/scripts/resolve_release_version.py
+++ b/.github/scripts/resolve_release_version.py
@@ -1,0 +1,383 @@
+#!/usr/bin/env python3
+"""Resolve release channel, version, tag, and idempotency status for Bugaoshan CI/CD.
+
+Outputs GitHub Actions variables via GITHUB_OUTPUT or prints to stdout.
+
+发布语义详见 docs/architecture/release-pipeline.md，要点：
+- formal：仅来自 push 到 main（或指向 main 顶端的 tag）。tag = pubspec 的 vX.Y.Z，
+  远端已存在同名 tag 时幂等跳过。
+- preview：push/dispatch 到 preview（或指向 preview 顶端的含 `-` tag）。tag 与 pubspec
+  解耦、按阶段命名：
+  * 常态（pubspec == 最新正式 tag）：最新正式 tag 严格递增 Z 位 + `-preview[.N]`；
+  * 准备期（pubspec 领先最新正式 tag，/release 已 bump）：`vX.Y.Z-rc` / `-rcN`。
+  仓库尚无正式 tag 时回退用 pubspec 版本推导。
+- 预览构建（含 RC）统一注入「最新正式 tag」的 versionName/versionCode
+  （build_version / build_number），pubspec 的 /release bump 不影响预览构建版本。
+- build_only：dispatch 于非 main/preview 分支、tag 指向非 main/preview 顶端、
+  或正式命名 tag 指向 preview 顶端时，仅构建产物，不推 tag、不发布。
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+from pathlib import Path
+
+SEMVER_RE = re.compile(r"^(\d+)\.(\d+)\.(\d+)$")
+STABLE_TAG_RE = re.compile(r"^v(\d+)\.(\d+)\.(\d+)$")
+
+
+def run_git(args: list[str], root_dir: Path | None = None) -> tuple[int, str, str]:
+    """Execute git command and return (code, stdout, stderr)."""
+    try:
+        proc = subprocess.run(
+            ["git"] + args,
+            cwd=str(root_dir) if root_dir else None,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        return proc.returncode, proc.stdout.strip(), proc.stderr.strip()
+    except Exception as e:
+        return 1, "", str(e)
+
+
+def extract_pubspec_version(pubspec_path: Path) -> str:
+    """Extract version string from pubspec.yaml (e.g. '2.5.1+20501' -> '2.5.1')."""
+    if not pubspec_path.exists():
+        raise FileNotFoundError(f"{pubspec_path} does not exist")
+    for line in pubspec_path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if line.startswith("version:"):
+            raw = line.split(":", 1)[1].strip()
+            # Remove +build_number if present
+            return raw.split("+")[0].strip()
+    raise ValueError(f"No version: line found in {pubspec_path}")
+
+
+def get_existing_remote_tags(root_dir: Path | None = None) -> list[str]:
+    """Fetch existing git tags from local and remote if possible."""
+    code, out, _ = run_git(["tag", "--list", "v*"], root_dir=root_dir)
+    tags = set(out.splitlines()) if code == 0 and out else set()
+
+    # Also attempt ls-remote
+    code, remote_out, _ = run_git(["ls-remote", "--tags", "origin", "refs/tags/v*"], root_dir=root_dir)
+    if code == 0 and remote_out:
+        for line in remote_out.splitlines():
+            parts = line.split()
+            if len(parts) >= 2:
+                ref = parts[1]
+                if ref.startswith("refs/tags/"):
+                    tag_name = ref[len("refs/tags/"):]
+                    if not tag_name.endswith("^{}"):
+                        tags.add(tag_name)
+    return sorted(tags)
+
+
+def get_branch_heads(root_dir: Path | None = None) -> dict[str, str]:
+    """Return head SHAs of remote main/preview branches.
+
+    优先 ls-remote（实时）；失败时回退本地 remote-tracking ref。
+    """
+    heads: dict[str, str] = {}
+    code, out, _ = run_git(
+        ["ls-remote", "origin", "refs/heads/main", "refs/heads/preview"],
+        root_dir=root_dir,
+    )
+    if code == 0 and out:
+        for line in out.splitlines():
+            parts = line.split()
+            if len(parts) >= 2 and parts[1].startswith("refs/heads/"):
+                heads[parts[1].rsplit("/", 1)[-1]] = parts[0]
+    for name in ("main", "preview"):
+        if name not in heads:
+            code, out, _ = run_git(
+                ["rev-parse", "--verify", f"refs/remotes/origin/{name}"],
+                root_dir=root_dir,
+            )
+            if code == 0 and out:
+                heads[name] = out.strip()
+    return heads
+
+
+def parse_stable_tag(tag: str) -> tuple[int, int, int] | None:
+    m = STABLE_TAG_RE.match(tag)
+    if not m:
+        return None
+    return int(m.group(1)), int(m.group(2)), int(m.group(3))
+
+
+def latest_formal(existing_tags: list[str]) -> tuple[str | None, tuple[int, int, int] | None]:
+    """Return the greatest vX.Y.Z tag (semver order) and its tuple."""
+    best: tuple[str, tuple[int, int, int]] | None = None
+    for tag in existing_tags:
+        tup = parse_stable_tag(tag)
+        if tup and (best is None or tup > best[1]):
+            best = (tag, tup)
+    if best is None:
+        return None, None
+    return best
+
+
+def build_number_of(version: str) -> str:
+    """buildNumber = major*10000 + minor*100 + patch（与 F-Droid versionCode 公式同源）。"""
+    m = SEMVER_RE.match(version)
+    if not m:
+        return ""
+    major, minor, patch = (int(x) for x in m.groups())
+    return str(major * 10000 + minor * 100 + patch)
+
+
+def calculate_next_preview_tag(last_formal_version: str, existing_tags: list[str]) -> str:
+    """Next preview tag anchored to last_formal_version (v2.5.1 -> v2.5.1-preview / v2.5.1-preview.2)."""
+    first_tag = f"v{last_formal_version}-preview"
+    if first_tag not in existing_tags:
+        return first_tag
+
+    pattern = re.compile(rf"^v{re.escape(last_formal_version)}-preview\.(\d+)$")
+    max_num = 1
+    for t in existing_tags:
+        m = pattern.match(t)
+        if m:
+            num = int(m.group(1))
+            if num > max_num:
+                max_num = num
+
+    return f"v{last_formal_version}-preview.{max_num + 1}"
+
+
+def calculate_next_rc_tag(target_version: str, existing_tags: list[str]) -> str:
+    """Next RC tag for target_version (v2.5.2 -> v2.5.2-rc / v2.5.2-rc1 / v2.5.2-rc2)."""
+    base = f"v{target_version}-rc"
+    if base not in existing_tags:
+        return base
+
+    pattern = re.compile(rf"^v{re.escape(target_version)}-rc(\d+)$")
+    max_num = 0
+    for t in existing_tags:
+        m = pattern.match(t)
+        if m:
+            num = int(m.group(1))
+            if num > max_num:
+                max_num = num
+
+    return f"v{target_version}-rc{max_num + 1}"
+
+
+def resolve_release(
+    pubspec_path: Path,
+    event_name: str = "push",
+    ref_name: str = "",
+    ref_type: str = "branch",
+    channel_input: str = "auto",
+    version_override: str = "",
+    existing_tags: list[str] | None = None,
+    main_head: str = "",
+    preview_head: str = "",
+    head_sha: str = "",
+    root_dir: Path | None = None,
+) -> dict[str, str]:
+    """Determine channel, tag, version, build injection values, and publish eligibility.
+
+    Returns dict with keys:
+      channel: 'formal' | 'preview'
+      tag: resolved tag string (e.g. 'v2.5.2', 'v2.5.2-preview.2', 'v2.5.2-rc')
+      version_name: tag 的基础版本号（不含 v 与后缀）
+      is_prerelease: 'true' | 'false'
+      should_release: 'true' | 'false'（是否发布 Release；build_only 时恒为 false）
+      build_only: 'true' | 'false'（仅构建产物：不推 tag、不发布）
+      build_version: 构建注入的 versionName（预览=上一正式版；formal=pubspec）
+      build_number: 构建注入的 versionCode 基数
+      release_title: human readable release title
+      skip_reason: explanation if should_release is 'false'
+    """
+    if existing_tags is None:
+        existing_tags = get_existing_remote_tags(root_dir=root_dir)
+
+    pubspec_ver = extract_pubspec_version(pubspec_path)
+    m = SEMVER_RE.match(pubspec_ver)
+    pubspec_tuple = (int(m.group(1)), int(m.group(2)), int(m.group(3))) if m else None
+
+    formal_tag, formal_tuple = latest_formal(existing_tags)
+
+    # ── pubspec 与最新正式 tag 的三态自检 ─────────────────
+    pubspec_state = "no-formal"
+    if formal_tuple and pubspec_tuple:
+        if pubspec_tuple < formal_tuple:
+            pubspec_state = "behind"
+        elif pubspec_tuple > formal_tuple:
+            pubspec_state = "ahead"
+        else:
+            pubspec_state = "aligned"
+    if pubspec_state == "behind":
+        print(
+            f"::warning::pubspec 版本 {pubspec_ver} 落后于最新正式 tag {formal_tag}"
+            "——下一次正式发布会被幂等守卫卡住，请尽快 bump pubspec 对齐。"
+        )
+    elif pubspec_state == "ahead":
+        print(
+            f"::notice::pubspec 版本 {pubspec_ver} 领先于最新正式 tag {formal_tag}"
+            "——处于 /release 准备期，本轮预览 tag 使用 rc 命名。"
+        )
+
+    # ── 通道判定 ─────────────────────────────────────
+    skip_reason = ""
+    should_release = "true"
+    build_only = "false"
+
+    if event_name == "workflow_dispatch" and ref_type == "branch" and ref_name not in ("main", "preview"):
+        build_only = "true"
+        skip_reason = f"build-only：dispatch 于非 main/preview 分支 {ref_name}，仅构建产物。"
+        print("::warning::dispatch 于非 main/preview 分支，本次仅构建产物、不发布。")
+    elif ref_type == "tag":
+        if not head_sha:
+            build_only = "true"
+            skip_reason = "build-only：无法解析 main/preview 分支顶端 SHA，保守处理仅构建产物。"
+            print("::warning::无法解析 main/preview 分支顶端 SHA，保守起见本次仅构建产物、不发布。")
+        elif main_head and head_sha == main_head:
+            pass  # 指向 main 顶端：按名称发布
+        elif preview_head and head_sha == preview_head:
+            if "-" not in ref_name.lstrip("v"):
+                # 正式命名的 tag 不允许指向 preview——formal 仅允许指向 main
+                build_only = "true"
+                skip_reason = f"build-only：正式 tag {ref_name} 指向 preview 顶端，formal 仅允许指向 main。"
+                print(
+                    f"::warning::正式 tag {ref_name} 指向 preview 顶端，本次仅构建产物、不发布；"
+                    "formal tag 仅允许指向 main。"
+                )
+        else:
+            build_only = "true"
+            skip_reason = f"build-only：tag {ref_name} 未指向 main/preview 顶端，仅构建产物；若为误推请删除该 tag。"
+            print(f"::warning::tag {ref_name} 未指向 main/preview 顶端，本次仅构建产物、不发布；若为误推请删除该 tag。")
+
+    if version_override:
+        is_pre = "-" in version_override.lstrip("v")
+        channel = "preview" if is_pre else "formal"
+        if channel_input in ("formal", "preview"):
+            channel = channel_input
+    elif ref_type == "tag":
+        channel = "preview" if "-" in ref_name.lstrip("v") else "formal"
+    elif ref_name == "main":
+        channel = channel_input if channel_input in ("formal", "preview") else "formal"
+    elif ref_name == "preview":
+        channel = channel_input if channel_input in ("formal", "preview") else "preview"
+    else:
+        # dispatch 于其他分支（build_only）：按状态给预览命名通道
+        channel = "preview"
+
+    # ── tag / version_name 计算 ──────────────────────
+    if version_override:
+        clean_override = version_override.lstrip("v")
+        tag = f"v{clean_override}"
+        version_name = clean_override.split("-")[0]
+        is_prerelease = "-" in clean_override
+    elif ref_type == "tag":
+        tag = ref_name
+        version_name = ref_name.lstrip("v").split("-")[0]
+        is_prerelease = "-" in ref_name.lstrip("v")
+    elif channel == "formal":
+        version_name = pubspec_ver
+        tag = f"v{pubspec_ver}"
+        is_prerelease = False
+        # Idempotency guard for formal releases:
+        # If tag already exists on remote, avoid re-releasing or erroring out
+        if tag in existing_tags:
+            should_release = "false"
+            skip_reason = f"Formal release tag {tag} already exists on remote."
+    else:
+        # preview 命名状态机：常态锚定最新正式 tag 递增 Z 位；准备期用 rc 命名
+        is_prerelease = True
+        if pubspec_state == "ahead":
+            version_name = pubspec_ver
+            tag = calculate_next_rc_tag(pubspec_ver, existing_tags)
+        elif formal_tuple is not None:
+            version_name = f"{formal_tuple[0]}.{formal_tuple[1]}.{formal_tuple[2] + 1}"
+            tag = calculate_next_preview_tag(version_name, existing_tags)
+        else:
+            version_name = pubspec_ver
+            tag = calculate_next_preview_tag(pubspec_ver, existing_tags)
+
+    # ── 构建注入：formal 用 version_name（分支推送=pubspec；tag/override=显式声明的
+    # 版本号），预览（含 RC）统一用上一正式版，pubspec 的 /release bump 不影响预览 ──
+    if channel == "preview" or is_prerelease:
+        build_version = (
+            f"{formal_tuple[0]}.{formal_tuple[1]}.{formal_tuple[2]}"
+            if formal_tuple is not None
+            else pubspec_ver
+        )
+    else:
+        build_version = version_name
+    build_number = build_number_of(build_version)
+
+    # ── 发布资格 ─────────────────────────────────────
+    if build_only == "true":
+        should_release = "false"
+        if not skip_reason:
+            skip_reason = "build-only：仅构建产物。"
+
+    title = f"Release {tag}" if not is_prerelease else f"Preview {tag}"
+
+    return {
+        "channel": channel,
+        "tag": tag,
+        "version_name": version_name,
+        "is_prerelease": "true" if is_prerelease else "false",
+        "should_release": should_release,
+        "build_only": build_only,
+        "build_version": build_version,
+        "build_number": build_number,
+        "release_title": title,
+        "skip_reason": skip_reason,
+    }
+
+
+def main():
+    root = Path(__file__).resolve().parents[2]
+    pubspec_path = root / "pubspec.yaml"
+
+    event_name = os.environ.get("GITHUB_EVENT_NAME", "push")
+    ref_name = os.environ.get("GITHUB_REF_NAME", "")
+    ref_type = os.environ.get("GITHUB_REF_TYPE", "branch")
+    head_sha = os.environ.get("GITHUB_SHA", "")
+    channel_input = os.environ.get("INPUT_CHANNEL", "auto").strip().lower()
+    version_override = os.environ.get("INPUT_VERSION_OVERRIDE", "").strip()
+
+    main_head = preview_head = ""
+    if ref_type == "tag":
+        heads = get_branch_heads(root_dir=root)
+        main_head = heads.get("main", "")
+        preview_head = heads.get("preview", "")
+        # GITHUB_SHA 对 annotated tag（git tag -a）是 tag 对象 SHA 而非其指向的
+        # commit——本地剥离到 commit 再与分支 head 比对（fetch-depth: 0 会带上
+        # 全部 tag，rev-parse 可靠）；失败时回退 GITHUB_SHA。
+        code, peeled, _ = run_git(["rev-parse", f"refs/tags/{ref_name}^{{commit}}"], root_dir=root)
+        if code == 0 and peeled:
+            head_sha = peeled
+
+    result = resolve_release(
+        pubspec_path=pubspec_path,
+        event_name=event_name,
+        ref_name=ref_name,
+        ref_type=ref_type,
+        channel_input=channel_input,
+        version_override=version_override,
+        main_head=main_head,
+        preview_head=preview_head,
+        head_sha=head_sha,
+        root_dir=root,
+    )
+
+    output_path = os.environ.get("GITHUB_OUTPUT", "")
+    if output_path:
+        with open(output_path, "a", encoding="utf-8") as f:
+            for k, v in result.items():
+                f.write(f"{k}={v}\n")
+
+    print("Resolved Release Metadata:")
+    for k, v in result.items():
+        print(f"  {k}: {v}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/tests/test_release_changelog.py
+++ b/.github/scripts/tests/test_release_changelog.py
@@ -1,0 +1,103 @@
+import contextlib
+import io
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+import release_changelog
+
+
+class ReleaseChangelogTest(unittest.TestCase):
+    """回归重点：预览/RC 的发布说明只能来自 [Unreleased] 章节，
+    绝不允许在章节缺失时借用其他版本（通常是上一个正式版）的内容。"""
+
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp_dir.name)
+        (self.root / "CHANGELOG.md").write_text("", encoding="utf-8")
+        self._old_cwd = os.getcwd()
+        os.chdir(self.root)
+        self._old_env = {k: os.environ.get(k) for k in ("VERSION", "GITHUB_OUTPUT")}
+
+    def tearDown(self):
+        os.chdir(self._old_cwd)
+        for k, v in self._old_env.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+        self.temp_dir.cleanup()
+
+    def write_changelog(self, text):
+        (self.root / "CHANGELOG.md").write_text(text, encoding="utf-8")
+
+    def run_extract(self, version):
+        os.environ["VERSION"] = version
+        output = self.root / "github_output.txt"
+        if output.exists():
+            output.unlink()
+        os.environ["GITHUB_OUTPUT"] = str(output)
+        stdout = io.StringIO()
+        with contextlib.redirect_stdout(stdout):
+            release_changelog.main()
+        return output.read_text(encoding="utf-8"), stdout.getvalue()
+
+    CHANGELOG_WITH_SECTIONS = (
+        "## [Unreleased]\n"
+        "\n"
+        "### Added\n"
+        "- 新功能 A\n"
+        "\n"
+        "## [2.5.1] - 2026-09-11\n"
+        "\n"
+        "### Fixed\n"
+        "- 修复 B\n"
+    )
+
+    def test_prerelease_uses_unreleased_section(self):
+        self.write_changelog(self.CHANGELOG_WITH_SECTIONS)
+        out, _ = self.run_extract("v2.5.2-preview.1")
+        self.assertIn("- 新功能 A", out)
+        self.assertNotIn("修复 B", out)
+
+    def test_prerelease_empty_unreleased_gets_placeholder_and_warning(self):
+        self.write_changelog("## [Unreleased]\n\n## [2.5.1] - 2026-09-11\n\n### Fixed\n- 修复 B\n")
+        out, warn = self.run_extract("v2.5.2-preview.1")
+        self.assertIn("No changelog entry", out)
+        self.assertNotIn("修复 B", out)
+        self.assertIn("::warning::", warn)
+
+    def test_prerelease_missing_unreleased_never_borrows_last_formal(self):
+        self.write_changelog("## [2.5.1] - 2026-09-11\n\n### Fixed\n- 修复 B\n")
+        out, warn = self.run_extract("v2.5.2-rc")
+        self.assertIn("No changelog entry", out)
+        self.assertNotIn("修复 B", out)
+        self.assertIn("::warning::", warn)
+
+    def test_formal_uses_matching_section(self):
+        self.write_changelog(self.CHANGELOG_WITH_SECTIONS)
+        out, _ = self.run_extract("v2.5.1")
+        self.assertIn("- 修复 B", out)
+        self.assertNotIn("新功能 A", out)
+
+    def test_formal_missing_section_fails(self):
+        self.write_changelog("## [Unreleased]\n\n- 未发布\n")
+        with self.assertRaises(SystemExit) as ctx:
+            self.run_extract("v9.9.9")
+        self.assertEqual(ctx.exception.code, 1)
+
+    def test_formal_empty_section_fails(self):
+        self.write_changelog("## [Unreleased]\n\n## [2.5.1] - 2026-09-11\n")
+        with self.assertRaises(SystemExit) as ctx:
+            self.run_extract("v2.5.1")
+        self.assertEqual(ctx.exception.code, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/tests/test_resolve_release_version.py
+++ b/.github/scripts/tests/test_resolve_release_version.py
@@ -1,0 +1,298 @@
+import contextlib
+import io
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+from resolve_release_version import (
+    build_number_of,
+    calculate_next_preview_tag,
+    calculate_next_rc_tag,
+    latest_formal,
+    resolve_release,
+)
+
+
+class ResolveReleaseVersionTest(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp_dir.name)
+        self.pubspec = self.root / "pubspec.yaml"
+        self.set_pubspec_version("2.5.1")
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def set_pubspec_version(self, version):
+        self.pubspec.write_text(f"name: bugaoshan\nversion: {version}\n", encoding="utf-8")
+
+    def resolve(self, **kwargs):
+        stdout = io.StringIO()
+        with contextlib.redirect_stdout(stdout):
+            result = resolve_release(pubspec_path=self.pubspec, **kwargs)
+        return result, stdout.getvalue()
+
+    # ── 基础工具 ─────────────────────────────────────
+
+    def test_extract_pubspec_version(self):
+        self.pubspec.write_text("name: bugaoshan\nversion: 2.5.1+20501\n", encoding="utf-8")
+        from resolve_release_version import extract_pubspec_version
+
+        self.assertEqual(extract_pubspec_version(self.pubspec), "2.5.1")
+
+    def test_build_number_formula(self):
+        self.assertEqual(build_number_of("2.5.1"), "20501")
+        self.assertEqual(build_number_of("2.6.0"), "20600")
+
+    def test_latest_formal_ignores_prerelease_tags(self):
+        tag, tup = latest_formal(["v2.5.1", "v2.5.1-preview.2", "v2.4.0", "v2.5.2-rc"])
+        self.assertEqual(tag, "v2.5.1")
+        self.assertEqual(tup, (2, 5, 1))
+
+    def test_calculate_next_preview_tag_first(self):
+        self.assertEqual(
+            calculate_next_preview_tag("2.5.1", ["v2.4.0", "v2.5.0-preview", "v2.5.0"]),
+            "v2.5.1-preview",
+        )
+
+    def test_calculate_next_preview_tag_increment(self):
+        self.assertEqual(
+            calculate_next_preview_tag("2.5.1", ["v2.5.1-preview", "v2.5.1-preview.2", "v2.4.0"]),
+            "v2.5.1-preview.3",
+        )
+
+    def test_calculate_next_rc_tag_first_and_increment(self):
+        self.assertEqual(calculate_next_rc_tag("2.5.2", ["v2.5.1"]), "v2.5.2-rc")
+        self.assertEqual(calculate_next_rc_tag("2.5.2", ["v2.5.1", "v2.5.2-rc"]), "v2.5.2-rc1")
+        self.assertEqual(
+            calculate_next_rc_tag("2.5.2", ["v2.5.1", "v2.5.2-rc", "v2.5.2-rc1"]),
+            "v2.5.2-rc2",
+        )
+
+    # ── 常态预览：锚定最新正式 tag 递增 Z 位 ─────────────
+
+    def test_preview_anchored_to_last_formal(self):
+        res, _ = self.resolve(ref_name="preview", ref_type="branch", existing_tags=["v2.5.1"])
+        self.assertEqual(res["channel"], "preview")
+        self.assertEqual(res["tag"], "v2.5.2-preview")
+        self.assertEqual(res["build_version"], "2.5.1")
+        self.assertEqual(res["build_number"], "20501")
+        self.assertEqual(res["should_release"], "true")
+        self.assertEqual(res["build_only"], "false")
+
+    def test_preview_increments_sequence(self):
+        res, _ = self.resolve(
+            ref_name="preview",
+            ref_type="branch",
+            existing_tags=["v2.5.1", "v2.5.2-preview", "v2.5.2-preview.2"],
+        )
+        self.assertEqual(res["tag"], "v2.5.2-preview.3")
+        self.assertEqual(res["build_version"], "2.5.1")
+
+    def test_preview_aligned_state_is_silent(self):
+        _, out = self.resolve(ref_name="preview", ref_type="branch", existing_tags=["v2.5.1"])
+        self.assertNotIn("::warning::", out)
+        self.assertNotIn("::notice::", out)
+
+    # ── 准备期：pubspec 领先 → rc 命名 ──────────────────
+
+    def test_rc_naming_when_pubspec_ahead(self):
+        self.set_pubspec_version("2.5.2")
+        res, out = self.resolve(ref_name="preview", ref_type="branch", existing_tags=["v2.5.1"])
+        self.assertEqual(res["tag"], "v2.5.2-rc")
+        self.assertEqual(res["build_version"], "2.5.1")
+        self.assertIn("::notice::", out)
+
+    def test_rc_increment_when_pubspec_ahead(self):
+        self.set_pubspec_version("2.5.2")
+        res, _ = self.resolve(
+            ref_name="preview",
+            ref_type="branch",
+            existing_tags=["v2.5.1", "v2.5.2-rc", "v2.5.2-rc1"],
+        )
+        self.assertEqual(res["tag"], "v2.5.2-rc2")
+
+    # ── 落后状态：锚定最新正式 tag 并强提示 ─────────────
+
+    def test_behind_state_anchors_to_last_formal_with_warning(self):
+        res, out = self.resolve(
+            ref_name="preview",
+            ref_type="branch",
+            existing_tags=["v2.5.1", "v2.5.2"],
+        )
+        self.assertEqual(res["tag"], "v2.5.3-preview")
+        self.assertEqual(res["build_version"], "2.5.2")
+        self.assertIn("::warning::", out)
+
+    # ── 无正式 tag 的回退 ────────────────────────────
+
+    def test_no_formal_tag_falls_back_to_pubspec(self):
+        res, _ = self.resolve(ref_name="preview", ref_type="branch", existing_tags=[])
+        self.assertEqual(res["tag"], "v2.5.1-preview")
+        self.assertEqual(res["build_version"], "2.5.1")
+
+    # ── formal 通道 ─────────────────────────────────
+
+    def test_formal_release_main_branch_new(self):
+        res, _ = self.resolve(ref_name="main", ref_type="branch", existing_tags=["v2.4.0"])
+        self.assertEqual(res["channel"], "formal")
+        self.assertEqual(res["tag"], "v2.5.1")
+        self.assertEqual(res["is_prerelease"], "false")
+        self.assertEqual(res["should_release"], "true")
+        self.assertEqual(res["build_only"], "false")
+        self.assertEqual(res["build_version"], "2.5.1")
+        self.assertEqual(res["build_number"], "20501")
+        self.assertEqual(res["release_title"], "Release v2.5.1")
+
+    def test_formal_release_main_branch_already_tagged(self):
+        res, _ = self.resolve(
+            ref_name="main", ref_type="branch", existing_tags=["v2.5.1", "v2.4.0"]
+        )
+        self.assertEqual(res["should_release"], "false")
+        self.assertIn("already exists", res["skip_reason"])
+
+    def test_formal_after_release_prep_bump(self):
+        self.set_pubspec_version("2.5.2")
+        res, _ = self.resolve(ref_name="main", ref_type="branch", existing_tags=["v2.5.1"])
+        self.assertEqual(res["tag"], "v2.5.2")
+        self.assertEqual(res["build_version"], "2.5.2")
+        self.assertEqual(res["build_number"], "20502")
+
+    # ── build_only：dispatch 于非 main/preview 分支 ────
+
+    def test_dispatch_on_feature_branch_is_build_only(self):
+        res, out = self.resolve(
+            event_name="workflow_dispatch",
+            ref_name="feat/foo",
+            ref_type="branch",
+            existing_tags=["v2.5.1"],
+        )
+        self.assertEqual(res["build_only"], "true")
+        self.assertEqual(res["should_release"], "false")
+        self.assertEqual(res["tag"], "v2.5.2-preview")
+        self.assertIn("::warning::", out)
+
+    def test_dispatch_on_main_is_not_build_only(self):
+        res, _ = self.resolve(
+            event_name="workflow_dispatch",
+            ref_name="main",
+            ref_type="branch",
+            existing_tags=["v2.5.1"],
+        )
+        self.assertEqual(res["build_only"], "false")
+        self.assertEqual(res["should_release"], "false")  # v2.5.1 已存在，幂等跳过
+
+    # ── tag 事件：按指向判定发布资格 ──────────────────
+
+    def test_tag_on_main_head_publishes_formal(self):
+        res, _ = self.resolve(
+            ref_type="tag",
+            ref_name="v2.5.2",
+            existing_tags=["v2.5.1"],
+            main_head="m1",
+            preview_head="p1",
+            head_sha="m1",
+        )
+        self.assertEqual(res["channel"], "formal")
+        self.assertEqual(res["build_only"], "false")
+        self.assertEqual(res["should_release"], "true")
+        self.assertEqual(res["build_version"], "2.5.2")
+
+    def test_formal_named_tag_on_preview_head_is_build_only(self):
+        res, out = self.resolve(
+            ref_type="tag",
+            ref_name="v2.5.2",
+            existing_tags=["v2.5.1"],
+            main_head="m1",
+            preview_head="p1",
+            head_sha="p1",
+        )
+        self.assertEqual(res["build_only"], "true")
+        self.assertEqual(res["should_release"], "false")
+        self.assertIn("::warning::", out)
+
+    def test_rc_named_tag_on_preview_head_publishes_prerelease(self):
+        res, _ = self.resolve(
+            ref_type="tag",
+            ref_name="v2.5.2-rc1",
+            existing_tags=["v2.5.1"],
+            main_head="m1",
+            preview_head="p1",
+            head_sha="p1",
+        )
+        self.assertEqual(res["channel"], "preview")
+        self.assertEqual(res["is_prerelease"], "true")
+        self.assertEqual(res["build_only"], "false")
+        self.assertEqual(res["should_release"], "true")
+
+    def test_tag_on_other_commit_is_build_only(self):
+        res, out = self.resolve(
+            ref_type="tag",
+            ref_name="v2.5.2",
+            existing_tags=["v2.5.1"],
+            main_head="m1",
+            preview_head="p1",
+            head_sha="deadbeef",
+        )
+        self.assertEqual(res["build_only"], "true")
+        self.assertEqual(res["should_release"], "false")
+        self.assertIn("::warning::", out)
+
+    def test_tag_with_unresolvable_heads_is_build_only(self):
+        res, out = self.resolve(
+            ref_type="tag",
+            ref_name="v2.5.2",
+            existing_tags=["v2.5.1"],
+            main_head="",
+            preview_head="",
+            head_sha="abc123",
+        )
+        self.assertEqual(res["build_only"], "true")
+        self.assertEqual(res["should_release"], "false")
+        self.assertIn("::warning::", out)
+
+    # ── version_override ────────────────────────────
+
+    def test_version_override_prerelease_on_preview(self):
+        res, _ = self.resolve(
+            ref_name="preview",
+            ref_type="branch",
+            version_override="2.5.2-beta",
+            existing_tags=["v2.5.1"],
+        )
+        self.assertEqual(res["tag"], "v2.5.2-beta")
+        self.assertEqual(res["is_prerelease"], "true")
+        self.assertEqual(res["should_release"], "true")
+
+    def test_push_tag_formal_on_main_head(self):
+        res, _ = self.resolve(
+            ref_type="tag",
+            ref_name="v2.5.1",
+            existing_tags=[],
+            main_head="m1",
+            head_sha="m1",
+        )
+        self.assertEqual(res["channel"], "formal")
+        self.assertEqual(res["tag"], "v2.5.1")
+        self.assertEqual(res["should_release"], "true")
+
+    def test_push_tag_prerelease_on_main_head(self):
+        res, _ = self.resolve(
+            ref_type="tag",
+            ref_name="v2.5.1-rc1",
+            existing_tags=[],
+            main_head="m1",
+            head_sha="m1",
+        )
+        self.assertEqual(res["channel"], "preview")
+        self.assertEqual(res["is_prerelease"], "true")
+        self.assertEqual(res["should_release"], "true")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -7,6 +7,14 @@ on:
         description: "tag name"
         required: false
         type: string
+      build_name:
+        description: "构建注入的 versionName（--build-name；预览=上一正式版，formal=pubspec）"
+        required: false
+        type: string
+      build_number:
+        description: "构建注入的 versionCode 基数（--build-number）"
+        required: false
+        type: string
 
 jobs:
   build-android:
@@ -61,8 +69,14 @@ jobs:
 
       - name: Build universal APK for in-app updates
         run: |
+          # 版本注入：预览通道统一使用上一正式版的版本号（pubspec 的 /release bump
+          # 不影响预览构建），formal 与 pubspec 一致；空值时回退 pubspec 默认。
+          BUILD_ARGS=()
+          if [ -n "${{ inputs.build_name }}" ]; then BUILD_ARGS+=(--build-name "${{ inputs.build_name }}"); fi
+          if [ -n "${{ inputs.build_number }}" ]; then BUILD_ARGS+=(--build-number "${{ inputs.build_number }}"); fi
           flutter build apk --release \
             --obfuscate --split-debug-info=build/app/outputs/symbols/universal \
+            "${BUILD_ARGS[@]}" \
             --dart-define=GIT_TAG=${{ steps.setup.outputs.GIT_TAG }} \
             --dart-define=GIT_COMMIT=${{ steps.setup.outputs.GIT_COMMIT }} \
             --dart-define=GIT_COMMIT_DATE=${{ steps.setup.outputs.GIT_COMMIT_DATE }}
@@ -72,8 +86,12 @@ jobs:
 
       - name: Build ABI split APKs for manual downloads
         run: |
+          BUILD_ARGS=()
+          if [ -n "${{ inputs.build_name }}" ]; then BUILD_ARGS+=(--build-name "${{ inputs.build_name }}"); fi
+          if [ -n "${{ inputs.build_number }}" ]; then BUILD_ARGS+=(--build-number "${{ inputs.build_number }}"); fi
           flutter build apk --release --split-per-abi \
             --obfuscate --split-debug-info=build/app/outputs/symbols/split \
+            "${BUILD_ARGS[@]}" \
             --dart-define=GIT_TAG=${{ steps.setup.outputs.GIT_TAG }} \
             --dart-define=GIT_COMMIT=${{ steps.setup.outputs.GIT_COMMIT }} \
             --dart-define=GIT_COMMIT_DATE=${{ steps.setup.outputs.GIT_COMMIT_DATE }}

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -7,6 +7,14 @@ on:
         description: "tag name"
         required: false
         type: string
+      build_name:
+        description: "构建注入的 versionName（--build-name；预览=上一正式版，formal=pubspec）"
+        required: false
+        type: string
+      build_number:
+        description: "构建注入的 versionCode 基数（--build-number）"
+        required: false
+        type: string
 
 jobs:
   build-windows:
@@ -32,7 +40,13 @@ jobs:
 
       - name: Build Windows
         run: |
+          # 版本注入：预览通道统一使用上一正式版的版本号（pubspec 的 /release bump
+          # 不影响预览构建），formal 与 pubspec 一致；空值时回退 pubspec 默认。
+          BUILD_ARGS=()
+          if [ -n "${{ inputs.build_name }}" ]; then BUILD_ARGS+=(--build-name "${{ inputs.build_name }}"); fi
+          if [ -n "${{ inputs.build_number }}" ]; then BUILD_ARGS+=(--build-number "${{ inputs.build_number }}"); fi
           flutter build windows --release \
+            "${BUILD_ARGS[@]}" \
             --dart-define=GIT_TAG=${{ steps.setup.outputs.GIT_TAG }} \
             --dart-define=GIT_COMMIT=${{ steps.setup.outputs.GIT_COMMIT }} \
             --dart-define=GIT_COMMIT_DATE=${{ steps.setup.outputs.GIT_COMMIT_DATE }}

--- a/.github/workflows/pre-flight.yml
+++ b/.github/workflows/pre-flight.yml
@@ -1,0 +1,79 @@
+name: Pre-flight Quality Checks
+
+on:
+  pull_request:
+    branches:
+      - main
+      - preview
+  push:
+    branches:
+      - main
+      - preview
+  workflow_dispatch:
+
+concurrency:
+  group: preflight-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  branch-policy:
+    name: Enforce Branch Flow Policy
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify branch flow compliance
+        run: |
+          BASE="${{ github.base_ref }}"
+          HEAD="${{ github.head_ref }}"
+          echo "Base branch (target): $BASE"
+          echo "Head branch (source): $HEAD"
+
+          # Strict flow policy:
+          # feature/*, fix/* -> preview -> main
+          if [ "$BASE" = "main" ]; then
+            if [ "$HEAD" != "preview" ]; then
+              echo "::error::[Branch Policy Violation] 禁止直接向 main 分支合并！main 只能接收来自 preview 分支的 PR（标准流向: feature -> preview -> main）。当前来源: $HEAD"
+              exit 1
+            fi
+          fi
+          echo "Branch policy check passed: $HEAD -> $BASE is compliant."
+
+  check:
+    name: Lint, Test & Verification Gate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Flutter and Environment
+        uses: ./.github/actions/setup
+
+      - name: Static Analysis
+        run: dart analyze --fatal-infos
+
+      - name: Verify Clean Working Tree after Code Generation
+        run: |
+          git status --porcelain
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "::error::Generated code drift detected! Please run 'dart run build_runner build --delete-conflicting-outputs' and 'flutter gen-l10n', then commit the updated files."
+            git diff
+            exit 1
+          fi
+
+      - name: Run Flutter Tests
+        run: flutter test
+
+      - name: Run Python CI Automation Tests
+        run: |
+          python3 -m unittest discover -s .github/scripts/tests/
+          python3 -m unittest discover -s .github/scripts/
+
+      - name: Pre-release Metadata & Consistency Check
+        run: |
+          if [ "${{ github.base_ref || github.ref_name }}" = "main" ]; then
+            python3 tool/pre_release_check.py --ci
+          else
+            python3 tool/pre_release_check.py --ci --prerelease
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,111 +1,179 @@
-name: Build App
+name: Release Pipeline
 
 on:
   push:
+    branches:
+      - main
+      - preview
     tags:
       - "v*.*.*"
   workflow_dispatch:
     inputs:
-      version:
-        description: "tag name"
+      channel:
+        description: "Release channel (auto / formal / preview)"
+        required: false
+        default: "auto"
+        type: choice
+        options:
+          - auto
+          - formal
+          - preview
+      version_override:
+        description: "Explicit version or tag (optional, e.g. 2.5.1 or v2.5.1-rc1)"
         required: false
         type: string
 
+concurrency:
+  group: release-${{ github.ref }}
+  # 预览轨道只保留最新一轮：连续合并/ dispatch 到 preview 时取消进行中的旧发布；
+  # main 与 tag 事件绝不取消，正式发布必须完整走完。
+  cancel-in-progress: ${{ github.ref_type == 'branch' && github.ref_name == 'preview' }}
+
 jobs:
-  build-android:
-    uses: ./.github/workflows/build-android.yml
-    with:
-      version: ${{ github.event.inputs.version }}
-    secrets: inherit
-
-  build-windows:
-    uses: ./.github/workflows/build-windows.yml
-    with:
-      version: ${{ github.event.inputs.version }}
-    secrets: inherit
-
-  release:
-    name: Release
-    needs: [ build-android, build-windows ]
+  resolve-metadata:
+    name: Resolve Release Metadata
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/') || github.event_name ==
-      'workflow_dispatch'
     permissions:
       contents: write
-
+    outputs:
+      channel: ${{ steps.resolve.outputs.channel }}
+      tag: ${{ steps.resolve.outputs.tag }}
+      version_name: ${{ steps.resolve.outputs.version_name }}
+      is_prerelease: ${{ steps.resolve.outputs.is_prerelease }}
+      should_release: ${{ steps.resolve.outputs.should_release }}
+      build_only: ${{ steps.resolve.outputs.build_only }}
+      build_version: ${{ steps.resolve.outputs.build_version }}
+      build_number: ${{ steps.resolve.outputs.build_number }}
+      release_title: ${{ steps.resolve.outputs.release_title }}
+      skip_reason: ${{ steps.resolve.outputs.skip_reason }}
     steps:
-      - name: Checkout code
+      - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Download APK
+      - name: Setup Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.12"
+
+      - name: Resolve Version & Channel
+        id: resolve
+        env:
+          INPUT_CHANNEL: ${{ github.event.inputs.channel || 'auto' }}
+          INPUT_VERSION_OVERRIDE: ${{ github.event.inputs.version_override || '' }}
+        run: python3 .github/scripts/resolve_release_version.py
+
+      - name: Tag commit in repository (if new branch release)
+        if: steps.resolve.outputs.should_release == 'true' && github.ref_type != 'tag'
+        run: |
+          TAG="${{ steps.resolve.outputs.tag }}"
+          echo "Applying tag $TAG to HEAD..."
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag "$TAG"
+          # 推送失败即终止（tag 被并发 run 抢占或受保护时，继续构建只会在
+          # publish 阶段以更晚、更难排查的方式失败）
+          if ! git push origin "refs/tags/$TAG"; then
+            echo "::error::Failed to push tag $TAG. 另一个发布 run 可能已占用该 tag，请检查 Actions 运行记录。"
+            exit 1
+          fi
+
+  build-android:
+    name: Android Build
+    needs: resolve-metadata
+    if: needs.resolve-metadata.outputs.should_release == 'true' || needs.resolve-metadata.outputs.build_only == 'true'
+    uses: ./.github/workflows/build-android.yml
+    with:
+      version: ${{ needs.resolve-metadata.outputs.tag }}
+      build_name: ${{ needs.resolve-metadata.outputs.build_version }}
+      build_number: ${{ needs.resolve-metadata.outputs.build_number }}
+    secrets: inherit
+
+  build-windows:
+    name: Windows Build
+    needs: resolve-metadata
+    if: needs.resolve-metadata.outputs.should_release == 'true' || needs.resolve-metadata.outputs.build_only == 'true'
+    uses: ./.github/workflows/build-windows.yml
+    with:
+      version: ${{ needs.resolve-metadata.outputs.tag }}
+      build_name: ${{ needs.resolve-metadata.outputs.build_version }}
+      build_number: ${{ needs.resolve-metadata.outputs.build_number }}
+
+  publish-release:
+    name: Publish Release
+    needs: [resolve-metadata, build-android, build-windows]
+    if: needs.resolve-metadata.outputs.should_release == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Download Android Artifacts
         uses: actions/download-artifact@v4
         with:
           name: android-apk
           path: android-apk
 
-      - name: Download Windows
+      - name: Download Windows Artifacts
         uses: actions/download-artifact@v4
         with:
           name: windows-release
           path: windows-release
 
-      - name: Cache Argos Translate models
-        uses: actions/cache@v4
-        with:
-          path: ~/.local/share/argos-translate
-          key: argos-translate-zh-en-v1
-
-      - name: Set up Python 3
+      - name: Set up Python
         uses: actions/setup-python@v3
         with:
           python-version: "3.12"
 
       - name: Install Python dependencies
-        run: pip install pyyaml deep-translator argostranslate
-
-      - name: Pre-install Argos Translate model (cached)
         run: |
-          python3 -c "
+          pip install pyyaml deep-translator argostranslate
+
+      - name: Cache Argos Translate model
+        uses: actions/cache@v4
+        id: cache-argos
+        with:
+          path: ~/.local/share/argos-translate
+          key: argos-translate-zh-en-v1
+
+      - name: Download Argos Translate zh->en model
+        if: steps.cache-argos.outputs.cache-hit != 'true'
+        run: |
+          python -c "
           import argostranslate.package
-          import argostranslate.translate
-          installed = argostranslate.translate.get_installed_languages()
-          if not any(l.code == 'zh' for l in installed):
-              argostranslate.package.update_package_index()
-              pkgs = argostranslate.package.get_available_packages()
-              zh_en = next(p for p in pkgs if p.from_code == 'zh' and p.to_code == 'en')
-              zh_en.download()
-              argostranslate.package.install_from_path(zh_en.download())
-              print('Model installed')
-          else:
-              print('Model already cached')
+          argostranslate.package.update_package_index()
+          available = argostranslate.package.get_available_packages()
+          zh_en = next(p for p in available if p.from_code == 'zh' and p.to_code == 'en')
+          argostranslate.package.install_from_path(zh_en.download())
           "
 
-      - name: Get version and tags
+      - name: Resolve release tag & range
         id: vars
         run: python .github/scripts/release_tags.py
         env:
-          VERSION: ${{ github.event.inputs.version }}
-          GITHUB_REF_NAME: ${{ github.ref_name }}
+          VERSION: ${{ needs.resolve-metadata.outputs.tag }}
 
-      - name: Generate metadata changelogs
-        if: ${{ !contains(github.ref_name, '-') }}
+      - name: Generate metadata changelogs (formal releases only)
+        if: needs.resolve-metadata.outputs.is_prerelease != 'true'
         run: python .github/scripts/metadata_changelog.py --skip-existing
 
       - name: Commit & push metadata changelogs (safety net)
-        if: ${{ !contains(github.ref_name, '-') }}
+        if: needs.resolve-metadata.outputs.is_prerelease != 'true'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          if git diff --quiet && git diff --cached --quiet; then
-            echo "No metadata changelog changes to commit."
-          else
+          git status --porcelain
+          if [ -n "$(git status --porcelain metadata/*/changelogs/)" ]; then
             git add metadata/*/changelogs/*.txt
             git commit -m "chore: update F-Droid metadata changelogs for ${{ steps.vars.outputs.tag }}"
-            git fetch origin main
-            git rebase origin/main || { git rebase --abort || true; echo "rebase failed, continuing"; }
+            git pull --rebase origin main || { git rebase --abort || true; echo "rebase failed, continuing"; }
             git push origin HEAD:main || echo "safety-net push failed (main moved on), continuing"
+          else
+            echo "No metadata changelog changes to commit."
           fi
 
       - name: Extract changelog
@@ -114,12 +182,12 @@ jobs:
         env:
           VERSION: ${{ steps.vars.outputs.tag }}
 
-      - name: Build release body
+      - name: Generate release body
         id: release_body
         run: python .github/scripts/release_body.py
         env:
           VERSION: ${{ steps.vars.outputs.tag }}
-          REPO: https://github.com/${{ github.repository }}
+          REPO: ${{ github.server_url }}/${{ github.repository }}
           CHANGELOG: ${{ steps.changelog.outputs.changelog }}
           PREV: ${{ steps.vars.outputs.prev }}
 
@@ -128,28 +196,31 @@ jobs:
         env:
           VERSION: ${{ steps.vars.outputs.tag }}
 
-      - name: Create GitHub Release
+      - name: Create Release and Upload Assets
         run: |
           set -euo pipefail
-          PRERELEASE=${{ contains(steps.vars.outputs.tag, '-') }}
-          printf '%s' "$BODY" > notes.md
+
+          TAG="${{ steps.vars.outputs.tag }}"
+          IS_PRERELEASE="${{ needs.resolve-metadata.outputs.is_prerelease }}"
+          TITLE="${{ needs.resolve-metadata.outputs.release_title }}"
 
           GOPTS=()
-          if [ "$PRERELEASE" = "true" ]; then
+          if [ "$IS_PRERELEASE" = "true" ]; then
             GOPTS+=(--prerelease)
           fi
 
-          # 不可变发布(Immutable Releases)仓库下，prerelease 必须先落成 draft、
-          # 上传资产、再发布。若直接 publish，GitHub 会立刻将其标记为不可变，之后的资产上传会被拒绝
+          # 创建 Draft Release -> 上传制品 -> 发布（确保与不可变 Release 策略完全兼容）
+          printf "%s\n" "$BODY" > notes.md
+
           gh release create "$TAG" \
-            --title "Release $TAG" \
+            --title "$TITLE" \
             --notes-file notes.md \
             --draft \
             "${GOPTS[@]}"
 
           gh release upload "$TAG" bugaoshan_*.apk bugaoshan_*.zip
 
-          if [ "$PRERELEASE" = "true" ]; then
+          if [ "$IS_PRERELEASE" = "true" ]; then
             gh release edit "$TAG" --draft=false --prerelease
           else
             gh release edit "$TAG" --draft=false --latest
@@ -157,4 +228,3 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BODY: ${{ steps.release_body.outputs.body }}
-          TAG: ${{ steps.vars.outputs.tag }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,7 +146,7 @@ Follow [Conventional Commits](https://www.conventionalcommits.org/): `feat:`, `f
     │   ├── release_body.py         # build the GitHub release markdown body
     │   └── release_prepare.py      # rename APK/zip/tar artifacts for upload
     ├── workflows/
-    │   ├── release.yml         # triggered by tags v*.*.* or manual dispatch
+    │   ├── release.yml         # releases on push to main/preview, target-gated tags, or manual dispatch
     │   ├── build-android.yml   # workflow_call → APK (split per ABI, obfuscated)
     │   ├── build-windows.yml   # workflow_call → Windows zip
     └── ISSUE_TEMPLATE/feature_request.yml
@@ -336,18 +336,37 @@ Always run `dart format` (the repo's pre-commit hook enforces this on staged `.d
 
 ## Continuous Integration & Release
 
-GitHub Actions:
+### Branching Model & Workflow Architecture
 
-- **`release.yml`** — triggered by tags `v*.*.*` (or `workflow_dispatch`). Calls Android and Windows builds, then runs the Python release scripts and publishes both platforms via `softprops/action-gh-release@v2`. Prerelease tags (containing `-`) are flagged as pre-releases.
-- **`build-android.yml`** — Ubuntu, JDK 21, decodes keystore from `secrets.KEYSTORE_BASE64`, writes `android/key.properties`, builds **split-per-ABI** release APK with `--obfuscate --split-debug-info=build/app/outputs/symbols`.
-- **`build-windows.yml`** — Windows runner, archives `build\windows\x64\runner\Release\*` into `windows-release.zip` via `Compress-Archive`.
+The repository operates a strict two-tier release model (`preview` -> `main`):
 
-### Release helpers (`.claude/commands/`)
+- **`preview` (Staging / Preview Release Track)**:
+  - Staging branch for preview testing and daily integration.
+  - Accepts PRs from any feature/fix/refactor/docs branch directly.
+  - Merges into `preview` automatically trigger the release pipeline to publish a **Preview Release** (`prerelease: true`, tag sequence `vX.Y.Z-preview` or `vX.Y.Z-preview.N`).
+- **`main` (Production / Formal Stable Release Track)**:
+  - Production stable branch.
+  - **Only accepts PRs from `preview`**. Direct pushes or direct feature PRs are strictly forbidden.
+  - Merges into `main` automatically trigger the release pipeline to publish a **Formal Stable Release** (`prerelease: false, latest: true`, tag `vX.Y.Z`), generate F-Droid changelogs, and commit metadata.
 
-These are project-specific Claude Code slash commands (all interactions in Chinese):
+### CI Workflows
 
-- `release.md` (`/release <version>`) — full release: validates workspace, edits `pubspec.yaml` version, updates `CHANGELOG.md` (auto-generates from git log via subagent if `[Unreleased]` is empty), commits + tags + pushes.
-- `prerelease.md` (`/prerelease <tag>`) — preview release: same changelog flow but **does not modify `pubspec.yaml`**; pushes a `vX.Y.Z-{suffix}` tag and lets the release workflow mark it as a GitHub prerelease.
+- **`pre-flight.yml` (Quality Gate & Policy Enforcement)**:
+  - Triggers on PRs to `main` / `preview`, pushes to `main` / `preview`, and `workflow_dispatch`.
+  - Enforces branch flow policy: `main` must originate from `preview` (there is no `dev` branch; feature branches target `preview` directly).
+  - Runs `dart analyze --fatal-infos`, `flutter test`, codegen cleanliness check (`git status --porcelain` after codegen), Python CI unit tests (`.github/scripts/tests/`), and `tool/pre_release_check.py --ci` (release-timing checks are advisory WARNs in CI; structural checks still fail the gate).
+- **`release.yml` (Release Pipeline)**:
+  - Triggers on pushes to `main` / `preview`, tags matching `v*.*.*` (published only when the tag targets the main/preview head), and `workflow_dispatch` (build-only on other branches).
+  - Version/tag rules via `.github/scripts/resolve_release_version.py` (formal: pubspec, idempotent; preview: anchored to the last formal tag with a patch increment `-preview[.N]`; the `/release` prep phase switches to `-rc` naming; preview builds inject the last formal versionName/versionCode).
+  - Triggers `build-android.yml` (universal + split APKs with Java 21) and `build-windows.yml` (Windows zip with dynamic WebView2Loader).
+  - Publishes GitHub Releases with safe Draft -> Upload -> Publish ordering to support Immutable Releases.
+
+### Release Helpers (`.claude/commands/`)
+
+These are project-specific Claude Code slash commands:
+
+- `release.md` (`/release <version>`) — prepares formal release: updates `pubspec.yaml` (e.g. `2.5.1+20501`), formats `CHANGELOG.md [X.Y.Z]`, generates F-Droid metadata changelogs, runs `tool/pre_release_check.py`, and opens/merges a PR from `preview` to `main`.
+- `prerelease.md` (`/prerelease [tag]`) — prepares preview release: updates `CHANGELOG.md [Unreleased]`, runs pre-flight checks, and merges into `preview` to trigger automated preview builds.
 
 The auto-changelog flow:
 1. Find last stable tag: `git tag -l "v[0-9]*.[0-9]*.[0-9]*" --sort=-v:refname | grep -E "^v[0-9]+\.[0-9]+\.[0-9]+$" | head -n 1`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,6 +149,48 @@ lib/
 
 
 
+## 🌿 Git 分支模型与流水线 (Branching & Release Pipeline)
+
+本项目采用严格单向流转的 **分级自动化发布流水线**：
+
+```text
+日常开发分支 (feat/*, fix/*, docs/* ...)
+       │
+       ▼ (发起 PR, 触发 Pre-flight 门禁)
+`preview` 分支 ────► 自动触发 release.yml ────► 自动发布 vX.Y.Z-preview 预览版 (Prerelease)
+       │
+       ▼ (仅允许来自 preview 的 PR, 触发 Pre-flight 门禁)
+`main` 分支 ───────► 自动触发 release.yml ────► 自动发布 vX.Y.Z 正式版 (Latest Release & F-Droid)
+```
+
+### 严格流转规则 (Branch Flow Policy)
+- **禁止向 `main` 分支直接推送或提交日常 PR**：`main` 只能接收来自 `preview` 分支的 Pull Request。
+- **所有日常功能与修复**（`feat/*`、`fix/*`、`docs/*` 等）：请统一向 **`preview`** 分支发起 Pull Request。
+
+### 自动化发布与门禁触发
+- **PR 门禁 (`pre-flight.yml`)**：向 `preview`、`main` 发起 PR 时，会自动执行分支合规检查、代码静态分析 (`dart analyze`)、生成文件漂移检测、测试套件 (`flutter test`) 以及发布前预检。
+- **`preview` 分支更新**：当 feature 分支合入 `preview` 后，触发全平台构建并发布 **Preview 预发布版本**；短时间连续合并只保留最新一轮。
+- **`main` 分支更新**：当 `preview` 合入 `main` 后，触发全平台构建、更新 F-Droid 元数据并发布 **Formal 正式版本**。
+- **手动入口边界**：`workflow_dispatch` 仅在 `main` / `preview` 上发布（其他分支仅构建产物）；手动推送 `v*.*.*` tag 仅在指向 `main` / `preview` 顶端时发布。行为细节见 `docs/architecture/release-pipeline.md`。
+
+### 分支规范
+
+| 分支 | 职责 | 触发动作 |
+|---|---|---|
+| `main` | **正式版生产分支**。仅接收来自 `preview` 的 PR（禁止日常直接提交）。 | 合并后自动创建 Tag `vX.Y.Z`，构建并发布 **Formal 正式版** (GitHub Release latest)。 |
+| `preview` | **预览版预发布分支，兼日常集成分支**。所有日常功能、修复 PR 均以 `preview` 为目标分支。 | 合并后自动创建 Tag `vX.Y.Z-preview[.N]`（`/release` 准备期为 `vX.Y.Z-rc[.N]`），构建并发布 **Preview 预览版** (prerelease)。 |
+| `feat/*`, `fix/*` | **特性/修复工作分支**。从 `preview` 分支切出。 | 提交 PR 至 `preview` 时自动触发 Pre-flight 质量门禁检查。 |
+
+### 质量门禁 (Pre-flight Checks)
+
+每次向 `preview` 或 `main` 提交 Pull Request 时，GitHub Actions 会自动运行发布前检查：
+1. `dart analyze --fatal-infos`：严格的 Dart 静态代码检查。
+2. `flutter test`：全套单元与 Widget 测试。
+3. `git status --porcelain`：代码生成物 (`build_runner` / `flutter gen-l10n`) 完整性检查。
+4. Python 自动化发布脚本单元测试与版本格式预检（发布时机类检查在 CI 中为 WARN 级提示）。
+
+---
+
 ## 团队
 
 **The-Brotherhood-of-SCU** — 一个非官方的四川大学开源组织

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@
 | [认证架构](architecture/authentication.md) | SCU 根认证、子系统认证、重试、会话隔离和 DI | 当前实现 |
 | [通知 WebView 架构](architecture/notice-webview.md) | 三类通知来源、JS bridge、附件下载和平台边界 | 当前实现 |
 | [Linux 分发架构](architecture/linux-distribution.md) | 本地构建、WPE 边界、Flatpak、AUR 和 Debian 状态 | 当前实现 |
+| [发布流水线](architecture/release-pipeline.md) | 两级分支流、预览/正式双通道、版本号模型与边界情况 | 当前实现 |
 
 ## 设计决策
 

--- a/docs/architecture/release-pipeline.md
+++ b/docs/architecture/release-pipeline.md
@@ -1,0 +1,176 @@
+# 发布流水线（Release Pipeline）
+
+本文描述仓库的两级分支发布流水线：一次变更从 Pull Request 到预览版、再到正式版的完整生命周期，以及流水线的版本号模型与已知边界情况。工作流定义见 `.github/workflows/`，版本推导脚本见 `.github/scripts/resolve_release_version.py`。
+
+## 1. 分支模型与触发矩阵
+
+仓库采用严格单向流转的两级分支流，**没有 dev 分支**：
+
+```text
+日常开发分支 (feat/*, fix/*, docs/* ...)
+       │  发起 PR（触发 pre-flight 门禁）
+       ▼
+preview ──── 合并即自动发 vX.Y.Z-preview[.N] 预览版（Prerelease）
+       │  仅允许来自 preview 的 PR（触发 pre-flight 门禁）
+       ▼
+main ─────── 合并即自动发 vX.Y.Z 正式版（Latest Release & F-Droid）
+```
+
+| 分支 | 职责 | 发布行为 |
+|---|---|---|
+| `preview` | 预览发布分支，兼日常集成分支，直接接收 feature/fix/docs PR | 每次合并**必然**触发一轮预览版发布（无跳过开关）；并发上只保留最新一轮（见 §4.14） |
+| `main` | 正式版生产分支，仅接收来自 `preview` 的 PR | 从 `pubspec.yaml` 推导 `vX.Y.Z`；tag 已存在则幂等跳过 |
+
+各工作流的触发矩阵：
+
+| 事件 | pre-flight 门禁 | branch-policy | release.yml |
+|---|---|---|---|
+| 打开 / 更新 PR（→ main 或 preview） | ✅ | ✅（仅 PR 事件） | ❌ |
+| push / 合并进 `main` | ✅ | ❌ | ✅ formal 通道 |
+| push / 合并进 `preview` | ✅ | ❌ | ✅ preview 通道 |
+| push tag `v*.*.*` | ❌ | ❌ | ✅ 仅当指向 main / preview 顶端；其他指向仅构建产物（见 §4.16） |
+| 手动 `workflow_dispatch`（main/preview 上） | 可选 | ❌ | ✅ 正常发布（可选 channel 与 version_override） |
+| 手动 `workflow_dispatch`（其他分支） | 可选 | ❌ | 仅构建产物：不推 tag、不发 Release（见 §4.15） |
+
+branch-policy 只做一条硬校验：**`main` 只能接收来自 `preview` 的 PR**；`preview` 接受任意来源分支。该检查仅存在于 PR 事件，真正的强制落地还需要 GitHub 侧把 pre-flight 配置为 required status check（见 §4.4）。
+
+## 2. 一次变更的完整生命周期
+
+以功能分支 `feat/foo` 为例：
+
+1. **切分支并开发**：从 `preview` 切出 `feat/foo`，开发并推送。
+2. **发起 PR → `preview`**：pre-flight 门禁执行——
+   - 分支策略检查（`preview` 接受任意来源，仅记录日志）；
+   - `dart analyze --fatal-infos`；
+   - 代码生成物干净树检查：setup 阶段已运行 `flutter pub get`、`build_runner`、`flutter gen-l10n`，之后 `git status --porcelain` 必须为空；
+   - `flutter test` 全量测试；
+   - Python 自动化脚本单测（`.github/scripts/tests/`）；
+   - `tool/pre_release_check.py --ci --prerelease`：版本格式、CHANGELOG 结构等**结构性 FAIL 会拦截**；发布时机类检查（版本递增 / tag 冲突 / Unreleased 空置）为 **WARN** 提示。
+3. **合并进 `preview`**：push 事件同时触发 pre-flight 重跑与 release.yml preview 通道——
+   - 预览 tag 与 pubspec 解耦：脚本取「最新正式 tag」严格递增 Z 位（X、Y 不动），推导 `vX.Y.Z-preview`（首次）或递增序号 `vX.Y.Z-preview.N`（如上一正式版 v2.5.1 → v2.5.2-preview.2）；
+   - workflow 自动打 tag（`resolve-metadata` job，需要 `contents: write`，推送失败立即终止本次发布）；
+   - `build-android.yml`（universal + split-per-ABI，混淆，JDK 21）与 `build-windows.yml`（zip）并行构建；
+   - 发布走 **Draft → 上传产物 → Publish** 顺序，兼容仓库的不可变 Release 策略，标记为 prerelease；
+   - 预览版的 release notes 取 `CHANGELOG.md` 第一个章节（约定为 `[Unreleased]`；该取法的已知问题见 §4.8），对比范围为上一个**正式** tag。tag 在构建开始前就已推送，构建/发布失败时 tag 会留存（见 §4.12）。
+4. **周期内迭代**：后续变更继续以 PR 合入 `preview`，预览版序号自动递增（`.2`、`.3`…）。周期内 `pubspec.yaml` 的版本号保持上一正式版不变，预览产物的 versionName 与 tag 不同名是设计使然。
+5. **准备正式版（`/release X.Y.Z`）**：bump `pubspec.yaml` 版本（保留 `+buildNumber`）、将 `[Unreleased]` 重命名为 `[X.Y.Z] - 日期`、更新 F-Droid 元数据（`metadata/*.yml` 的 versionName/versionCode + `metadata_changelog.py` 生成多语言 changelogs）、本地跑严格模式 `pre_release_check.py X.Y.Z`，提交推送 `preview`——这会先触发一轮预览版发布（tag 按 §3 规则切换为 `vX.Y.Z-rc`，直接使用即将发布的版本号；若 RC 之后仍有合并进 preview，后续轮次为 `vX.Y.Z-rc1`、`-rc2`…；产物版本号与其余预览一致，构建时注入的是上一正式版的版本号，pubspec 的 bump 不影响预览构建；内容与正式版一致，性质等同发布候选）——随后创建 `preview → main` 的发布 PR，合并后才发正式版。
+6. **合并进 `main`**：release.yml formal 通道——
+   - 基础版本读自 pubspec；远端不存在 `vX.Y.Z` → 打 tag、双端构建、发布正式 Release（`--latest`）；
+   - F-Droid changelog 由 `metadata_changelog.py --skip-existing` 生成并兜底提交回 `main`；
+   - `vX.Y.Z` 已存在 → `should_release=false`，秒级跳过，不会重复发布。
+7. **事后**：main 的 push 再触发一次 pre-flight（结构性检查照常硬拦截；时机类检查在两个版本之间的正常状态下为 WARN，不会长期挂红）。
+
+## 3. 版本号模型
+
+- **正式版的唯一事实来源是 `pubspec.yaml` 的 `version: X.Y.Z+BBBB`**，formal tag = `vX.Y.Z`，远端已存在同名 tag 时幂等跳过。`BBBB`（buildNumber）= `major*10000 + minor*100 + patch`（如 `2.5.1+20501`）；F-Droid 的 ABI versionCode = `base*10 + 1/2/4`（如 2.5.1 → 205011 / 205012 / 205014）。
+- **预览通道与 pubspec 解耦，按阶段命名**：常态（pubspec == 最新正式版）下 tag 锚定「最新正式 tag」**严格只递增 Z 位**（X、Y 不动）加 `-preview[.N]`——上一正式版 v2.5.1 → v2.5.2-preview、v2.5.2-preview.2…；进入准备期（`/release` 已 bump，pubspec > 最新正式版）后 tag 直接使用即将发布的版本号：首个为 `v2.5.2-rc`，之后每次合并递增为 `v2.5.2-rc1`、`v2.5.2-rc2`…。仓库尚无任何正式 tag 的极端情况回退用 pubspec 版本推导。周期内 `pubspec.yaml` 保持上一正式版的版本号不变。**所有预览构建（含 RC）在构建时注入「最新正式 tag」的 versionName/versionCode**（`flutter build --build-name/--build-number`），整个周期的预览产物版本号完全一致（= 上一正式版），pubspec 的 bump 不影响预览构建的版本号；常态的 `-preview.N` tag 不预示正式版的最终版本号，RC 阶段的 tag 就是即将发布的版本。
+- **预览触发时的自检与阶段判定**：比较 pubspec 版本与最新正式 tag——**一致**（常态）静默通过，按 `-preview.N` 命名；pubspec **落后**于最新正式版属于异常状态（下一次正式发布会被幂等守卫卡住），输出强 WARN 提示尽快 bump 对齐；pubspec **领先**即为 `/release` 准备期，输出 notice 并切换到 `-rc` 命名（首个 `vX.Y.Z-rc`，后续 `-rc1`、`-rc2`…）。semver 排序上两类预览 tag 恒大于上一正式版、小于未来正式版，永不倒挂。
+- **与应用内更新渠道的兼容**：稳定渠道只读 GitHub `/releases/latest`（不含 prerelease），RC 不进入正式用户的更新视野；预览渠道取最近一个 prerelease tag 的基础版本号（`v2.5.2-preview.3` → `2.5.2`）与当前版本做语义比较（`isNewerPrerelease`），并对「当前构建就是该预发布版」自我排除。预览构建统一使用上一正式版的 versionName/versionCode，因此：正式版用户在周期内会被任何新预览正常提示升级；预览/RC 用户在正式版发布后也会被稳定渠道提示升级（versionCode 真实递增），预览→预览的同 versionCode 重装 Android 允许（仅禁止降级）。
+- **发 2.5.2 还是 2.6.0 完全是人的决策**，发生在 `/release` 准备正式版、修改 pubspec 的那一刻；预览阶段不需要任何 bump，也不存在「周期开始 bump」的约定。
+- 自动推导识别两类形态：常态 `-preview[.N]`、准备期 `-rc` / `-rcN`（同版本下扫描已有 rc tag 递增序号）；历史遗留的 `-pre1`、`-preview2` 等命名不参与推导。其他自定义后缀（如 `-beta`）通过 `workflow_dispatch` 的 `version_override` 手动触发。
+
+## 4. 边界情况与已知风险
+
+### 4.1 创建分支即触发发布
+`on: push` 事件在**分支创建时同样触发**。从 `main` 创建 `preview` 分支的瞬间，release.yml 就会以当时的 pubspec（可能还是上一个正式版）发一轮预览版。启用流水线时的规避方式见 §5。
+
+### 4.2 preview 通道没有跳过开关
+每次合入 `preview` 都会真实构建并发版。不要把 preview 当作「只合代码、不发版」的集成分支使用；不希望发版的改动（如纯文档微调）也应接受一次预览版，或攒到下一轮一起合。
+
+### 4.3 代码生成物漂移对 SDK 版本敏感
+`lib/injection/injector.config.dart` 由 build_runner 经 **SDK 自带的 dart_style** 格式化，输出随 Flutter patch 版本变化。CI 在 setup action 中精确钉住 `flutter-version: "3.44.9"`，生成物以 CI 产物为准；本地 SDK 版本不同时重新生成可能产生纯格式 diff，不要把它提交回去。`pubspec.lock` 锁定的是国内镜像 `pub.flutter-io.cn`，setup action 已统一设置 `PUB_HOSTED_URL`（缺了它 CI 的 `pub get` 会把 lock 全量翻成 pub.dev 造成漂移）。
+
+### 4.4 门禁红不等于挡合并
+`main` 的 ruleset（`protect-main`）要求 1 个 approve、评论必须解决、禁止删除与强推，但**未配置 required status checks**。pre-flight 挂红只是展示性的，不阻塞合并；流程的真正闸门是人工 review。若要让门禁硬生效，需在仓库设置中将 pre-flight 的 check 配为 required。
+
+### 4.5 预览 tag 竞态
+preview 通道开启「只保留最新一轮」的取消语义后，短时间连续 push 的竞态窗口大幅收窄：仅当旧 run 恰好在被取消前已推 tag，新 run 会自动递增序号绕开。tag 推送失败仍会立即终止当前 run（宁可早失败，不在 20 分钟构建后死在 publish 阶段）。formal 通道不取消，靠幂等守卫防重复。
+
+### 4.6 version_override 无预检
+`workflow_dispatch` 传入 `version_override` 时不做「tag 是否已存在」检查，遇到已存在的 tag 会在构建完成后才于 publish 阶段失败。手动触发前先确认目标 tag 未被占用。
+
+### 4.7 不会递归触发
+CI 自己的 `git push`（自动 tag、F-Droid metadata 兜底提交）使用 `GITHUB_TOKEN`，GitHub 不会为 GITHUB_TOKEN 产生的事件新建 workflow run，因此发布流程不会自我连环触发。
+
+### 4.8 CHANGELOG 的提取路径
+`release_changelog.py`：版本号含 `-`（预览/RC）→ 按**名称**匹配 `CHANGELOG.md` 的 `[Unreleased]` 章节；正式版 → 严格匹配 `[X.Y.Z]` 章节，缺失或为空直接报错终止。
+
+预览/RC 路径的行为：
+
+- `[Unreleased]` 有内容 → 作为发布说明；
+- `[Unreleased]` 存在但为空、或整个缺失 → 发布占位文案 `*No changelog entry for this version.*` 并打 `::warning::` 注解，**绝不借用其他版本的章节**（早期实现按位置取第一个章节，章节缺失时会静默把上一个正式版的更新说明发进新预览版，已修复并有回归测试锁定）；
+- 预览阶段**不要**重命名 `[Unreleased]` 章节——重命名是 `/release` 的职责。
+
+相关守卫：正式版忘记把 `[Unreleased]` 重命名清空时，下周期预览会把已发布内容重复宣传——`pre_release_check` 稳定模式已有 WARN（「[Unreleased] 仍有 N 条未发布内容」）兜底；正式版 `[X.Y.Z]` 章节缺失/为空除 publish 阶段硬失败（构建跑完才报错）外，pre-flight 稳定模式会在发布 PR 阶段就 FAIL 提前拦截——但门禁不是 required check，需要人工看红叉。
+
+### 4.9 F-Droid 元数据需要先行
+`metadata/*.yml` 的 versionName/versionCode 不会由流水线自动生成，必须在 `preview → main` 发布 PR 之前手动补齐（`/release` 命令包含此步骤），否则 pre-flight 的结构性检查会 FAIL；`metadata/{lang}/changelogs/*.txt` 由 CI 在正式发布时兜底生成并提交回 `main`。
+
+### 4.10 手动严格模式与 CI 门禁模式的分界
+`tool/pre_release_check.py` 手动运行（`/release` 流程）为严格模式：版本递增、tag 冲突、Unreleased 空置等一律 FAIL，用于发布前拦截。`--ci` 模式运行在任意 PR/push 上，代码库常处于「两个版本之间」的正常状态，上述时机类检查降级为 WARN，结构性检查（版本格式、pubspec 解析、CHANGELOG 结构、F-Droid 元数据）保持 FAIL。
+
+### 4.11 fork PR 的推送方式
+外部贡献者的 PR 分支位于其 fork。维护者推送修正提交依赖 PR 的 `maintainer_can_modify`；仓库启用 git-lfs 时，直接推送需跳过 LFS pre-push 钩子（`git push --no-verify`，仅当变更不含 LFS 文件时安全）。
+
+### 4.12 tag 先于产物：孤儿 tag
+tag 在 `resolve-metadata` 阶段推送，构建在其后。构建/发布失败时 tag 已经存在：
+
+- preview 通道：留下无 release 的孤儿 tag。重跑**失败的 job** 可复用原 tag 重试发布；重跑整个 run 或重新合并则会因 tag 已存在而推导出**下一个序号**；
+- formal 通道：孤儿 tag 会触发幂等守卫，同一版本的重发被跳过——必须手动 `git push origin --delete vX.Y.Z` 删除孤儿 tag 后才能重发。
+
+### 4.13 Draft 半成品残留
+正式发布采用 Draft → 上传 → Publish 顺序；上传中途失败会留下带部分产物的 draft release。无论以哪种方式重试，都需先手动删除残留草稿，否则 `gh release create` 会因同名 tag 的 release 已存在而失败。
+
+### 4.14 预览轨道只保留最新一轮
+preview 通道的并发组开启取消（cancel-in-progress）：短时间连续合并会停掉进行中的旧发布，只构建发布最后一轮——设计上预览轨道只保留最新一轮。被取消的 run 与失败的 run 一样可能留下孤儿 tag（见 §4.12），随预览清理一并处理；历史预览版 release 与 tag 属于可清理对象，定期删除即可。formal 通道绝不取消，正式发布必须完整走完。
+
+### 4.15 手动 dispatch 的行为边界
+`workflow_dispatch` 的发布行为由触发所在的 ref 决定：
+
+- 在 `main` 上触发：auto → formal 通道，tag 从 pubspec 推导；tag 已存在（如刚发完版）则整个 run 秒级跳过，不会误发。显式选择 preview 通道会用 main 的代码发一轮预览（少见但允许）；
+- 在 `preview` 上触发：auto → preview 通道，等同「把当前 preview 状态重新发一轮」——常态期发 `vX.Y.Z-preview.N`（自动递增），准备期发 `vX.Y.Z-rc[.N]`。适合在构建失败或清理残留草稿后重发；注意它会取消同一通道上正在进行的 run；
+- 在其他分支上触发 → **仅构建产物**（build-only）：照常解析版本号并命名产物，可供下载验证，但不推 tag、不创建 Release——特性分支上演练发布构建不会误发版；
+- 仍在的陷阱：在 preview 上 dispatch 且 `version_override` 不含 `-` 时，通道仍为 preview（is_prerelease=true），会把形如 `v2.5.1` 的正式命名以 prerelease 发布，占用正式 tag 命名空间，后续真正的 formal 会被幂等守卫挡住。
+
+### 4.16 手动推 tag 的指向约束
+`v*.*.*` tag push 仍不跑 pre-flight、不校验 pubspec（tag 号与 APK 内 versionName 可能错位），但**发布资格由 tag 指向的 commit 决定**——与在哪个分支上执行 `git tag` 无关：
+
+- 指向 **main 顶端** → 按名称发布：无 `-` 为 formal，含 `-` 为 prerelease；
+- 指向 **preview 顶端** → 一律按 prerelease 发布（可用于手动补发 `v2.5.2-rc1` 这类 RC）；若名称无 `-`（形如 `v2.5.2` 的正式命名），**只构建不发版**并告警——正式 tag 只允许指向 main；
+- 指向其他任何 commit（feature 分支、历史提交等）→ 仅构建产物并告警，不发布；若为误推请手动删除该 tag。
+
+对比旧行为的收益：指向 preview / feature 分支的正式 tag 不再能用未进 main 的代码发布正式版、不再预先占用版本命名（此前会让真正的 formal 被幂等守卫挡死）。仍存在的不便：tag 路径没有幂等守卫，同名 release 已存在时会在完整构建后才于 `gh release create` 处失败。
+
+### 4.17 bump 版本号须同步 `+buildNumber`
+`buildNumber = major*10000 + minor*100 + patch`，与 F-Droid 元数据的 versionCode（`base*10 + 1/2/4`）同源。只改 `X.Y.Z` 忘改 `+BBBB` 会导致 APK versionCode 与元数据错位。`/release` 命令已内置该规则提醒。
+
+### 4.18 setup 阶段的代码生成失败被吞
+setup action 里 `build_runner` 带 `|| true`，生成器配置坏了不会让 setup 显式失败，只能靠漂移检查与测试兜底。
+
+### 4.19 发布正文的外链硬编码 fork 地址
+`release_body.py` 中 macOS dmg / iOS ipa 的下载链接指向 `Visio-Vanitas/Bugaoshan`（#285 的 ipa mirror 决策），且这些产物不由流水线上传。仓库迁移、改名或镜像调整时需同步修改该脚本。
+
+### 4.20 Python 单测重复发现
+pre-flight 的 `unittest discover -s .github/scripts/` 会把 `tests/` 子目录的用例再发现并执行一遍，用例双跑属无害冗余，分析 CI 时长时勿据此误判。
+
+## 5. 启用时序（一次性）
+
+流水线随引入它的 PR 合入 `main` 而生效，启用时需要注意：
+
+1. 引入 PR 本身合入 `main` 时，formal 通道因「tag 已存在」而跳过（若 pubspec 未 bump），不会误发版。
+2. 从 main 直接创建 `preview` 分支即可：分支创建触发的那轮预览发布按 §3 规则自动命名为「上一正式版 +1」-preview（如 v2.5.2-preview），命名正确；该轮内容与刚发布的正式版相同，属预期，无需处理。
+3. 此后进入 §2 的常规循环：feature PR → preview；正式版经 `/release` 走 `preview → main`。
+
+## 6. 相关文件
+
+| 文件 | 职责 |
+|---|---|
+| `.github/workflows/pre-flight.yml` | PR/push 质量门禁与分支策略 |
+| `.github/workflows/release.yml` | 双通道发布：版本推导、打 tag、构建、发布 |
+| `.github/workflows/build-android.yml` / `build-windows.yml` | 双端构建（可独立 workflow_call 复用） |
+| `.github/actions/setup/action.yml` | 公共环境：钉版 Flutter、镜像 pub get、代码生成、git 元数据 |
+| `.github/scripts/resolve_release_version.py` | 通道判定、tag 推导、幂等守卫 |
+| `.github/scripts/release_tags.py` / `release_changelog.py` / `release_body.py` / `release_prepare.py` | 发布说明与产物整理 |
+| `.github/scripts/metadata_changelog.py` | F-Droid 多语言 changelogs 生成 |
+| `tool/pre_release_check.py` | 发布前静态检查（手动严格 / `--ci` 门禁两种模式） |
+| `.claude/commands/release.md` / `prerelease.md` | `/release` 与 `/prerelease` 操作流程 |

--- a/docs/architecture/release-pipeline.md
+++ b/docs/architecture/release-pipeline.md
@@ -77,8 +77,8 @@ branch-policy 只做一条硬校验：**`main` 只能接收来自 `preview` 的 
 ### 4.2 preview 通道没有跳过开关
 每次合入 `preview` 都会真实构建并发版。不要把 preview 当作「只合代码、不发版」的集成分支使用；不希望发版的改动（如纯文档微调）也应接受一次预览版，或攒到下一轮一起合。
 
-### 4.3 代码生成物漂移对 SDK 版本敏感
-`lib/injection/injector.config.dart` 由 build_runner 经 **SDK 自带的 dart_style** 格式化，输出随 Flutter patch 版本变化。CI 在 setup action 中精确钉住 `flutter-version: "3.44.9"`，生成物以 CI 产物为准；本地 SDK 版本不同时重新生成可能产生纯格式 diff，不要把它提交回去。`pubspec.lock` 锁定的是国内镜像 `pub.flutter-io.cn`，setup action 已统一设置 `PUB_HOSTED_URL`（缺了它 CI 的 `pub get` 会把 lock 全量翻成 pub.dev 造成漂移）。
+### 4.3 代码生成物漂移对解析来源敏感
+`lib/injection/injector.config.dart` 由 build_runner（injectable_generator + dart_style）生成，输出取决于 **pub get 实际解析到的工具链状态**：`pubspec.lock` 锁定国内镜像 `pub.flutter-io.cn`，若 CI 未设置 `PUB_HOSTED_URL`，pub get 会按 pub.dev 重解析——除把 lock 的 hosted URL 全量翻成 pub.dev 外，还可能产出格式不同的生成物（曾在依赖版本完全相同的情况下复现为 injector.config.dart 多一行空行）。setup action 已统一设置 `PUB_HOSTED_URL`，生成随之确定；生成物以锁定工具链的产物为准，出现纯格式 diff 时不要提交回去（干净树检查会在 CI 兜底拦截）。
 
 ### 4.4 门禁红不等于挡合并
 `main` 的 ruleset（`protect-main`）要求 1 个 approve、评论必须解决、禁止删除与强推，但**未配置 required status checks**。pre-flight 挂红只是展示性的，不阻塞合并；流程的真正闸门是人工 review。若要让门禁硬生效，需在仓库设置中将 pre-flight 的 check 配为 required。

--- a/lib/injection/injector.config.dart
+++ b/lib/injection/injector.config.dart
@@ -9,6 +9,7 @@
 // coverage:ignore-file
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
+
 import 'package:get_it/get_it.dart' as _i174;
 import 'package:injectable/injectable.dart' as _i526;
 

--- a/lib/injection/injector.config.dart
+++ b/lib/injection/injector.config.dart
@@ -9,7 +9,6 @@
 // coverage:ignore-file
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-
 import 'package:get_it/get_it.dart' as _i174;
 import 'package:injectable/injectable.dart' as _i526;
 

--- a/tool/pre_release_check.py
+++ b/tool/pre_release_check.py
@@ -52,13 +52,24 @@ def _try_reconfigure_encoding():
 
 
 class Checker:
-    def __init__(self, version):
+    def __init__(self, version, ci=False):
         self.version = version
         self.base_version = version.split("-", 1)[0]
         self.is_prerelease = "-" in version
+        self.ci = ci
         self.results = []  # (status, name, message)
         self.tag = f"v{self.version}"
         self.base_tag = f"v{self.base_version}"
+
+    def _release_timing_status(self):
+        """发布时机类检查（版本递增 / tag 冲突 / Unreleased 空置）的状态。
+
+        CI 门禁（--ci）跑在任意 PR/push 上，代码库经常处于「两个版本之间」
+        的正常状态（刚发完 X.Y.Z、pubspec 还未 bump），此时这些检查必然
+        不满足，硬 FAIL 会让 main/preview 的门禁长期挂红。CI 模式下降级为
+        WARN 供人工确认；本地手动 /release 流程保持 FAIL 严格拦截。
+        """
+        return WARN if self.ci else FAIL
 
     # ---- 基础工具 ----
 
@@ -169,15 +180,16 @@ class Checker:
 
     def check_tag_not_exists(self):
         name = "本地/远端 tag 冲突"
+        timing = self._release_timing_status()
         if not self.is_prerelease:
             code, out, err = self.run("git", "tag", "--list", self.tag)
             if code == 0 and out.strip():
-                self.record(FAIL, name, f"本地已存在 tag {self.tag}，发布会冲突")
+                self.record(timing, name, f"本地已存在 tag {self.tag}，发布会冲突")
                 return
         code, out, err = self.run("git", "ls-remote", "--tags", "origin", f"refs/tags/{self.tag}", timeout=20)
         if code == 0:
             if out.strip():
-                self.record(FAIL, name, f"远端 origin 已存在 tag {self.tag}")
+                self.record(timing, name, f"远端 origin 已存在 tag {self.tag}")
             else:
                 self.record(OK, name, f"tag {self.tag} 尚未使用")
         else:
@@ -201,12 +213,13 @@ class Checker:
         new_tuple = self.semver_tuple(self.base_version)
         if new_tuple is None:
             return
+        timing = self._release_timing_status()
         if new_tuple > latest_tuple:
             self.record(OK, name, f"{self.base_version} > 上一稳定版本 {latest_tag[1:]}")
         elif new_tuple == latest_tuple:
-            self.record(FAIL, name, f"{self.base_version} 与最新稳定版本 {latest_tag} 相同")
+            self.record(timing, name, f"{self.base_version} 与最新稳定版本 {latest_tag} 相同")
         else:
-            self.record(FAIL, name, f"{self.base_version} < 最新稳定版本 {latest_tag}，版本号应递增")
+            self.record(timing, name, f"{self.base_version} < 最新稳定版本 {latest_tag}，版本号应递增")
 
     def check_pubspec(self):
         name = "pubspec.yaml 版本"
@@ -226,10 +239,10 @@ class Checker:
 
         if self.is_prerelease:
             new_tuple = self.semver_tuple(self.base_version)
-            if pub_tuple and new_tuple and new_tuple > pub_tuple:
-                self.record(OK, name, f"pubspec {raw}（预览版不改 pubspec，基础版本 {self.base_version} 更大）")
+            if pub_tuple and new_tuple and new_tuple >= pub_tuple:
+                self.record(OK, name, f"pubspec {raw}（预览版基础版本 {self.base_version} 合法）")
             elif pub_tuple and new_tuple:
-                self.record(FAIL, name, f"预览版基础版本 {self.base_version} 应大于 pubspec 当前 {raw}")
+                self.record(FAIL, name, f"预览版基础版本 {self.base_version} 应大于或等于 pubspec 当前 {raw}")
             else:
                 self.record(FAIL, name, f"pubspec 版本 {raw} 格式非法")
             return
@@ -274,15 +287,16 @@ class Checker:
             return sum(1 for ln in content if ln.lstrip().startswith(("- ", "* ")))
 
         if self.is_prerelease:
+            timing = self._release_timing_status()
             unreleased = next((i for i, (h, _) in enumerate(sections) if h.strip().lower() in ("[unreleased]", "unreleased")), None)
             if unreleased is None:
-                self.record(FAIL, name, "预览版需要 ## [Unreleased] 章节，未找到")
+                self.record(timing, name, "预览版需要 ## [Unreleased] 章节，未找到")
                 return
             bullets = count_bullets(section_content(unreleased))
             if bullets > 0:
                 self.record(OK, name, f"[Unreleased] 有 {bullets} 条内容")
             else:
-                self.record(FAIL, name, "[Unreleased] 为空，预览版没有更新说明")
+                self.record(timing, name, "[Unreleased] 为空，预览版没有更新说明")
             return
 
         # 稳定版：找到 [X.Y.Z] 章节
@@ -435,15 +449,35 @@ def main(argv=None):
     parser = argparse.ArgumentParser(
         description="Bugaoshan 发布前检查。用法示例: python tool/pre_release_check.py 2.3.0",
     )
-    parser.add_argument("version", help="目标版本号，如 2.3.0 或 2.3.0-pre8")
+    parser.add_argument("version", nargs="?", default="", help="目标版本号，如 2.3.0 或 2.3.0-preview（在 CI 模式下可省略）")
     parser.add_argument(
         "--prerelease",
         action="store_true",
         help="按预览版检查（等价于版本号里含 '-'）",
     )
+    parser.add_argument(
+        "--ci",
+        action="store_true",
+        help="CI 门禁模式：自动从 pubspec.yaml 读取版本号，发布时机类检查"
+             "（版本递增 / tag 冲突 / Unreleased 空置）降级为 WARN，其余检查未通过时退出码为 1",
+    )
     args = parser.parse_args(argv)
 
     version = args.version
+    if not version and args.ci:
+        # Auto-read from pubspec.yaml
+        pub_path = ROOT / "pubspec.yaml"
+        if pub_path.exists():
+            for line in pub_path.read_text(encoding="utf-8").splitlines():
+                if line.strip().startswith("version:"):
+                    raw = line.split(":", 1)[1].strip().split("+")[0].strip()
+                    version = raw
+                    break
+
+    if not version:
+        print("错误: 未指定版本号，且无法从 pubspec.yaml 解析", file=sys.stderr)
+        return 2
+
     if args.prerelease and "-" not in version:
         version = f"{version}-prerelease"
 
@@ -451,7 +485,7 @@ def main(argv=None):
         print(f"错误: 非法版本号 '{args.version}'，应为 X.Y.Z 或 X.Y.Z-suffix", file=sys.stderr)
         return 2
 
-    return Checker(version).run_all()
+    return Checker(version, ci=args.ci).run_all()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## PR 说明

**Supersedes #294**。原 PR 由 @Visio-Vanitas 设计并实现三级流水线（感谢！），本 PR 在其基础上按讨论重构为两级流，并修复了门禁的若干实际问题。核心思路——双通道自动发版、幂等守卫、Draft→Upload→Publish 顺序——均源自原设计。

### 架构：两级发布流水线（feature → preview → main）

取消独立 `dev` 分支，`preview` 兼任日常集成分支：

```
feature/fix PR ──► preview ──自动发 vX.Y.Z-preview[.N] / rc 预览版──► main ──自动发 vX.Y.Z 正式版
```

### 版本号模型
- **formal**：唯一事实来源是 `pubspec.yaml`，tag = `vX.Y.Z`，已存在则幂等跳过；
- **preview**：与 pubspec 解耦、按阶段命名——常态锚定最新正式 tag 严格递增 Z 位（`v2.5.2-preview[.N]`）；`/release` bump 后的准备期切换 `v2.5.2-rc`、`-rc1`…；semver 排序永不倒挂；
- **预览构建统一注入上一正式版的 versionName/versionCode**（`--build-name/--build-number`）：整周期包体版本号一致，pubspec 的 bump 不影响预览构建，RC→正式版是真实递增；
- **三态自检**：pubspec 与最新正式 tag 一致静默 / 落后强 WARN（正式通道会被卡死）/ 领先 notice（准备期信号）。

### 质量门禁（pre-flight.yml）
PR 与 push 触发：`dart analyze --fatal-infos`、代码生成物干净树、`flutter test`、Python 单测、发布预检（时机类 WARN / 结构性 FAIL）；分支策略：main 仅收来自 preview 的 PR。

### 发布行为边界
- 预览轨道只保留最新一轮（并发取消），formal 绝不取消；
- `workflow_dispatch`：main/preview 上正常发布，**其他分支仅构建产物（build-only）**；
- 手动 tag：仅指向 main/preview 顶端时发布（正式 tag 只允许指向 main），其余仅构建；
- changelog：预览/RC 按名称取 `[Unreleased]`，缺失/为空输出占位并告警，**绝不借用其他版本章节**。

### 引导说明
本 PR 为流水线本体，需先行合入 main。branch-policy 检查对本 PR 会红（main 仅收 preview 的 PR，而 preview 尚不存在）——引导期特例，ruleset 未配 required checks，不阻塞合并。合入后从 main 创建 `preview` 分支即启动周期。

### 顺带修复
- setup action 统一设置 `PUB_HOSTED_URL`：修复 CI `pub get` 将 pubspec.lock 全量翻成 pub.dev 造成的「生成物漂移」假失败；
- `injector.config.dart` 对齐 CI（Flutter 3.44.9 钉版）的 dart_style 生成格式。

### 验证
- [x] Python 单测 35 个全部通过（版本推导状态机 / changelog 借用回归 / build-only 门控 / formal 幂等）
- [x] 全部 workflow YAML 合法；真实仓库状态模拟三组场景输出符合设计
- [x] 待 CI 实测：`cancel-in-progress` 表达式、Windows 端 `--build-name` 生效性（合入后首轮构建确认）